### PR TITLE
Bug fix for #270

### DIFF
--- a/app/models/questionnaire.rb
+++ b/app/models/questionnaire.rb
@@ -18,7 +18,7 @@ class Questionnaire < ActiveRecord::Base
     DEFAULT_QUESTIONNAIRE_URL = "http://www.courses.ncsu.edu/csc517"
     
 	def compute_weighted_score(symbol, assignment, scores)
-      aq = self.assignment_questionnaire.find_by_assignment_id(assignment.id)
+      aq = AssignmentQuestionnaire.find_by_assignment_id(assignment.id)
       if scores[symbol][:scores][:avg]
         #dont bracket and to_f the whole thing - you get a 0 in the result.. what you do is just to_f the 100 part .. to get the fractions
        


### PR DESCRIPTION
Any record can be found by its primary key in the database if you
know what type of object you are looking for. Any time you have
an id passed in as a parameter, you can use the top level class
name which corresponds to the primary key in the database.

In this instance, the code was looking for an AssignmentQuestionnaire
object, and the id was available, so using the code
self.assignment_questionnaire.find_by... throws a NoMethodError
because the 'find' method is a class method of each model, not
an instance method called on a specific object.
