### PR TITLE
Fixed error message when trying to add a nonexistent user to a course.

### DIFF
--- a/app/controllers/participants_controller.rb
+++ b/app/controllers/participants_controller.rb
@@ -13,7 +13,8 @@ class ParticipantsController < ApplicationController
     begin
       curr_object.add_participant(params[:user][:name])
     rescue
-      flash[:error] = $!
+      url_new_user = url_for :controller => 'users', :action => 'new'
+      flash[:error] = "User #{params[:user][:name]} does not exist. Would you like to <a href = '#{url_new_user}'>create this user?</a>"
     end
     redirect_to :action => 'list', :id => curr_object.id, :model => params[:model]
   end


### PR DESCRIPTION
Before, when trying to add a nonexistent user to a course, this error would pop up:
_Error!_
_undefined method `url_for' for #_

Now it says:
_Error!_
_User <user> does not exist. Would you like to create this user?_
With a link to the new user page.
