### PR TITLE
E1583: Fix the CSS for the menu

### DIFF
--- a/app/assets/stylesheets/navbar.scss
+++ b/app/assets/stylesheets/navbar.scss
@@ -156,20 +156,28 @@ ul.navbar-right > li.right-most > a:hover {
     border-radius: 6px 0 6px 6px;
 }
 
-.margintop {
-    margin-top: 23px;
+.containerposition {
+    position: relative;
+    left: 43px;
+    margin-top: -30px;
+}
+
+.navbarposition {
+  margin-top: -70px;
+}
+
+.menuposition {
+  margin-top: 23px;
 }
 // end
 
 
 // Refer from http://www.bootply.com/120604
 @media (max-width: 1170px) {
-    .margintop {
-        marvin-top: 0px;
-    }
     .navbar-header {
-        float: none;
+      float: none;
     }
+
     .navbar-toggle {
         display: block;
     }

--- a/app/assets/stylesheets/navbar.scss
+++ b/app/assets/stylesheets/navbar.scss
@@ -155,12 +155,18 @@ ul.navbar-right > li.right-most > a:hover {
     -moz-border-radius: 6px 0 6px 6px;
     border-radius: 6px 0 6px 6px;
 }
+
+.margintop {
+    margin-top: 23px;
+}
 // end
 
 
 // Refer from http://www.bootply.com/120604
 @media (max-width: 1170px) {
-
+    .margintop {
+        marvin-top: 0px;
+    }
     .navbar-header {
         float: none;
     }

--- a/app/assets/stylesheets/navbar.scss
+++ b/app/assets/stylesheets/navbar.scss
@@ -174,7 +174,7 @@ ul.navbar-right > li.right-most > a:hover {
     }
     .navbar-nav {
         float: none!important;
-        margin: 7.5px -15px;
+        margin: 0px -15px;
         background: #A90201;
     }
     .navbar .divider-vertical {

--- a/app/assets/stylesheets/navbar.scss
+++ b/app/assets/stylesheets/navbar.scss
@@ -202,11 +202,12 @@ ul.navbar-right > li.right-most > a:hover {
     .collapsing {
         overflow: hidden!important;
     }
-    .dropdown-submenu>.dropdown-menu {
-    }
-
     .logout-box{
       margin-top: 7px;
       left: -2px;
     }
+   .dropdown-menu.pull-left{
+     top: 25%;
+     left: 15%;
+   }
 }

--- a/app/assets/stylesheets/navbar.scss
+++ b/app/assets/stylesheets/navbar.scss
@@ -43,12 +43,11 @@
 
 ul.nav li.first-level {
   font-size: 100%;
-  height: 66px;
 }
 
 li.first-level > a {
-  line-height: 36px;
-  padding: 15px 10px;
+  line-height: 10px;
+  padding: 0px 10px;
 }
 
 ul.nav li.dropdown:hover > ul.dropdown-menu {
@@ -65,7 +64,7 @@ ul.nav > li.dropdown > a:hover {
 
 ul.navbar-right > li.right-most > a {
   color: #EEEEEE;
-  line-height: 36px;
+//  line-height: 36px;
 }
 
 ul.navbar-right > li.right-most > a:hover {
@@ -73,9 +72,11 @@ ul.navbar-right > li.right-most > a:hover {
 }
 
 .navbar .impersonate-box {
-  height: 66px; 
-  padding: 10px 0;
+  height: 13px;
+  padding: 0px 0;
 }
+
+
 
 .impersonate-box .input-group {
   width: 170px;
@@ -83,6 +84,7 @@ ul.navbar-right > li.right-most > a:hover {
 
 #impersonate-user-info {
   color: #EEEEEE;
+  padding-left: 13px;
 }
 
 #impersonate-button {
@@ -158,6 +160,7 @@ ul.navbar-right > li.right-most > a:hover {
 
 // Refer from http://www.bootply.com/120604
 @media (max-width: 1170px) {
+
     .navbar-header {
         float: none;
     }
@@ -200,5 +203,10 @@ ul.navbar-right > li.right-most > a:hover {
         overflow: hidden!important;
     }
     .dropdown-submenu>.dropdown-menu {
+    }
+
+    .logout-box{
+      margin-top: 7px;
+      left: -2px;
     }
 }

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,9 +10,8 @@
 </head>
 
 <body>
-  <div class="container-fluid">
   <%= render 'shared/navigation' %>
-
+  <div class="container" style="position: relative; margin-top: -30px">
   <div class="wrapper">
     <div class="main">
       <div class="content">
@@ -24,12 +23,9 @@
       </div>
     </div>
   </div>
-
+</div>
   <div class="clearing">&nbsp;</div>
-
-  </div>
   <!-- class="wrapper" -->
-
   <div class="footer" align="center">
     <%= render 'shared/footer_message' %>
   </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,7 +11,7 @@
 
 <body>
   <%= render 'shared/navigation' %>
-  <div class="container" style="position: relative; margin-top: -30px">
+  <div class="container" style="position: relative; margin-top: -30px; left: 43px;">
   <div class="wrapper">
     <div class="main">
       <div class="content">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,7 +11,7 @@
 
 <body>
   <%= render 'shared/navigation' %>
-  <div class="container" style="position: relative; margin-top: -30px; left: 43px;">
+  <div class="container containerposition">
   <div class="wrapper">
     <div class="main">
       <div class="content">

--- a/app/views/menu_items/_suckerfish.html.erb
+++ b/app/views/menu_items/_suckerfish.html.erb
@@ -17,7 +17,7 @@
       end %>title='<%= long_name %>'><%= item.label.html_safe %></a>
     <% if item.children -%>
     <% if level == 1 %>
-    <ul class="dropdown-menu multi-level">
+    <ul class="dropdown-menu pull-left">
       <%= render :partial => 'menu_items/suckerfish', :locals => {:items => item.children, :level => level} %>
     </ul>
     <% else %>

--- a/app/views/shared/_navigation.html.erb
+++ b/app/views/shared/_navigation.html.erb
@@ -51,7 +51,7 @@
   $(function() {
     $('button.navbar-toggle').click(function() {
         if ($('.container').css('margin-top') === '-30px') {
-                $('.container').css('margin-top', '+=600');
+                $('.container').css('margin-top', '+=255');
             } else {
                     $('.container').css('margin-top', '-30px');
                 }

--- a/app/views/shared/_navigation.html.erb
+++ b/app/views/shared/_navigation.html.erb
@@ -1,8 +1,8 @@
-<nav role="navigation" class="navbar navbar-default navbar-static-top" style="margin-top: -70px;">
+<nav role="navigation" class="navbar navbar-default navbar-static-top navbarposition">
   <div class="container-fluid">
     <div class="navbar-header">
       <%= image_tag "logo.jpg", height: '65'%>
-      <button type="button" class="pull-left navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
+      <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
       <span class="sr-only">Toggle navigation</span>
       <span class="icon-bar"></span>
       <span class="icon-bar"></span>
@@ -11,7 +11,7 @@
     </div>
     <div class="navbar-collapse collapse">
 
-      <ul class="nav navbar-nav margintop">
+      <ul class="nav navbar-nav menuposition">
         <% if session[:menu] %>
           <%= render :partial => 'menu_items/suckerfish',
             :locals => { items: session[:menu].get_menu(0), level: 0 } %>
@@ -52,9 +52,9 @@
     $('button.navbar-toggle').click(function() {
         if ($('.container').css('margin-top') === '-30px') {
                 $('.container').css('margin-top', '+=255');
-            } else {
+        } else {
                     $('.container').css('margin-top', '-30px');
-                }
-      });
+        }
+    });
   });
 </script>

--- a/app/views/shared/_navigation.html.erb
+++ b/app/views/shared/_navigation.html.erb
@@ -1,4 +1,5 @@
-  <div class="navbar navbar-default navbar-fixed-top">
+<nav role="navigation" class="navbar navbar-default navbar-static-top" style="margin-top: -70px;">
+  <div class="container-fluid">
     <div class="navbar-header">
       <%= image_tag "logo.jpg", height: '65'%>
       <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
@@ -40,9 +41,20 @@
       </ul>
     </div>
   </div>
+  </nav>
 
 <script type="text/javascript">
   jQuery("#impersonate-button").click(function(event) {
     jQuery("#impersonate-form").submit()
+  });
+
+  $(function() {
+    $('button.navbar-toggle').click(function() {
+        if ($('.container').css('margin-top') === '-30px') {
+                $('.container').css('margin-top', '+=600');
+            } else {
+                    $('.container').css('margin-top', '-30px');
+                }
+      });
   });
 </script>

--- a/app/views/shared/_navigation.html.erb
+++ b/app/views/shared/_navigation.html.erb
@@ -34,7 +34,7 @@
           <% end %>
           </li>
             <li class="divider-vertical"></li>
-            <li class="right-most">
+            <li class="right-most logout-box">
               <%= link_to "Logout", {controller: "auth", action: "logout"}, method: :post %>
             </li>
         <% end %>

--- a/app/views/shared/_navigation.html.erb
+++ b/app/views/shared/_navigation.html.erb
@@ -2,7 +2,7 @@
   <div class="container-fluid">
     <div class="navbar-header">
       <%= image_tag "logo.jpg", height: '65'%>
-      <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
+      <button type="button" class="pull-left navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
       <span class="sr-only">Toggle navigation</span>
       <span class="icon-bar"></span>
       <span class="icon-bar"></span>
@@ -11,7 +11,7 @@
     </div>
     <div class="navbar-collapse collapse">
 
-      <ul class="nav navbar-nav">
+      <ul class="nav navbar-nav margintop">
         <% if session[:menu] %>
           <%= render :partial => 'menu_items/suckerfish',
             :locals => { items: session[:menu].get_menu(0), level: 0 } %>


### PR DESCRIPTION
In this pull request, we have included CSS fixes for menu on smaller screen devices as mentioned below.

1. Moved the menu button from right hand side to left hand side.
2. Decreased the vertical extra space between the menu items.
3. Pushed content down on opening the menu.
4. Submenus of menus now open on right hand side rather than below the main menu item.

The demo can be seen in this video: https://www.youtube.com/watch?v=dJQa5PGlWv0