### PR TITLE
alldos2unix should be a rake task instead of capistrano

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,11 +1,5 @@
 require 'bundler/capistrano'
 
-task :alldos2unix do
-  `find ./*`.split("\n").each do |str|
-    `dos2unix #{str}`
-  end
-end
-
 set :application, "expertiza"
 set :repository,  "git://github.com/expertiza/expertiza.git"
 set :use_sudo, false

--- a/lib/tasks/line_endings.rake
+++ b/lib/tasks/line_endings.rake
@@ -1,0 +1,6 @@
+desc 'Convert line endings to unix for all files under the current directory'
+task :alldos2unix do
+  `find ./*`.split("\n").each do |str|
+    `dos2unix #{str}`
+  end
+end


### PR DESCRIPTION
`alldos2unix` functions perfectly well as a capistrano task, but it doesn't belong there, especially now that capistrano tasks will require a stage to be specified. Capistrano is essentially rake for remote tasks. Since this is a local task, it should just be a normal rake task. Run it with `rake alldos2unix`.

```
$ rake -T
rake alldos2unix  # Convert line endings to unix for all files under the current directory
```

I wanted to run this by you @akofink before I made the change.
