### PR TITLE
Added a proxy server option in the cap script.

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -18,16 +18,25 @@ set :bundle_without,  [:development, :test]
 set :deploy_to, "/local/rails/expertiza"
 set :runner, "www-data"
 
-desc "Run tasks in staging enviroment."
-task :staging do
-  puts "*** Using the \033[1;42m STAGING \033[0m server!"
-  role :web, "test.expertiza.csc.ncsu.edu"
-  role :app, "test.expertiza.csc.ncsu.edu"
-  role :cron, "test.expertiza.csc.ncsu.edu"
-  role :db,  "test.expertiza.csc.ncsu.edu", :primary => true # This is where Rails migrations will run
+desc "Run tasks from a proxied environment"
+task :proxy do
+  puts "*** \033[1;41mUsing a PROXY to connect to the server!\033[0m"
+  
+  set :proxy_server do
+    proxy_server = Capistrano::CLI.ui.ask "Server: "
+  end
+  
+  role :web, proxy_server
+  role :app, proxy_server
+  role :cron, proxy_server
+  role :db,  proxy_server, :primary => true # This is where Rails migrations will run
+  
+  set :port do
+    port = Capistrano::CLI.ui.ask "Port: "
+  end
   
   set :user do
-    puts "\033[32mYou need to log in. This is generally your user ID.\033[0m"
+    puts "\033[32mYou need to log in. This is generally your Unity ID.\033[0m"
     user = Capistrano::CLI.ui.ask "Login: "
   end
   
@@ -41,6 +50,28 @@ task :staging do
 end
 
 desc "Run tasks in staging enviroment."
+task :staging do
+  puts "*** Using the \033[1;42m STAGING \033[0m server!"
+  role :web, "test.expertiza.csc.ncsu.edu"
+  role :app, "test.expertiza.csc.ncsu.edu"
+  role :cron, "test.expertiza.csc.ncsu.edu"
+  role :db,  "test.expertiza.csc.ncsu.edu", :primary => true # This is where Rails migrations will run
+  
+  set :user do
+    puts "\033[32mYou need to log in. This is generally your Unity ID.\033[0m"
+    user = Capistrano::CLI.ui.ask "Login: "
+  end
+  
+  set :branch do
+    default_branch = 'staging'
+    
+    branch = Capistrano::CLI.ui.ask "Branch to deploy (make sure to push first) [#{default_branch}]: "
+    branch = default_branch if branch.empty?
+    branch
+  end
+end
+
+desc "Run tasks in production enviroment."
 task :production do
   puts "*** Using the \033[1;41m PRODUCTION \033[0m server!"
   role :web, "expertiza.ncsu.edu"
@@ -49,7 +80,7 @@ task :production do
   role :db,  "expertiza.ncsu.edu", :primary => true # This is where Rails migrations will run
   
   set :user do
-    puts "\033[32mYou need to log in. This is generally your user ID.\033[0m"
+    puts "\033[32mYou need to log in. This is generally your Unity ID.\033[0m"
     user = Capistrano::CLI.ui.ask "Login: "
   end
   


### PR DESCRIPTION
Now you can deploy and load_data from any
address and port in order to communicate through
an outside server.

Here are added commands:
(You will be prompted for a server, port, and user name)
cap proxy load_data # load data from a proxy
cap proxy deploy # deploy to the proxy server
