### PR TITLE
E1776 OSS Project Carolina Blue: Import Enhancements

### DIFF
--- a/app/assets/javascripts/shared.js
+++ b/app/assets/javascripts/shared.js
@@ -1,3 +1,50 @@
+function checkForFile() {
+    var file_value = $('#import_file').val();
+    $(document).ready(function() {
+        if (file_value.length <= 0) {
+            alert('Please select a file before clicking Import.');
+        } else {
+            import_form.submit();
+        };
+    });
+}
+
+function checkIfUserColumnDuplicate() {
+
+    var sel1 = document.getElementById("select1");
+    var sel2 = document.getElementById("select2");
+    var sel3 = document.getElementById("select3");
+
+    var val1 = sel1.options[sel1.selectedIndex].value;
+    var val2 = sel2.options[sel2.selectedIndex].value;
+    var val3 = sel3.options[sel3.selectedIndex].value;
+
+    if(val1 == val2 || val2 == val3 || val1 == val3) {
+        alert("No two columns can have same value.")
+    } else {
+      column_form.submit();
+    }
+}
+function checkForParticipantColumnDuplicate() {
+
+    var sel1 = document.getElementById("select1");
+    var sel2 = document.getElementById("select2");
+    var sel3 = document.getElementById("select3");
+    var sel4 = document.getElementById("select4");
+
+    var val1 = sel1.options[sel1.selectedIndex].value;
+    var val2 = sel2.options[sel2.selectedIndex].value;
+    var val3 = sel3.options[sel3.selectedIndex].value;
+    var val4 = sel4.options[sel4.selectedIndex].value;
+
+    if(val1 == val2 || val1 == val3 || val1 == val4 || val2 == val3 || val2 == val4 || val3 == val4) {
+        alert("No two columns can have same value.")
+    } else {
+        column_form.submit();
+    }
+}
+
+
 function checkIfFileExists(filename, flag)
 {
     if(filename=='')

--- a/app/assets/javascripts/shared.js
+++ b/app/assets/javascripts/shared.js
@@ -59,12 +59,10 @@ function checkTopicForDuplicatesAndRequiredColumns(optional_count) {
 
     for (var i = 0; i < optional_count; i++) {
         var sel = document.getElementById("select" + (i + 4).toString());
-        console.log("\n\n********** " + sel + " **********\n\n");
         val_array[i + 3] = sel.options[sel.selectedIndex].value;
     }
 
     var sorted_val_array = val_array.slice().sort();
-    console.log("\n\n********** " + sorted_val_array + " **********\n\n");
     var has_duplicates = false;
 
     for (var i = 0; i < sorted_val_array.length - 1; i++) {
@@ -72,8 +70,6 @@ function checkTopicForDuplicatesAndRequiredColumns(optional_count) {
             has_duplicates = true;
         }
     }
-
-    console.log("\n\n********** " + val_array + " **********\n\n");
 
     if (!val_array.includes('topic_identifier') || !val_array.includes('topic_name') || !val_array.includes('max_choosers')) {
         alert("Topic Identifier, Topic Name, and Max Choosers are required columns.");

--- a/app/assets/javascripts/shared.js
+++ b/app/assets/javascripts/shared.js
@@ -25,6 +25,7 @@ function checkIfUserColumnDuplicate() {
       column_form.submit();
     }
 }
+
 function checkForParticipantColumnDuplicate() {
 
     var sel1 = document.getElementById("select1");
@@ -44,6 +45,44 @@ function checkForParticipantColumnDuplicate() {
     }
 }
 
+function checkTopicForDuplicatesAndRequiredColumns(optional_count) {
+
+    var sel1 = document.getElementById("select1");
+    var sel2 = document.getElementById("select2");
+    var sel3 = document.getElementById("select3");
+
+    var val1 = sel1.options[sel1.selectedIndex].value;
+    var val2 = sel2.options[sel2.selectedIndex].value;
+    var val3 = sel3.options[sel3.selectedIndex].value;
+
+    var val_array = [val1, val2, val3];
+
+    for (var i = 0; i < optional_count; i++) {
+        var sel = document.getElementById("select" + (i + 4).toString());
+        console.log("\n\n********** " + sel + " **********\n\n");
+        val_array[i + 3] = sel.options[sel.selectedIndex].value;
+    }
+
+    var sorted_val_array = val_array.slice().sort();
+    console.log("\n\n********** " + sorted_val_array + " **********\n\n");
+    var has_duplicates = false;
+
+    for (var i = 0; i < sorted_val_array.length - 1; i++) {
+        if (sorted_val_array[i + 1] == sorted_val_array[i]) {
+            has_duplicates = true;
+        }
+    }
+
+    console.log("\n\n********** " + val_array + " **********\n\n");
+
+    if (!val_array.includes('topic_identifier') || !val_array.includes('topic_name') || !val_array.includes('max_choosers')) {
+        alert("Topic Identifier, Topic Name, and Max Choosers are required columns.");
+    } else if (has_duplicates) {
+        alert("No two columns can have the same value.");
+    } else {
+        column_form.submit();
+    }
+}
 
 function checkIfFileExists(filename, flag)
 {

--- a/app/controllers/import_file_controller.rb
+++ b/app/controllers/import_file_controller.rb
@@ -75,15 +75,11 @@ class ImportFileController < ApplicationController
 
 
   def import_from_hash(session, params)
-
     if params[:model] == "AssignmentTeam" or params[:model] == "CourseTeam"
-
       contents_hash = eval(params[:contents_hash])
       @header_integrated_body = hash_rows_with_headers(contents_hash[:header],contents_hash[:body])
       errors = []
-
       begin
-
         @header_integrated_body.each do |row_hash|
           if params[:model] == "AssignmentTeam"
             teamtype = AssignmentTeam
@@ -94,104 +90,76 @@ class ImportFileController < ApplicationController
           options[:has_teamname] = params[:has_teamname]
           Team.import(row_hash,params[:id], options, teamtype)
         end
-
       rescue
         errors << $ERROR_INFO
-        puts errors.to_s
       end
-
       elsif params[:model] == "ReviewResponseMap"
         contents_hash = eval(params[:contents_hash])
         @header_integrated_body = hash_rows_with_headers(contents_hash[:header],contents_hash[:body])
         errors = []
-
         begin
           @header_integrated_body.each do |row_hash|
             ReviewResponseMap.import(row_hash,session,params[:id])
           end
-
         rescue
           errors << $ERROR_INFO
-          puts errors.to_s
         end
     elsif params[:model] == "MetareviewResponseMap"
-        contents_hash = eval(params[:contents_hash])
-        @header_integrated_body = hash_rows_with_headers(contents_hash[:header],contents_hash[:body])
-        errors = []
-
-        begin
-          @header_integrated_body.each do |row_hash|
-            MetareviewResponseMap.import(row_hash,session,params[:id])
-          end
-
-        rescue
-          errors << $ERROR_INFO
-          puts errors.to_s
-          end
+      contents_hash = eval(params[:contents_hash])
+      @header_integrated_body = hash_rows_with_headers(contents_hash[:header],contents_hash[:body])
+      errors = []
+      begin
+        @header_integrated_body.each do |row_hash|
+          MetareviewResponseMap.import(row_hash,session,params[:id])
+        end
+      rescue
+        errors << $ERROR_INFO
+        end
     elsif params[:model] == 'SignUpTopic'
       session[:assignment_id] = params[:id]
       contents_hash = eval(params[:contents_hash])
       contents_hash[:body].each do |row|
         SignUpTopic.import(row, session, params[:id])
       end
-
     elsif params[:model] == 'AssignmentParticipant' || params[:model] == 'CourseParticipant'
-
       contents_hash = eval(params[:contents_hash])
-
       if params[:has_header] == 'true'
         @header_integrated_body = hash_rows_with_headers(contents_hash[:header], contents_hash[:body])
       else
         new_header = [params[:select1], params[:select2], params[:select3], params[:select4]]
         @header_integrated_body = hash_rows_with_headers(new_header, contents_hash[:body])
       end
-
       errors = []
-
       begin
-
         if params[:model] == 'AssignmentParticipant'
-
           @header_integrated_body.each do |row_hash|
             AssignmentParticipant.import(row_hash, session, params[:id])
           end
-
         elsif params[:model] == 'CourseParticipant'
-
           @header_integrated_body.each do |row_hash|
             CourseParticipant.import(row_hash, session, params[:id])
           end
-
         end
-
       rescue
         errors << $ERROR_INFO
       end
-
-
-    else    # params[:model] = "User"
+    else # params[:model] = "User"
       contents_hash = eval(params[:contents_hash])
-
       if params[:has_header] == 'true'
         @header_integrated_body = hash_rows_with_headers(contents_hash[:header],contents_hash[:body])
       else
         new_header = [params[:select1], params[:select2], params[:select3]]
         @header_integrated_body = hash_rows_with_headers(new_header, contents_hash[:body])
       end
-
       errors = []
-
       begin
-
         @header_integrated_body.each do |row_hash|
-          User.import(row_hash, nil,session)
+          User.import(row_hash, nil, session)
         end
-
       rescue
         errors << $ERROR_INFO
-        puts errors.to_s
       end
-   end
+    end
     errors
   end
 
@@ -200,8 +168,10 @@ class ImportFileController < ApplicationController
 
   # Produces an array, where each entry in the array is a hash.
   # The hash keys are the column titles, and the hash values are the associated values.
+  #
   # E.G. [ { :name => 'jsmith', :fullname => 'John Smith' , :email => 'jsmith@gmail.com' },
   #        { :name => 'jdoe', :fullname => 'Jane Doe', :email => 'jdoe@gmail.com' } ]
+  #
   def hash_rows_with_headers(header, body)
 
     new_body = []
@@ -272,6 +242,11 @@ class ImportFileController < ApplicationController
   # Produces a hash where :header refers to the header (may be nil)
   # and :body refers to the contents of the file except the header.
   # :header is an array, and :body is a two-dimensional array.
+  #
+  # E.G. { :header => ['name', 'fullname', 'email'],
+  #        :body => [ ['jsmith', 'John Smith', 'jsmith@gmail.com'],
+  #                   ['jdoe', 'Jane Doe', 'jdoe@gmail.com' ] ] }
+  #
   def parse_to_hash(import_grid, has_header)
     file_hash = Hash.new
     if has_header == 'true'
@@ -288,6 +263,11 @@ class ImportFileController < ApplicationController
   # Produces a two-dimensional array.
   # The outer array contains "rows".
   # The inner arrays contain "elements of rows" or "columns".
+  #
+  # E.G. [ [ 'name', 'fullname', 'email' ],
+  #        [ 'jsmith', 'John Smith', 'jsmith@gmail.com' ],
+  #        [ 'jdoe', 'Jane Doe', 'jdoe@gmail.com' ] ]
+  #
   def parse_to_grid(contents, delimiter)
     contents_grid = []
     contents.each_line do |line|

--- a/app/controllers/import_file_controller.rb
+++ b/app/controllers/import_file_controller.rb
@@ -130,6 +130,7 @@ class ImportFileController < ApplicationController
           end
     elsif params[:model] == 'SignUpTopic'
       session[:assignment_id] = params[:id]
+      contents_hash = eval(params[:contents_hash])
       contents_hash[:body].each do |row|
         SignUpTopic.import(row, session, params[:id])
       end

--- a/app/controllers/import_file_controller.rb
+++ b/app/controllers/import_file_controller.rb
@@ -6,6 +6,36 @@ class ImportFileController < ApplicationController
      'Super-Administrator'].include? current_role_name
   end
 
+  def show
+    @id = params[:id]
+    @model = params[:model]
+    @options = params[:options]
+    @delimiter = get_delimiter(params)
+    @has_header = params[:has_header]
+    if (@model == 'AssignmentTeam'|| @model == 'CourseTeam')
+      @has_teamname = params[:has_teamname]
+    else
+      @has_teamname = "nil"
+    end
+    if (@model == 'ReviewResponseMap')
+      @has_reviewee = params[:has_reviewee]
+    else
+      @has_reviewee = nil
+    end
+
+    if (@model == 'MetareviewResponseMap')
+      @has_reviewee = params[:has_reviewee]
+      @has_reviewer = params[:has_reviewer]
+    else
+      @has_reviewee = "nil"
+      @has_reviewer = "nil"
+    end
+    @current_file = params[:file]
+    @current_file_contents = @current_file.read
+    @contents_grid = parse_to_grid(@current_file_contents, @delimiter)
+    @contents_hash = parse_to_hash(@contents_grid, params[:has_header])
+  end
+
   def start
     @id = params[:id]
     @expected_fields = params[:expected_fields]
@@ -13,19 +43,257 @@ class ImportFileController < ApplicationController
     @title = params[:title]
   end
 
+
   def import
-    errors = importFile(session, params)
+
+    errors = import_from_hash(session, params)
+
     err_msg = "The following errors were encountered during import.<br/>Other records may have been added. A second submission will not duplicate these records.<br/><ul>"
+
     errors.each do |error|
       err_msg = err_msg + "<li>" + error.to_s + "<br/>"
     end
+
     err_msg += "</ul>"
     flash[:error] = err_msg unless errors.empty?
     undo_link("The file has been successfully imported.")
     redirect_to session[:return_to]
+
+  end
+
+  # def import
+  #   errors = importFile(session, params)
+  #   err_msg = "The following errors were encountered during import.<br/>Other records may have been added. A second submission will not duplicate these records.<br/><ul>"
+  #   errors.each do |error|
+  #     err_msg = err_msg + "<li>" + error.to_s + "<br/>"
+  #   end
+  #   err_msg += "</ul>"
+  #   flash[:error] = err_msg unless errors.empty?
+  #   undo_link("The file has been successfully imported.")
+  #   redirect_to session[:return_to]
+  # end
+
+
+  def import_from_hash(session, params)
+
+    if params[:model] == "AssignmentTeam" or params[:model] == "CourseTeam"
+
+      contents_hash = eval(params[:contents_hash])
+      @header_integrated_body = hash_rows_with_headers(contents_hash[:header],contents_hash[:body])
+      errors = []
+
+      begin
+
+        @header_integrated_body.each do |row_hash|
+          if params[:model] == "AssignmentTeam"
+            teamtype = AssignmentTeam
+          else
+            teamtype = CourseTeam
+          end
+          options = eval(params[:options])
+          options[:has_teamname] = params[:has_teamname]
+          Team.import(row_hash,params[:id], options, teamtype)
+        end
+
+      rescue
+        errors << $ERROR_INFO
+        puts errors.to_s
+      end
+
+      elsif params[:model] == "ReviewResponseMap"
+        contents_hash = eval(params[:contents_hash])
+        @header_integrated_body = hash_rows_with_headers(contents_hash[:header],contents_hash[:body])
+        errors = []
+
+        begin
+          @header_integrated_body.each do |row_hash|
+            ReviewResponseMap.import(row_hash,session,params[:id])
+          end
+
+        rescue
+          errors << $ERROR_INFO
+          puts errors.to_s
+        end
+    elsif params[:model] == "MetareviewResponseMap"
+        contents_hash = eval(params[:contents_hash])
+        @header_integrated_body = hash_rows_with_headers(contents_hash[:header],contents_hash[:body])
+        errors = []
+
+        begin
+          @header_integrated_body.each do |row_hash|
+            MetareviewResponseMap.import(row_hash,session,params[:id])
+          end
+
+        rescue
+          errors << $ERROR_INFO
+          puts errors.to_s
+          end
+    elsif params[:model] == 'SignUpTopic'
+      session[:assignment_id] = params[:id]
+      contents_hash[:body].each do |row|
+        SignUpTopic.import(row, session, params[:id])
+      end
+
+    elsif params[:model] == 'AssignmentParticipant' || params[:model] == 'CourseParticipant'
+
+      contents_hash = eval(params[:contents_hash])
+
+      if params[:has_header] == 'true'
+        @header_integrated_body = hash_rows_with_headers(contents_hash[:header], contents_hash[:body])
+      else
+        new_header = [params[:select1], params[:select2], params[:select3], params[:select4]]
+        @header_integrated_body = hash_rows_with_headers(new_header, contents_hash[:body])
+      end
+
+      errors = []
+
+      begin
+
+        if params[:model] == 'AssignmentParticipant'
+
+          @header_integrated_body.each do |row_hash|
+            AssignmentParticipant.import(row_hash, session, params[:id])
+          end
+
+        elsif params[:model] == 'CourseParticipant'
+
+          @header_integrated_body.each do |row_hash|
+            CourseParticipant.import(row_hash, session, params[:id])
+          end
+
+        end
+
+      rescue
+        errors << $ERROR_INFO
+      end
+
+
+    else    # params[:model] = "User"
+      contents_hash = eval(params[:contents_hash])
+
+      if params[:has_header] == 'true'
+        @header_integrated_body = hash_rows_with_headers(contents_hash[:header],contents_hash[:body])
+      else
+        new_header = [params[:select1], params[:select2], params[:select3]]
+        @header_integrated_body = hash_rows_with_headers(new_header, contents_hash[:body])
+      end
+
+      errors = []
+
+      begin
+
+        @header_integrated_body.each do |row_hash|
+          User.import(row_hash, session)
+        end
+
+      rescue
+        errors << $ERROR_INFO
+        puts errors.to_s
+      end
+   end
+    errors
   end
 
   protected
+
+
+  # Produces an array, where each entry in the array is a hash.
+  # The hash keys are the column titles, and the hash values are the associated values.
+  # E.G. [ { :name => 'jsmith', :fullname => 'John Smith' , :email => 'jsmith@gmail.com' },
+  #        { :name => 'jdoe', :fullname => 'Jane Doe', :email => 'jdoe@gmail.com' } ]
+  def hash_rows_with_headers(header, body)
+
+    new_body = []
+
+    if params[:model] == "User" or params[:model] == "AssignmentParticipant" or params[:model] == "CourseParticipant"
+      header.map! { |column_name| column_name.to_sym }
+
+      body.each do |row|
+        new_body << header.zip(row).to_h
+      end
+
+    elsif params[:model] == "AssignmentTeam" or params[:model] == "CourseTeam"
+      header.map! { |column_name| column_name.to_sym }
+      body.each do |row|
+        h = Hash.new()
+        if params[:has_teamname] == "true_first"
+          h[header[0]] = row.shift
+          h[header[1]] = row
+        elsif params[:has_teamname] == "true_last"
+          h[header[1]] = row.pop
+          h[header[0]] = row
+        else
+          h[header[0]] = row
+        end
+        new_body << h
+      end
+
+    elsif params[:model] == "ReviewResponseMap"
+
+      header.map! { |column_name| column_name.to_sym }
+      body.each do |row|
+        h = Hash.new()
+        if params[:has_reviewee] == "true_first"
+          h[header[0]] = row.shift
+          h[header[1]] = row
+        elsif params[:has_reviewee] == "true_last"
+          h[header[1]] = row.pop
+          h[header[0]] = row
+        else
+          h[header[0]] = row
+        end
+        new_body << h
+      end
+
+    elsif params[:model] == "MetareviewResponseMap"
+
+      header.map! { |column_name| column_name.to_sym }
+      body.each do |row|
+        h = Hash.new()
+        if params[:has_reviewee] == "true_first"
+          h[header[0]] = row.shift
+          h[header[1]] = row.shift
+          h[header[2]] = row
+        elsif params[:has_reviewee] == "true_last"
+          h[header[2]] = row.pop
+          h[header[1]] = row.pop
+          h[header[0]] = row
+        else
+          h[header[0]] = row
+        end
+        new_body << h
+      end
+    end
+
+    new_body
+  end
+
+  # Produces a hash where :header refers to the header (may be nil)
+  # and :body refers to the contents of the file except the header.
+  # :header is an array, and :body is a two-dimensional array.
+  def parse_to_hash(import_grid, has_header)
+    file_hash = Hash.new
+    if has_header == 'true'
+      file_hash[:header] = import_grid.shift
+      file_hash[:body] = import_grid
+    else
+      file_hash[:header] = nil
+      file_hash[:body] = import_grid
+    end
+    puts file_hash
+    file_hash
+  end
+
+  # Produces a two-dimensional array.
+  # The outer array contains "rows".
+  # The inner arrays contain "elements of rows" or "columns".
+  def parse_to_grid(contents, delimiter)
+    contents_grid = []
+    contents.each_line do |line|
+      contents_grid << parse_line(line, delimiter)
+    end
+    contents_grid
+  end
 
   def importFile(session, params)
     delimiter = get_delimiter(params)

--- a/app/controllers/import_file_controller.rb
+++ b/app/controllers/import_file_controller.rb
@@ -164,8 +164,7 @@ class ImportFileController < ApplicationController
   end
 
   protected
-
-
+  
   # Produces an array, where each entry in the array is a hash.
   # The hash keys are the column titles, and the hash values are the associated values.
   #

--- a/app/controllers/import_file_controller.rb
+++ b/app/controllers/import_file_controller.rb
@@ -184,7 +184,7 @@ class ImportFileController < ApplicationController
       begin
 
         @header_integrated_body.each do |row_hash|
-          User.import(row_hash, session)
+          User.import(row_hash, nil,session)
         end
 
       rescue

--- a/app/controllers/import_file_controller.rb
+++ b/app/controllers/import_file_controller.rb
@@ -45,20 +45,15 @@ class ImportFileController < ApplicationController
 
 
   def import
-
     errors = import_from_hash(session, params)
-
     err_msg = "The following errors were encountered during import.<br/>Other records may have been added. A second submission will not duplicate these records.<br/><ul>"
-
     errors.each do |error|
       err_msg = err_msg + "<li>" + error.to_s + "<br/>"
     end
-
     err_msg += "</ul>"
     flash[:error] = err_msg unless errors.empty?
     undo_link("The file has been successfully imported.")
     redirect_to session[:return_to]
-
   end
 
   # def import

--- a/app/controllers/import_file_controller.rb
+++ b/app/controllers/import_file_controller.rb
@@ -164,7 +164,7 @@ class ImportFileController < ApplicationController
   end
 
   protected
-  
+
   # Produces an array, where each entry in the array is a hash.
   # The hash keys are the column titles, and the hash values are the associated values.
   #

--- a/app/controllers/import_file_controller.rb
+++ b/app/controllers/import_file_controller.rb
@@ -22,13 +22,26 @@ class ImportFileController < ApplicationController
     else
       @has_reviewee = nil
     end
-
     if (@model == 'MetareviewResponseMap')
       @has_reviewee = params[:has_reviewee]
       @has_reviewer = params[:has_reviewer]
     else
       @has_reviewee = "nil"
       @has_reviewer = "nil"
+    end
+    if (@model == 'SignUpTopic')
+      @optional_count = 0;
+      if (params[:category] == 'true')
+        @optional_count += 1
+      end
+      if (params[:description] == 'true')
+        @optional_count += 1
+      end
+      if (params[:link] == 'true')
+        @optional_count += 1
+      end
+    else
+      @optional_count = 0
     end
     @current_file = params[:file]
     @current_file_contents = @current_file.read

--- a/app/controllers/import_file_controller.rb
+++ b/app/controllers/import_file_controller.rb
@@ -30,7 +30,7 @@ class ImportFileController < ApplicationController
       @has_reviewer = "nil"
     end
     if (@model == 'SignUpTopic')
-      @optional_count = 0;
+      @optional_count = 0
       if (params[:category] == 'true')
         @optional_count += 1
       end
@@ -55,7 +55,6 @@ class ImportFileController < ApplicationController
     @model = params[:model]
     @title = params[:title]
   end
-
 
   def import
     errors = import_from_hash(session, params)
@@ -122,7 +121,6 @@ class ImportFileController < ApplicationController
       rescue
         errors << $ERROR_INFO
       end
-
     elsif params[:model] == 'SignUpTopic'
       contents_hash = eval(params[:contents_hash])
       if params[:has_header] == 'true'

--- a/app/helpers/import_file_helper.rb
+++ b/app/helpers/import_file_helper.rb
@@ -1,17 +1,33 @@
 require 'csv'
 
 module ImportFileHelper
-  def self.define_attributes(row)
+
+  def self.define_attributes(row_hash)
     attributes = {}
     attributes["role_id"] = Role.student.id
-    attributes["name"] = row[0].strip
-    attributes["fullname"] = row[1]
-    attributes["email"] = row[2].strip
+    attributes["name"] = row_hash[:name]
+    attributes["fullname"] = row_hash[:fullname]
+    attributes["email"] = row_hash[:email]
     attributes["email_on_submission"] = 1
     attributes["email_on_review"] = 1
     attributes["email_on_review_of_review"] = 1
     attributes
   end
+
+  # The old method is commented out below.
+
+  # def self.define_attributes(row)
+  #   attributes = {}
+  #   attributes["role_id"] = Role.student.id
+  #   attributes["name"] = row[0].strip
+  #   attributes["fullname"] = row[1]
+  #   attributes["email"] = row[2].strip
+  #   attributes["email_on_submission"] = 1
+  #   attributes["email_on_review"] = 1
+  #   attributes["email_on_review_of_review"] = 1
+  #   attributes
+  # end
+
 
   def self.create_new_user(attributes, session)
     user = User.new(attributes)
@@ -20,4 +36,16 @@ module ImportFileHelper
     user.save!
     user
   end
+
+  # The old method is commented out below.
+
+  # def self.create_new_user(attributes, session)
+  #   user = User.new(attributes)
+  #   user.parent_id = (session[:user]).id
+  #   user.timezonepref = User.find(user.parent_id).timezonepref
+  #   user.save!
+  #   user
+  # end
+
+
 end

--- a/app/helpers/import_topics_helper.rb
+++ b/app/helpers/import_topics_helper.rb
@@ -1,24 +1,39 @@
 require 'csv'
 
 module ImportTopicsHelper
-  def self.define_attributes(columns)
+
+  def self.define_attributes(row_hash)
     attributes = {}
-    attributes["topic_identifier"] = columns[0].strip
-    attributes["topic_name"] = columns[1].strip
-    attributes["max_choosers"] = columns[2].strip
-
-    # Instead of calling this extra method, we can check if row_hash[:field] is nil.
-
-    define_attributes_extra(attributes, columns)
+    attributes["topic_identifier"] = row_hash[:topic_identifier].strip
+    attributes["topic_name"] = row_hash[:topic_name].strip
+    attributes["max_choosers"] = row_hash[:max_choosers].strip
+    attributes["category"] = row_hash[:category].strip unless row_hash[:category].nil?
+    attributes["description"] = row_hash[:description].strip unless row_hash[:description].nil?
+    attributes["link"] = row_hash[:link].strip unless row_hash[:link].nil?
     attributes
   end
 
-  def self.define_attributes_extra(attributes, columns)
-    attributes["category"] = columns[3].strip if columns.length > 3
-    attributes["description"] = columns[4].strip if columns.length > 4
-    attributes["link"] = columns[5].strip if columns.length > 5
-    attributes
-  end
+  # The old method is commented out below.
+  # The define_attributes and define_attributes_extra methods were merged.
+  #
+  # def self.define_attributes(columns)
+  #   attributes = {}
+  #   attributes["topic_identifier"] = columns[0].strip
+  #   attributes["topic_name"] = columns[1].strip
+  #   attributes["max_choosers"] = columns[2].strip
+  #   define_attributes_extra(attributes, columns)
+  #   attributes
+  # end
+
+  # The old method is commented out below.
+  # The define_attributes and define_attributes_extra methods were merged.
+  #
+  # def self.define_attributes_extra(attributes, columns)
+  #   attributes["category"] = columns[3].strip if columns.length > 3
+  #   attributes["description"] = columns[4].strip if columns.length > 4
+  #   attributes["link"] = columns[5].strip if columns.length > 5
+  #   attributes
+  # end
 
   def self.create_new_sign_up_topic(attributes, session)
     sign_up_topic = SignUpTopic.new(attributes)

--- a/app/helpers/import_topics_helper.rb
+++ b/app/helpers/import_topics_helper.rb
@@ -6,12 +6,15 @@ module ImportTopicsHelper
     attributes["topic_identifier"] = columns[0].strip
     attributes["topic_name"] = columns[1].strip
     attributes["max_choosers"] = columns[2].strip
-    attributes["category"] = columns[3].strip if columns.length > 3
+
+    # Instead of calling this extra method, we can check if row_hash[:field] is nil.
+
     define_attributes_extra(attributes, columns)
     attributes
   end
 
   def self.define_attributes_extra(attributes, columns)
+    attributes["category"] = columns[3].strip if columns.length > 3
     attributes["description"] = columns[4].strip if columns.length > 4
     attributes["link"] = columns[5].strip if columns.length > 5
     attributes

--- a/app/models/assignment_participant.rb
+++ b/app/models/assignment_participant.rb
@@ -191,11 +191,11 @@ class AssignmentParticipant < Participant
 
   # provide import functionality for Assignment Participants
   # if user does not exist, it will be created and added to this assignment
-  def self.import(row, _row_header = nil, session, id)
+  def self.import(row_hash, _row_header = nil, session, id)
     raise ArgumentError, "No user id has been specified." if row.empty?
-    user = User.find_by_name(row[0])
+    user = User.find_by_name(row_hash[:name])
     if user.nil?
-      raise ArgumentError, "The record containing #{row[0]} does not have enough items." if row.length < 4
+      raise ArgumentError, "The record containing #{row_hash[:name]} does not have enough items." if row_hash.length < 4
       attributes = ImportFileHelper.define_attributes(row)
       user = ImportFileHelper.create_new_user(attributes, session)
     end
@@ -205,6 +205,23 @@ class AssignmentParticipant < Participant
       new_part.set_handle
     end
   end
+
+  # # provide import functionality for Assignment Participants
+  # # if user does not exist, it will be created and added to this assignment
+  # def self.import(row, _row_header = nil, session, id)
+  #   raise ArgumentError, "No user id has been specified." if row.empty?
+  #   user = User.find_by_name(row[0])
+  #   if user.nil?
+  #     raise ArgumentError, "The record containing #{row[0]} does not have enough items." if row.length < 4
+  #     attributes = ImportFileHelper.define_attributes(row)
+  #     user = ImportFileHelper.create_new_user(attributes, session)
+  #   end
+  #   raise ImportError, "The assignment with id \"" + id.to_s + "\" was not found." if Assignment.find(id).nil?
+  #   unless AssignmentParticipant.exists?(user_id: user.id, parent_id: id)
+  #     new_part = AssignmentParticipant.create(user_id: user.id, parent_id: id)
+  #     new_part.set_handle
+  #   end
+  # end
 
   # provide export functionality for Assignment Participants
   def self.export(csv, parent_id, _options)

--- a/app/models/assignment_participant.rb
+++ b/app/models/assignment_participant.rb
@@ -192,11 +192,11 @@ class AssignmentParticipant < Participant
   # provide import functionality for Assignment Participants
   # if user does not exist, it will be created and added to this assignment
   def self.import(row_hash, _row_header = nil, session, id)
-    raise ArgumentError, "No user id has been specified." if row.empty?
+    raise ArgumentError, "No user id has been specified." if row_hash.empty?
     user = User.find_by_name(row_hash[:name])
     if user.nil?
       raise ArgumentError, "The record containing #{row_hash[:name]} does not have enough items." if row_hash.length < 4
-      attributes = ImportFileHelper.define_attributes(row)
+      attributes = ImportFileHelper.define_attributes(row_hash)
       user = ImportFileHelper.create_new_user(attributes, session)
     end
     raise ImportError, "The assignment with id \"" + id.to_s + "\" was not found." if Assignment.find(id).nil?
@@ -206,6 +206,8 @@ class AssignmentParticipant < Participant
     end
   end
 
+  # The old method is commented out below.
+  #
   # # provide import functionality for Assignment Participants
   # # if user does not exist, it will be created and added to this assignment
   # def self.import(row, _row_header = nil, session, id)

--- a/app/models/course_participant.rb
+++ b/app/models/course_participant.rb
@@ -12,6 +12,7 @@ class CourseParticipant < Participant
       return nil # return nil so we can tell a copy is not made
     end
   end
+
   # provide import functionality for Course Participants
   # if user does not exist, it will be created and added to this assignment
   def self.import(row_hash, _row_header = nil, session, id)
@@ -20,14 +21,6 @@ class CourseParticipant < Participant
     if user.nil?
       raise ArgumentError, "The record containing #{row_hash[:name]} does not have enough items." if row_hash.length < 4
       attributes = ImportFileHelper.define_attributes(row_hash)
-
-      #########################################################################################
-      #                                                                                       #
-      #    THIS DOES NOT SET THE PASSWORD TO WHAT THE FILE SPECIFIES IF THEY ARE NEW USERS    #
-      #    IN FACT, THE PASSWORD COLUMN DOES NOT SEEM TO BE USED AT ALL                       #
-      #                                                                                       #
-      #########################################################################################
-
       user = ImportFileHelper.create_new_user(attributes, session)
     end
     course = Course.find(id)
@@ -38,6 +31,9 @@ class CourseParticipant < Participant
       CourseParticipant.create(user_id: user.id, parent_id: course.id)
     end
   end
+
+  # The old method is commented out below.
+  #
   # provide import functionality for Course Participants
   # if user does not exist, it will be created and added to this assignment
   # def self.import(row, _row_header = nil, session, id)

--- a/app/models/course_participant.rb
+++ b/app/models/course_participant.rb
@@ -12,15 +12,22 @@ class CourseParticipant < Participant
       return nil # return nil so we can tell a copy is not made
     end
   end
-
   # provide import functionality for Course Participants
   # if user does not exist, it will be created and added to this assignment
-  def self.import(row, _row_header = nil, session, id)
-    raise ArgumentError, "No user id has been specified." if row.empty?
-    user = User.find_by_name(row[0])
+  def self.import(row_hash, session, id)
+    raise ArgumentError, "No user id has been specified." if row_hash.empty?
+    user = User.find_by_name(row_hash[:name])
     if user.nil?
-      raise ArgumentError, "The record containing #{row[0]} does not have enough items." if row.length < 4
-      attributes = ImportFileHelper.define_attributes(row)
+      raise ArgumentError, "The record containing #{row_hash[:name]} does not have enough items." if row_hash.length < 4
+      attributes = ImportFileHelper.define_attributes(row_hash)
+
+      #########################################################################################
+      #                                                                                       #
+      #    THIS DOES NOT SET THE PASSWORD TO WHAT THE FILE SPECIFIES IF THEY ARE NEW USERS    #
+      #    IN FACT, THE PASSWORD COLUMN DOES NOT SEEM TO BE USED AT ALL                       #
+      #                                                                                       #
+      #########################################################################################
+
       user = ImportFileHelper.create_new_user(attributes, session)
     end
     course = Course.find(id)
@@ -31,6 +38,24 @@ class CourseParticipant < Participant
       CourseParticipant.create(user_id: user.id, parent_id: course.id)
     end
   end
+  # provide import functionality for Course Participants
+  # if user does not exist, it will be created and added to this assignment
+  # def self.import(row, _row_header = nil, session, id)
+  #   raise ArgumentError, "No user id has been specified." if row.empty?
+  #   user = User.find_by_name(row[0])
+  #   if user.nil?
+  #     raise ArgumentError, "The record containing #{row[0]} does not have enough items." if row.length < 4
+  #     attributes = ImportFileHelper.define_attributes(row)
+  #     user = ImportFileHelper.create_new_user(attributes, session)
+  #   end
+  #   course = Course.find(id)
+  #   if course.nil?
+  #     raise ImportError, "The course with the id \"" + id.to_s + "\" was not found."
+  #   end
+  #   unless CourseParticipant.exists?(user_id: user.id, parent_id: course.id)
+  #     CourseParticipant.create(user_id: user.id, parent_id: course.id)
+  #   end
+  # end
 
   def path
     Course.find(self.parent_id).path + self.directory_num.to_s + "/"

--- a/app/models/course_participant.rb
+++ b/app/models/course_participant.rb
@@ -14,7 +14,7 @@ class CourseParticipant < Participant
   end
   # provide import functionality for Course Participants
   # if user does not exist, it will be created and added to this assignment
-  def self.import(row_hash, session, id)
+  def self.import(row_hash, _row_header = nil, session, id)
     raise ArgumentError, "No user id has been specified." if row_hash.empty?
     user = User.find_by_name(row_hash[:name])
     if user.nil?

--- a/app/models/course_team.rb
+++ b/app/models/course_team.rb
@@ -70,7 +70,7 @@ class CourseTeam < Team
   end
 
   # Add member to the course team
-  def add_member(user)
+  def add_member(user, id = nil)
     if has_user(user)
       raise "The user \"" + user.name + "\" is already a member of the team, \"" + self.name + "\""
     end

--- a/app/models/metareview_response_map.rb
+++ b/app/models/metareview_response_map.rb
@@ -51,38 +51,37 @@ class MetareviewResponseMap < ResponseMap
     fields = ["contributor", "reviewed by", "metareviewed by"]
     fields
   end
-
-  def self.import(row, _session, id)
-    if row.length < 3
+  def self.import(row_hash, session, id)
+    if row_hash.length < 3
       raise ArgumentError.new("Not enough items. The string should contain: Author, Reviewer, ReviewOfReviewer1 <, ..., ReviewerOfReviewerN>")
     end
 
-    index = 2
-    while index < row.length
+    row_hash[:metareviewers].each do |row|
+
       # ACS Make All contributors as teams
-      contributor = AssignmentTeam.where(name: row[0].to_s.strip, parent_id:  id).first
+      contributor = AssignmentTeam.where(name: row_hash[:reviewee].to_s, parent_id:  id).first
 
       if contributor.nil?
-        raise ImportError, "Contributor, " + row[0].to_s + ", was not found."
+        raise ImportError, "Contributor, " + row_hash[:reviewee].to_s + ", was not found."
       end
 
-      ruser = User.find_by_name(row[1].to_s.strip)
+      ruser = User.find_by_name(row_hash[:reviewer].to_s)
       reviewee = AssignmentParticipant.where(user_id: ruser.id, parent_id:  id).first
       if reviewee.nil?
-        raise ImportError, "Reviewee,  " + row[1].to_s + ", for contributor, " + contributor.name + ", was not found."
+        raise ImportError, "Reviewee,  " + row_hash[:reviewer].to_s + ", for contributor, " + contributor.name + ", was not found."
         end
 
-      muser = User.find_by_name(row[index].to_s.strip)
+      muser = User.find_by_name(row.to_s)
       reviewer = AssignmentParticipant.where(user_id: muser.id, parent_id:  id).first
       if reviewer.nil?
-        raise ImportError, "Metareviewer,  " + row[index].to_s + ", for contributor, " + contributor.name + ", and reviewee, " + row[1].to_s + ", was not found."
+        raise ImportError, "Metareviewer,  " + row.to_s + ", for contributor, " + contributor.name + ", and reviewee, " + row_hash[:reviewer].to_s + ", was not found."
         end
 
       # ACS Removed the if condition(and corressponding else) which differentiate assignments as team and individual assignments
       # to treat all assignments as team assignments
       reviewmapping = ReviewResponseMap.where(reviewee_id: contributor.id, reviewer_id:  reviewee.id).first
       if reviewmapping.nil?
-        raise ImportError, "No review mapping was found for contributor, " + contributor.name + ", and reviewee, " + row[1].to_s + "."
+        raise ImportError, "No review mapping was found for contributor, " + contributor.name + ", and reviewee, " + row_hash[:reviewer].to_s + "."
       end
 
       existing_mappings = MetareviewResponseMap.where(reviewee_id: reviewee.id, reviewer_id: reviewer.id, reviewed_object_id: reviewmapping.map_id)
@@ -93,9 +92,54 @@ class MetareviewResponseMap < ResponseMap
         MetareviewResponseMap.create(reviewer_id: reviewer.id, reviewee_id: reviewee.id, reviewed_object_id: reviewmapping.map_id)
       end
 
-      index += 1
-          end
+    end
   end
+
+  # Old Method
+  # def self.import(row, _session, id)
+  #   if row.length < 3
+  #     raise ArgumentError.new("Not enough items. The string should contain: Author, Reviewer, ReviewOfReviewer1 <, ..., ReviewerOfReviewerN>")
+  #   end
+  #
+  #   index = 2
+  #   while index < row.length
+  #     # ACS Make All contributors as teams
+  #     contributor = AssignmentTeam.where(name: row[0].to_s.strip, parent_id:  id).first
+  #
+  #     if contributor.nil?
+  #       raise ImportError, "Contributor, " + row[0].to_s + ", was not found."
+  #     end
+  #
+  #     ruser = User.find_by_name(row[1].to_s.strip)
+  #     reviewee = AssignmentParticipant.where(user_id: ruser.id, parent_id:  id).first
+  #     if reviewee.nil?
+  #       raise ImportError, "Reviewee,  " + row[1].to_s + ", for contributor, " + contributor.name + ", was not found."
+  #       end
+  #
+  #     muser = User.find_by_name(row[index].to_s.strip)
+  #     reviewer = AssignmentParticipant.where(user_id: muser.id, parent_id:  id).first
+  #     if reviewer.nil?
+  #       raise ImportError, "Metareviewer,  " + row[index].to_s + ", for contributor, " + contributor.name + ", and reviewee, " + row[1].to_s + ", was not found."
+  #       end
+  #
+  #     # ACS Removed the if condition(and corressponding else) which differentiate assignments as team and individual assignments
+  #     # to treat all assignments as team assignments
+  #     reviewmapping = ReviewResponseMap.where(reviewee_id: contributor.id, reviewer_id:  reviewee.id).first
+  #     if reviewmapping.nil?
+  #       raise ImportError, "No review mapping was found for contributor, " + contributor.name + ", and reviewee, " + row[1].to_s + "."
+  #     end
+  #
+  #     existing_mappings = MetareviewResponseMap.where(reviewee_id: reviewee.id, reviewer_id: reviewer.id, reviewed_object_id: reviewmapping.map_id)
+  #     # if no mappings have already been imported for this combination
+  #     # create it.
+  #
+  #     if existing_mappings.empty?
+  #       MetareviewResponseMap.create(reviewer_id: reviewer.id, reviewee_id: reviewee.id, reviewed_object_id: reviewmapping.map_id)
+  #     end
+  #
+  #     index += 1
+  #         end
+  # end
 
   def email(defn, _participant, assignment)
     defn[:body][:type] = "Metareview"

--- a/app/models/review_response_map.rb
+++ b/app/models/review_response_map.rb
@@ -45,12 +45,13 @@ class ReviewResponseMap < ResponseMap
     end
   end
 
-  def self.import(row, _header, _session, assignment_id)
-    reviewee_user_name = row[0].strip
+  def self.import(row_hash, session, assignment_id)
+
+    reviewee_user_name = row_hash[:reviewee].to_s
     reviewee_user = User.find_by(name: reviewee_user_name)
     raise ArgumentError, "Cannot find reviewee user." if reviewee_user.nil?
 
-    reviewee_participant = AssignmentParticipant.find_by_user_id_and_assignment_id(reviewee_user.id, assignment_id)
+    reviewee_participant = AssignmentParticipant.where(:user_id => reviewee_user.id, :parent_id => assignment_id).first
     raise ArgumentError, "Reviewee user is not a participant in this assignment." if reviewee_participant.nil?
 
     reviewee_team = AssignmentTeam.team(reviewee_participant)
@@ -62,23 +63,56 @@ class ReviewResponseMap < ResponseMap
       TeamUserNode.create(parent_id: team_node.id, node_object_id: t_user.id)
     end
 
-    index = 1
-    while index < row.length
-      reviewer_user_name = row[index].strip
+    row_hash[:reviewers].each do |reviewer|
+      reviewer_user_name = reviewer.to_s
       reviewer_user = User.find_by(name: reviewer_user_name)
       raise ArgumentError, "Cannot find reviewer user." if reviewer_user.nil?
       next if reviewer_user_name.empty?
 
-      reviewer_participant = AssignmentParticipant.find_by_user_id_and_assignment_id(reviewer_user.id, assignment_id)
+      reviewer_participant = AssignmentParticipant.where(:user_id => reviewer_user.id, :parent_id => assignment_id).first
       raise ArgumentError, "Reviewer user is not a participant in this assignment." if reviewer_participant.nil?
 
       if ReviewResponseMap.find_by(reviewed_object_id: assignment_id, reviewer_id: reviewer_participant.id, reviewee_id: reviewee_team.id, calibrate_to: false).nil?
         ReviewResponseMap.create(reviewed_object_id: assignment_id, reviewer_id: reviewer_participant.id, reviewee_id: reviewee_team.id, calibrate_to: false)
       end
-
-      index += 1
     end
   end
+
+  # Old Method
+  # def self.import(row, _header, _session, assignment_id)
+  #   reviewee_user_name = row[0].strip
+  #   reviewee_user = User.find_by(name: reviewee_user_name)
+  #   raise ArgumentError, "Cannot find reviewee user." if reviewee_user.nil?
+  #
+  #   reviewee_participant = AssignmentParticipant.find_by_user_id_and_assignment_id(reviewee_user.id, assignment_id)
+  #   raise ArgumentError, "Reviewee user is not a participant in this assignment." if reviewee_participant.nil?
+  #
+  #   reviewee_team = AssignmentTeam.team(reviewee_participant)
+  #   if reviewee_team.nil? # lazy team creation: if the reviewee does not have team, create one.
+  #     reviewee_team = AssignmentTeam.create(name: 'Team' + '_' + rand(1000).to_s,
+  #                                           parent_id: assignment_id, type: 'AssignmentTeam')
+  #     t_user = TeamsUser.create(team_id: reviewee_team.id, user_id: reviewee_user.id)
+  #     team_node = TeamNode.create(parent_id: assignment_id, node_object_id: reviewee_team.id)
+  #     TeamUserNode.create(parent_id: team_node.id, node_object_id: t_user.id)
+  #   end
+  #
+  #   index = 1
+  #   while index < row.length
+  #     reviewer_user_name = row[index].strip
+  #     reviewer_user = User.find_by(name: reviewer_user_name)
+  #     raise ArgumentError, "Cannot find reviewer user." if reviewer_user.nil?
+  #     next if reviewer_user_name.empty?
+  #
+  #     reviewer_participant = AssignmentParticipant.find_by_user_id_and_assignment_id(reviewer_user.id, assignment_id)
+  #     raise ArgumentError, "Reviewer user is not a participant in this assignment." if reviewer_participant.nil?
+  #
+  #     if ReviewResponseMap.find_by(reviewed_object_id: assignment_id, reviewer_id: reviewer_participant.id, reviewee_id: reviewee_team.id, calibrate_to: false).nil?
+  #       ReviewResponseMap.create(reviewed_object_id: assignment_id, reviewer_id: reviewer_participant.id, reviewee_id: reviewee_team.id, calibrate_to: false)
+  #     end
+  #
+  #     index += 1
+  #   end
+  # end
 
   def show_feedback(response)
     if !self.response.empty? && response

--- a/app/models/sign_up_topic.rb
+++ b/app/models/sign_up_topic.rb
@@ -16,24 +16,42 @@ class SignUpTopic < ActiveRecord::Base
   #  return find_by_sql("select t.id from teams t,teams_users u where t.id=u.team_id and u.user_id = 5");
   # end
 
-  def self.import(columns, session, _id = nil)
-    if columns.length < 3
-      raise ArgumentError, "The CSV File expects the format:
- Topic identifier, Topic name, Max choosers, Topic Category (optional), Topic Description (Optional), Topic Link (optional)."
+  def self.import(row_hash, session, _id = nil)
+    if row_hash.length < 3
+      raise ArgumentError, "The CSV File expects the format: Topic identifier, Topic name, Max choosers, Topic Category (optional), Topic Description (Optional), Topic Link (optional)."
     end
-
-    topic = SignUpTopic.where(topic_name: columns[1], assignment_id: session[:assignment_id]).first
-
+    topic = SignUpTopic.where(topic_name: row_hash[:topic_name], assignment_id: session[:assignment_id]).first
     if topic.nil?
-      attributes = ImportTopicsHelper.define_attributes(columns)
+      attributes = ImportTopicsHelper.define_attributes(row_hash)
+
       ImportTopicsHelper.create_new_sign_up_topic(attributes, session)
     else
-      topic.max_choosers = columns[2]
-      topic.topic_identifier = columns[0]
+      topic.max_choosers = row_hash[:max_choosers]
+      topic.topic_identifier = row_hash[:topic_identifier]
       # topic.assignment_id = session[:assignment_id]
       topic.save
     end
   end
+
+  # The old method is commented out below.
+  #
+  # def self.import(columns, session, _id = nil)
+  #   if columns.length < 3
+  #     raise ArgumentError, "The CSV File expects the format: Topic identifier, Topic name, Max choosers, Topic Category (optional), Topic Description (Optional), Topic Link (optional)."
+  #   end
+  #
+  #   topic = SignUpTopic.where(topic_name: columns[1], assignment_id: session[:assignment_id]).first
+  #
+  #   if topic.nil?
+  #     attributes = ImportTopicsHelper.define_attributes(columns)
+  #     ImportTopicsHelper.create_new_sign_up_topic(attributes, session)
+  #   else
+  #     topic.max_choosers = columns[2]
+  #     topic.topic_identifier = columns[0]
+  #     # topic.assignment_id = session[:assignment_id]
+  #     topic.save
+  #   end
+  # end
 
   def self.find_slots_filled(assignment_id)
     # SignUpTopic.find_by_sql("SELECT topic_id as topic_id, COUNT(t.max_choosers) as count FROM sign_up_topics t JOIN signed_up_teams u ON t.id = u.topic_id WHERE t.assignment_id =" + assignment_id+  " and u.is_waitlisted = false GROUP BY t.id")

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -53,7 +53,7 @@ class Team < ActiveRecord::Base
   end
 
   # Add memeber to the team
-  def add_member(user, _assignment_id)
+  def add_member(user, _assignment_id = nil)
 
     if has_user(user)
          raise "The user \"" + user.name + "\" is already a member of the team, \"" + self.name + "\""

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -19,7 +19,7 @@ class Team < ActiveRecord::Base
 
   # Delete the given team
   def delete
-    TeamsUser.where(team_id: self.id).each{ |teams_user| teams_user.destroy }
+    TeamsUser.where("team_id = ?", self.id).each{ |teams_user| teams_user.destroy }
     node = TeamNode.find_by(node_object_id: self.id)
     node.destroy if node
     self.destroy
@@ -53,13 +53,13 @@ class Team < ActiveRecord::Base
   end
 
   # Add memeber to the team
-  def add_member(user, _assignment_id = nil)
+  def add_member(user, _assignment_id)
+
     if has_user(user)
-      raise "The user #{user.name} is already a member of the team #{self.name}"
+         raise "The user \"" + user.name + "\" is already a member of the team, \"" + self.name + "\""
     end
-    can_add_member = false
-    unless full?
-      can_add_member = true
+
+    if can_add_member = !full?
       t_user = TeamsUser.create(user_id: user.id, team_id: self.id)
       parent = TeamNode.find_by_node_object_id(self.id)
       TeamUserNode.create(parent_id: parent.id, node_object_id: t_user.id)
@@ -68,9 +68,28 @@ class Team < ActiveRecord::Base
     can_add_member
   end
 
+  # Old Method
+  # Add memeber to the team
+  # def add_member(user, _assignment_id)
+  #   if has_user(user)
+  #     raise "The user \"" + user.name + "\" is already a member of the team, \"" + self.name + "\""
+  #   end
+  #
+  #   if can_add_member = !full?
+  #     t_user = TeamsUser.create(user_id: user.id, team_id: self.id)
+  #     parent = TeamNode.find_by_node_object_id(self.id)
+  #     TeamUserNode.create(parent_id: parent.id, node_object_id: t_user.id)
+  #     add_participant(self.parent_id, user)
+  #   end
+  #
+  #   can_add_member
+  # end
+
+
+
   # Define the size of the team
   def self.size(team_id)
-    TeamsUser.where(team_id: team_id).count
+    TeamsUser.where(["team_id = ?", team_id]).count
   end
 
   # Copy method to copy this team
@@ -85,17 +104,17 @@ class Team < ActiveRecord::Base
 
   # Check if the team exists
   def self.check_for_existing(parent, name, team_type)
-    list = Object.const_get(team_type + 'Team').where(parent_id: parent.id, name: name)
+    list = Object.const_get(team_type + 'Team').where(['parent_id = ? and name = ?', parent.id, name])
     unless list.empty?
-      raise TeamExistsError, "The team name #{name} is already in use."
+      raise TeamExistsError, 'The team name, "' + name + '", is already in use.'
     end
   end
 
   # Algorithm
-  # Start by adding participants to teams that have one slot.
-  # Adding participants to teams that have two slots. etc.
+  # Start by adding single members to teams that are one member too small.
+  # Add two-member teams to teams that two members too small. etc.
   def self.randomize_all_by_parent(parent, team_type, min_team_size)
-    participants = Participant.where(parent_id: parent.id, type: parent.class.to_s + "Participant")
+    participants = Participant.where(["parent_id = ? AND type = ?", parent.id, parent.class.to_s + "Participant"])
     participants = participants.sort { rand(3) - 1 }
     users = participants.map {|p| User.find(p.user_id) }.to_a
     # find teams still need team members and users who are not in any team
@@ -146,71 +165,123 @@ class Team < ActiveRecord::Base
   end
 
   # Generate the team name
-  def self.generate_team_name(team_name_prefix)
+  def self.generate_team_name(teamnameprefix)
     counter = 1
     loop do
-      team_name = team_name_prefix + "_Team#{counter}"
-      return team_name unless Team.find_by_name(team_name)
+      teamname = teamnameprefix + "_Team#{counter}"
+      return teamname unless Team.find_by_name(teamname)
       counter += 1
     end
   end
 
   # Extract team members from the csv and push to DB
-  def import_team_members(starting_index, row)
-    index = starting_index
-    while index < row.length
-      user = User.find_by_name(row[index].to_s.strip)
-      if user.nil?
-        raise ImportError, "The user #{row[index].to_s.strip} was not found. <a href='/users/new'>Create</a> this user?"
-      else
-        if TeamsUser.where(team_id: id, user_id: user.id).first.nil?
-          add_member(user)
-        end
+  def import_team_members(row_hash)
+
+    row_hash[:teammembers].each do |teammember|
+    user = User.find_by_name(teammember.to_s)
+        if user.nil?
+      raise ImportError, "The user \"" + teammember.to_s + "\" was not found. <a href='/users/new'>Create</a> this user?"
+    else
+      if TeamsUser.where(["team_id =? and user_id =?", id, user.id]).first.nil?
+        add_member(user, nil)
       end
-      index += 1
+    end
     end
   end
 
-  # REFACTOR BEGIN:: class methods import export moved from course_team & assignment_team to here
-  # Import from csv
-  def self.import(row, id, options, teamtype)
-    raise ArgumentError, 'Not enough fields on this line.' if (row.length < 2 && options[:has_column_names] == "true") || (row.empty? && options[:has_column_names] != "true")
+  # Old Method
+  # Extract team members from the csv and push to DB
+  # def import_team_members(starting_index, row)
+  #   index = starting_index
+  #   while index < row.length
+  #     user = User.find_by_name(row[index].to_s.strip)
+  #     if user.nil?
+  #       raise ImportError, "The user \"" + row[index].to_s.strip + "\" was not found. <a href='/users/new'>Create</a> this user?"
+  #     else
+  #       if TeamsUser.where(["team_id =? and user_id =?", id, user.id]).first.nil?
+  #         add_member(user, nil)
+  #       end
+  #     end
+  #     index += 1
+  #   end
+  # end
 
-    if options[:has_column_names] == "true"
-      name = row[0].to_s.strip
-      team = where(name: name, parent_id: id).first
+
+  def self.import(row_hash, id, options, teamtype)
+
+    raise ArgumentError, "Not enough fields on this line." if (row_hash[:teammembers].length < 2 && (options[:has_teamname] == "true_first" || options[:has_teamname] == "true_last")) || (row_hash[:teammembers].empty? && (options[:has_teamname] == "true_first" || options[:has_teamname] == "true_last"))
+    if options[:has_teamname] == "true_first" || options[:has_teamname] == "true_last"
+      name = row_hash[:teamname].to_s
+      team = where(["name =? && parent_id =?", name, id]).first
       team_exists = !team.nil?
       name = handle_duplicate(team, name, id, options[:handle_dups], teamtype)
-      index = 1
     else
-      if teamtype.is_a?(CourseTeam)
+      if teamtype.to_s == "CourseTeam"
         name = self.generate_team_name(Course.find(id).name)
-      elsif teamtype.is_a?(AssignmentTeam)
+      elsif teamtype.to_s == "AssignmentTeam"
         name = self.generate_team_name(Assignment.find(id).name)
       end
-      index = 0
     end
-
     if name
-      team = Object.const_get(teamtype.class.to_s).create_team_and_node(id)
+      team = Object.const_get(teamtype.to_s).create_team_and_node(id)
       team.name = name
       team.save
     end
 
     # insert team members into team unless team was pre-existing & we ignore duplicate teams
-    team.import_team_members(index, row) unless team_exists && options[:handle_dups] == "ignore"
+
+    team.import_team_members(row_hash) unless team_exists && options[:handle_dups] == "ignore"
   end
+
+
+  # Old function is written below
+
+  # REFACTOR BEGIN:: class methods import export moved from course_team & assignment_team to here
+  # Import from csv
+  # def self.import(row, id, options, teamtype)
+  #   raise ArgumentError, "Not enough fields on this line." if (row.length < 2 && options[:has_column_names] == "true") || (row.empty? && options[:has_column_names] != "true")
+  #
+  #   if options[:has_column_names] == "true"
+  #     # row_hash [:team_name].to_s
+  #     name = row[0].to_s.strip
+  #     team = where(["name =? && parent_id =?", name, id]).first
+  #     team_exists = !team.nil?
+  #     name = handle_duplicate(team, name, id, options[:handle_dups], teamtype)
+  #     # remove this line
+  #     index = 1
+  #   else
+  #     if teamtype.is_a?(CourseTeam)
+  #       name = self.generate_team_name(Course.find(id).name)
+  #     elsif teamtype.is_a?(AssignmentTeam)
+  #       name = self.generate_team_name(Assignment.find(id).name)
+  #     end
+  #     # remove this line
+  #     index = 0
+  #   end
+  #
+  #   if name
+  #     team = Object.const_get(teamtype.class.to_s).create_team_and_node(id)
+  #     team.name = name
+  #     team.save
+  #   end
+  #
+  #   # insert team members into team unless team was pre-existing & we ignore duplicate teams
+  #
+  #   #team.import_team_members(row) unless team_exists && options[:handle_dups] == "ignore"
+  #   team.import_team_members(index, row) unless team_exists && options[:handle_dups] == "ignore"
+  # end
 
   # Handle existence of the duplicate team
   def self.handle_duplicate(team, name, id, handle_dups, teamtype)
     return name if team.nil? # no duplicate
     if handle_dups == "ignore" # ignore: do not create the new team
+      puts '>>>setting name to nil ...'
       return nil
     end
     if handle_dups == "rename" # rename: rename new team
-      if teamtype.is_a?(CourseTeam)
+      if teamtype.to_s == "CourseTeam"                 #teamtype.is_a?(CourseTeam)
         return self.generate_team_name(Course.find(id).name)
-      elsif teamtype.is_a?(AssignmentTeam)
+      elsif  teamtype.to_s == "AssignmentTeam"         #teamtype.is_a?(AssignmentTeam)
         return self.generate_team_name(Assignment.find(id).name)
       end
     end
@@ -225,22 +296,22 @@ class Team < ActiveRecord::Base
   # Export the teams to csv
   def self.export(csv, parent_id, options, teamtype)
     if teamtype.is_a?(CourseTeam)
-      teams = CourseTeam.where(parent_id: parent_id)
+      teams = CourseTeam.where(["parent_id =?", parent_id])
     elsif teamtype.is_a?(AssignmentTeam)
-      teams = AssignmentTeam.where(parent_id: parent_id)
+      teams = AssignmentTeam.where(["parent_id =?", parent_id])
     end
     teams.each do |team|
       output = []
       output.push(team.name)
-      if options[:team_name] == "false"
-        teams_users = TeamsUser.where(team_id: team.id)
-        teams_users.each do |teams_user|
-          output.push(teams_user.user.name)
+      if options["team_name"] == "false"
+        team_members = TeamsUser.where(['team_id = ?', team.id])
+        team_members.each do |user|
+          output.push(user.name)
         end
       end
+      output.push(teams.name)
       csv << output
     end
-    csv
   end
 
   # Create the team with corresponding tree node

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -165,24 +165,48 @@ class User < ActiveRecord::Base
     password
   end
 
-  def self.import(row, _row_header, session, _id = nil)
-    if row.length != 3
-      raise ArgumentError, "Not enough items: expect 3 columns: your login name, your full name (first and last name, not seperated with the delimiter), and your email."
+  def self.import(row_hash, session)
+
+    if row_hash.length != 3
+      raise ArgumentError, "Not enough items. Three columns are expected, your username, your full name, and your email."
     end
-    user = User.find_by_name(row[0])
+
+    user = User.find_by_name(row_hash[:name])
 
     if user.nil?
-      attributes = ImportFileHelper.define_attributes(row)
+      attributes = ImportFileHelper.define_attributes(row_hash)
       user = ImportFileHelper.create_new_user(attributes, session)
-      password = user.reset_password # the password is reset
+      password = user.reset_password
       MailerHelper.send_mail_to_user(user, "Your Expertiza account has been created.", "user_welcome", password).deliver
     else
-      user.email = row[2].strip
-      user.fullname = row[1].strip
+      user.email = row_hash[:email]
+      user.fullname = row_hash[:fullname]
       user.parent_id = (session[:user]).id
       user.save
     end
+
   end
+
+  # The old method is commented out below.
+
+  # def self.import(row, _row_header, session, _id = nil)
+  #   if row.length != 3
+  #     raise ArgumentError, "Not enough items: expect 3 columns: your login name, your full name (first and last name, not seperated with the delimiter), and your email."
+  #   end
+  #   user = User.find_by_name(row[0])
+  #
+  #   if user.nil?
+  #     attributes = ImportFileHelper.define_attributes(row)
+  #     user = ImportFileHelper.create_new_user(attributes, session)
+  #     password = user.reset_password # the password is reset
+  #     MailerHelper.send_mail_to_user(user, "Your Expertiza account has been created.", "user_welcome", password).deliver
+  #   else
+  #     user.email = row[2].strip
+  #     user.fullname = row[1].strip
+  #     user.parent_id = (session[:user]).id
+  #     user.save
+  #   end
+  # end
 
   def self.yesorno(elt)
     if elt == true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -165,7 +165,7 @@ class User < ActiveRecord::Base
     password
   end
 
-  def self.import(row_hash, session)
+  def self.import(row_hash, _row_header = nil, session, _id = nil)
 
     if row_hash.length != 3
       raise ArgumentError, "Not enough items. Three columns are expected, your username, your full name, and your email."
@@ -188,7 +188,6 @@ class User < ActiveRecord::Base
   end
 
   # The old method is commented out below.
-
   # def self.import(row, _row_header, session, _id = nil)
   #   if row.length != 3
   #     raise ArgumentError, "Not enough items: expect 3 columns: your login name, your full name (first and last name, not seperated with the delimiter), and your email."

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -165,7 +165,7 @@ class User < ActiveRecord::Base
     password
   end
 
-  def self.import(row_hash, _row_header = nil, session, _id = nil)
+  def self.import(row_hash, _row_header, session, id = nil)
 
     if row_hash.length != 3
       raise ArgumentError, "Not enough items. Three columns are expected, your username, your full name, and your email."

--- a/app/views/course_participants/list.html.erb
+++ b/app/views/course_participants/list.html.erb
@@ -21,7 +21,7 @@
                           :action=>'start',
                           :model => 'Participant',
                           :title => @title+' Participants',
-                          :expected_fields => 'username, full name (first[ middle] last), e-mail address, password',
+                          :expected_fields => 'username&nbsp;&nbsp;|&nbsp;&nbsp;full name (first [middle] last)&nbsp;&nbsp;|&nbsp;&nbsp;e-mail address&nbsp;&nbsp;|&nbsp;&nbsp;password',
                           :id => @parent.id %>
                         | <%= render :partial => '/shared_scripts/back' %>
                       <hr/>

--- a/app/views/import_file/_metareviewer.html.erb
+++ b/app/views/import_file/_metareviewer.html.erb
@@ -1,0 +1,53 @@
+<%= form_tag( { :controller => 'import_file', :action => 'import' },
+              { :method => 'post', :name => 'column_form', :id => 'column_form'} ) do %>
+
+
+    <table class="table table-bordered table-striped">
+
+      <thead>
+      <tr>
+        <strong> Sequence of columns in file:
+          <ol>
+            <% if @has_reviewee == 'true_first' %>
+                <li>Contributor</li>
+                <li>Reviewer</li>
+                <li>Metareviewers</li>
+                <% @contents_hash[:header] = ["reviewee","reviewer","metareviewers"]%>
+            <% elsif @has_reviewee == 'true_last' %>
+                <li>Metareviewers</li>
+                <li>Contributor</li>
+                <li>Reviewer</li>
+                <%@contents_hash[:header] = ["metareviewers","reviewee","reviewer"]%>
+            <% end %>
+          </ol>
+        </strong>
+      </tr>
+      </thead>
+
+      <tbody>
+
+      <% @contents_hash[:body].each do |row| %>
+          <tr>
+            <% row.each do |column| %>
+                <td align="center"><%= column %></td>
+            <% end %>
+          </tr>
+
+      <% end %>
+
+      </tbody>
+    </table>
+
+    <%= hidden_field_tag('contents_hash', @contents_hash) %>
+    <%= hidden_field_tag('has_header', @has_header) %>
+    <%= hidden_field_tag('has_reviewee', @has_reviewee) %>
+    <%= hidden_field_tag('has_reviewer', @has_reviewer) %>
+    <%= hidden_field_tag('model', @model) %>
+    <%= hidden_field_tag('id', @id) %>
+    <%= hidden_field_tag('options', @options)%>
+
+    <div style="text-align:center">
+      <button type="button" class="btn btn-primary" onclick="column_form.submit()">Import <%= @model %></button>
+    </div>
+
+<% end %>

--- a/app/views/import_file/_participant.html.erb
+++ b/app/views/import_file/_participant.html.erb
@@ -1,0 +1,90 @@
+<%= form_tag( { :controller => 'import_file', :action => 'import' },
+              { :method => 'post', :name => 'column_form', :id => 'column_form' } ) do %>
+
+    <table class="table table-bordered table-striped">
+
+      <thead>
+      <tr>
+
+        <% if @has_header == 'true' %>
+
+            <th style="text-align:center">
+              <%= @contents_hash[:header][0].to_s.capitalize %>
+            </th>
+            <th style="text-align:center">
+              <%= @contents_hash[:header][1].to_s.capitalize %>
+            </th>
+            <th style="text-align:center">
+              <%= @contents_hash[:header][2].to_s.capitalize %>
+            </th>
+            <th style="text-align:center">
+              <%= @contents_hash[:header][3].to_s.capitalize %>
+            </th>
+
+        <% else %>
+
+            <th>
+              <select name="select1" id="select1" class="form-control" style="background-color:lightgrey">
+                <option value="name">Name</option>
+                <option value="fullname">Fullname</option>
+                <option value="email">Email</option>
+                <option value="password">Password</option>
+              </select>
+            </th>
+            <th>
+              <select name="select2" id="select2" class="form-control" style="background-color:lightgrey">
+                <option value="fullname">Fullname</option>
+                <option value="name">Name</option>
+                <option value="email">Email</option>
+                <option value="password">Password</option>
+              </select>
+            </th>
+            <th>
+              <select name="select3" id="select3" class="form-control" style="background-color:lightgrey">
+                <option value="email">Email</option>
+                <option value="name">Name</option>
+                <option value="fullname">Fullname</option>
+                <option value="password">Password</option>
+              </select>
+            </th>
+            <th>
+              <select name="select4" id="select4" class="form-control" style="background-color:lightgrey">
+                <option value="password">Password</option>
+                <option value="name">Name</option>
+                <option value="fullname">Fullname</option>
+                <option value="email">Email</option>
+              </select>
+            </th>
+
+        <% end %>
+
+      </tr>
+      </thead>
+
+      <tbody>
+
+      <% @contents_hash[:body].each do |row| %>
+          <tr>
+            <% row.each do |column| %>
+                <td align="center"><%= column %></td>
+            <% end %>
+          </tr>
+      <% end %>
+
+      </tbody>
+    </table>
+
+    <%= hidden_field_tag('contents_hash', @contents_hash) %>
+    <%= hidden_field_tag('has_header', @has_header) %>
+    <%= hidden_field_tag('model', @model) %>
+    <%= hidden_field_tag('id', @id) %>
+
+    <div style="text-align:center">
+      <% if @has_header == 'true' %>
+          <button type="button" class="btn btn-primary" onclick="column_form.submit()">Import <%= @model %></button>
+      <% else %>
+          <button type="button" class="btn btn-primary" onclick="checkForParticipantColumnDuplicate()">Import <%= @model %></button>
+      <% end %>
+    </div>
+
+<% end %>

--- a/app/views/import_file/_reviewer.html.erb
+++ b/app/views/import_file/_reviewer.html.erb
@@ -1,0 +1,50 @@
+<%= form_tag( { :controller => 'import_file', :action => 'import' },
+              { :method => 'post', :name => 'column_form', :id => 'column_form'} ) do %>
+
+
+    <table class="table table-bordered table-striped">
+
+      <thead>
+      <tr>
+        <strong> Sequence of columns in file:
+          <ol>
+            <% if params[:has_reviewee] == 'true_first' %>
+                <li>Contributor</li>
+                <li>Reviewers</li>
+                <% @contents_hash[:header] = ["reviewee","reviewers"]%>
+            <% elsif params[:has_reviewee] == 'true_last' %>
+                <li>Contributor</li>
+                <li>Reviewers</li>
+                <%@contents_hash[:header] = ["reviewers","reviewee"]%>
+           <% end %>
+          </ol>
+        </strong>
+      </tr>
+      </thead>
+
+      <tbody>
+
+      <% @contents_hash[:body].each do |row| %>
+          <tr>
+            <% row.each do |column| %>
+                <td align="center"><%= column %></td>
+            <% end %>
+          </tr>
+
+      <% end %>
+
+      </tbody>
+    </table>
+
+    <%= hidden_field_tag('contents_hash', @contents_hash) %>
+    <%= hidden_field_tag('has_header', @has_header) %>
+    <%= hidden_field_tag('has_reviewee', params[:has_reviewee]) %>
+    <%= hidden_field_tag('model', @model) %>
+    <%= hidden_field_tag('id', @id) %>
+    <%= hidden_field_tag('options', @options)%>
+
+    <div style="text-align:center">
+      <button type="button" class="btn btn-primary" onclick="column_form.submit()">Import <%= @model %></button>
+    </div>
+
+<% end %>

--- a/app/views/import_file/_reviewer.html.erb
+++ b/app/views/import_file/_reviewer.html.erb
@@ -13,8 +13,8 @@
                 <li>Reviewers</li>
                 <% @contents_hash[:header] = ["reviewee","reviewers"]%>
             <% elsif params[:has_reviewee] == 'true_last' %>
-                <li>Contributor</li>
                 <li>Reviewers</li>
+                <li>Contributor</li>
                 <%@contents_hash[:header] = ["reviewers","reviewee"]%>
            <% end %>
           </ol>

--- a/app/views/import_file/_sign_up_topic.html.erb
+++ b/app/views/import_file/_sign_up_topic.html.erb
@@ -1,0 +1,115 @@
+<%= form_tag( { :controller => 'import_file', :action => 'import' },
+              { :method => 'post', :name => 'column_form', :id => 'column_form' } ) do %>
+
+    <table class="table table-bordered table-striped">
+
+      <% if @has_header == 'true' %>
+
+        <thead>
+
+        <tr>
+
+          <th style="text-align:center">
+            <%= @contents_hash[:header][0].to_s.capitalize %>
+          </th>
+          <th style="text-align:center">
+            <%= @contents_hash[:header][1].to_s.capitalize %>
+          </th>
+          <th style="text-align:center">
+            <%= @contents_hash[:header][2].to_s.capitalize %>
+          </th>
+
+          <% (1..@optional_count).each do |i| %>
+
+              <th style="text-align:center">
+                <%= @contents_hash[:header][2 + i].to_s.capitalize %>
+              </th>
+
+          <% end %>
+
+        </tr>
+
+        </thead>
+
+      <% else %>
+
+          <thead>
+
+        <tr>
+          <th>
+            <select name="select1" id="select1" class="form-control" style="background-color:lightgrey">
+              <option value="topic_identifier">Topic Identifier (required)</option>
+              <option value="topic_name">Topic Name (required)</option>
+              <option value="max_choosers">Max Choosers (required)</option>
+              <option value="category">Category (optional)</option>
+              <option value="description">Description (optional)</option>
+              <option value="link">Link (optional)</option>
+            </select>
+          </th>
+          <th>
+            <select name="select2" id="select2" class="form-control" style="background-color:lightgrey">
+              <option value="topic_name">Topic Name (required)</option>
+              <option value="topic_identifier">Topic Identifier (required)</option>
+              <option value="max_choosers">Max Choosers (required)</option>
+              <option value="category">Category (optional)</option>
+              <option value="description">Description (optional)</option>
+              <option value="link">Link (optional)</option>
+            </select>
+          </th>
+          <th>
+            <select name="select3" id="select3" class="form-control" style="background-color:lightgrey">
+              <option value="max_choosers">Max Choosers (required)</option>
+              <option value="topic_identifier">Topic Identifier (required)</option>
+              <option value="topic_name">Topic Name (required)</option>
+              <option value="category">Category (optional)</option>
+              <option value="description">Description (optional)</option>
+              <option value="link">Link (optional)</option>
+            </select>
+          </th>
+
+          <% (1..@optional_count).each do |i| %>
+              <th>
+                <select name="select<%= i + 3 %>" id="select<%= i + 3 %>" class="form-control" style="background-color:lightgrey">
+                  <option value="category">Category (optional)</option>
+                  <option value="description">Description (optional)</option>
+                  <option value="link">Link (optional)</option>
+                  <option value="max_choosers">Max Choosers (required)</option>
+                  <option value="topic_identifier">Topic Identified (required)</option>
+                  <option value="topic_name">Topic Name (required)</option>
+                </select>
+              </th>
+          <% end %>
+
+        </tr>
+
+        </thead>
+
+      <% end %>
+
+      <tbody>
+
+      <% @contents_hash[:body].each do |row| %>
+        <tr>
+          <% row.each do |column| %>
+            <td align="center"><%= column %></td>
+          <% end %>
+        </tr>
+      <% end %>
+
+      </tbody>
+
+    </table>
+
+    <%= hidden_field_tag('contents_hash', @contents_hash) %>
+    <%= hidden_field_tag('has_header', @has_header) %>
+    <%= hidden_field_tag('model', @model) %>
+
+    <div style="text-align:center">
+      <% if @has_header == 'true' %>
+          <button type="button" class="btn btn-primary" onclick="column_form.submit()">Import <%= @model %></button>
+      <% else %>
+          <button type="button" class="btn btn-primary" onclick="checkTopicForDuplicatesAndRequiredColumns(<%= @optional_count %>)">Import <%= @model %></button>
+      <% end %>
+    </div>
+
+<% end %>

--- a/app/views/import_file/_sign_up_topic.html.erb
+++ b/app/views/import_file/_sign_up_topic.html.erb
@@ -19,12 +19,12 @@
             <%= @contents_hash[:header][2].to_s.capitalize %>
           </th>
 
-          <% (1..@optional_count).each do |i| %>
-
-              <th style="text-align:center">
-                <%= @contents_hash[:header][2 + i].to_s.capitalize %>
-              </th>
-
+          <% if @optional_count > 0 %>
+              <% (1..@optional_count).each do |i| %>
+                  <th style="text-align:center">
+                    <%= @contents_hash[:header][2 + i].to_s.capitalize %>
+                  </th>
+              <% end %>
           <% end %>
 
         </tr>
@@ -67,17 +67,19 @@
             </select>
           </th>
 
-          <% (1..@optional_count).each do |i| %>
-              <th>
-                <select name="select<%= i + 3 %>" id="select<%= i + 3 %>" class="form-control" style="background-color:lightgrey">
-                  <option value="category">Category (optional)</option>
-                  <option value="description">Description (optional)</option>
-                  <option value="link">Link (optional)</option>
-                  <option value="max_choosers">Max Choosers (required)</option>
-                  <option value="topic_identifier">Topic Identified (required)</option>
-                  <option value="topic_name">Topic Name (required)</option>
-                </select>
-              </th>
+          <% if @optional_count > 0 %>
+              <% (1..@optional_count).each do |i| %>
+                  <th>
+                    <select name="select<%= i + 3 %>" id="select<%= i + 3 %>" class="form-control" style="background-color:lightgrey">
+                      <option value="category">Category (optional)</option>
+                      <option value="description">Description (optional)</option>
+                      <option value="link">Link (optional)</option>
+                      <option value="max_choosers">Max Choosers (required)</option>
+                      <option value="topic_identifier">Topic Identifier (required)</option>
+                      <option value="topic_name">Topic Name (required)</option>
+                    </select>
+                  </th>
+              <% end %>
           <% end %>
 
         </tr>
@@ -100,9 +102,11 @@
 
     </table>
 
+    <%= hidden_field_tag('optional_count', @optional_count) %>
     <%= hidden_field_tag('contents_hash', @contents_hash) %>
     <%= hidden_field_tag('has_header', @has_header) %>
     <%= hidden_field_tag('model', @model) %>
+    <%= hidden_field_tag('id', @id) %>
 
     <div style="text-align:center">
       <% if @has_header == 'true' %>

--- a/app/views/import_file/_team.html.erb
+++ b/app/views/import_file/_team.html.erb
@@ -1,7 +1,6 @@
 <%= form_tag( { :controller => 'import_file', :action => 'import' },
               { :method => 'post', :name => 'column_form', :id => 'column_form'} ) do %>
 
-
     <table class="table table-bordered table-striped">
 
       <thead>

--- a/app/views/import_file/_team.html.erb
+++ b/app/views/import_file/_team.html.erb
@@ -1,0 +1,53 @@
+<%= form_tag( { :controller => 'import_file', :action => 'import' },
+              { :method => 'post', :name => 'column_form', :id => 'column_form'} ) do %>
+
+
+    <table class="table table-bordered table-striped">
+
+      <thead>
+      <tr>
+        <strong> Sequence of columns in file:
+        <ol>
+        <% if @has_teamname == 'true_first' %>
+              <li>Team Name</li>
+              <li>Team Members</li>
+                <% @contents_hash[:header] = ["teamname","teammembers"]%>
+        <% elsif @has_teamname == 'true_last' %>
+              <li>Team Members</li>
+              <li>Team Name</li>
+                <%@contents_hash[:header] = ["teammembers","teamname"]%>
+        <% else %>
+              <li>Team Members</li>
+              <%@contents_hash[:header] = ["teammembers"] %>
+        <% end %>
+        </ol>
+        </strong>
+      </tr>
+      </thead>
+
+      <tbody>
+
+      <% @contents_hash[:body].each do |row| %>
+          <tr>
+            <% row.each do |column| %>
+                <td align="center"><%= column %></td>
+            <% end %>
+          </tr>
+
+      <% end %>
+
+      </tbody>
+    </table>
+
+    <%= hidden_field_tag('contents_hash', @contents_hash) %>
+    <%= hidden_field_tag('has_header', @has_header) %>
+    <%= hidden_field_tag('has_teamname', @has_teamname) %>
+    <%= hidden_field_tag('model', @model) %>
+    <%= hidden_field_tag('id', @id) %>
+    <%= hidden_field_tag('options', @options)%>
+
+    <div style="text-align:center">
+          <button type="button" class="btn btn-primary" onclick="column_form.submit()">Import <%= @model %></button>
+    </div>
+
+<% end %>

--- a/app/views/import_file/_user.html.erb
+++ b/app/views/import_file/_user.html.erb
@@ -1,11 +1,10 @@
 <%= form_tag( { :controller => 'import_file', :action => 'import' },
               { :method => 'post', :name => 'column_form', :id => 'column_form'} ) do %>
 
-
     <table class="table table-bordered table-striped">
 
-  <thead>
-  <tr>
+      <thead>
+      <tr>
 
     <% if @has_header == 'true' %>
 
@@ -44,8 +43,6 @@
             <option value="fullname">Fullname</option>
           </select>
         </th>
-
-
 
     <% end %>
 

--- a/app/views/import_file/_user.html.erb
+++ b/app/views/import_file/_user.html.erb
@@ -1,0 +1,81 @@
+<%= form_tag( { :controller => 'import_file', :action => 'import' },
+              { :method => 'post', :name => 'column_form', :id => 'column_form'} ) do %>
+
+
+    <table class="table table-bordered table-striped">
+
+  <thead>
+  <tr>
+
+    <% if @has_header == 'true' %>
+
+        <th style="text-align:center">
+          <%= @contents_hash[:header][0].to_s.capitalize %>
+        </th>
+        <th style="text-align:center">
+          <%= @contents_hash[:header][1].to_s.capitalize %>
+        </th>
+        <th style="text-align:center">
+          <%= @contents_hash[:header][2].to_s.capitalize %>
+        </th>
+
+    <% else %>
+
+
+        <th>
+
+          <select name="select1" id="select1" class="form-control" style="background-color:lightgrey">
+            <option value="name">Name</option>
+            <option value="fullname">Fullname</option>
+            <option value="email">Email</option>
+          </select>
+        </th>
+        <th>
+          <select name="select2" id="select2" class="form-control" style="background-color:lightgrey">
+            <option value="fullname">Fullname</option>
+            <option value="name">Name</option>
+            <option value="email">Email</option>
+          </select>
+        </th>
+        <th>
+          <select name="select3" id="select3" class="form-control" style="background-color:lightgrey">
+            <option value="email">Email</option>
+            <option value="name">Name</option>
+            <option value="fullname">Fullname</option>
+          </select>
+        </th>
+
+
+
+    <% end %>
+
+  </tr>
+  </thead>
+
+  <tbody>
+
+  <% @contents_hash[:body].each do |row| %>
+      <tr>
+        <% row.each do |column| %>
+            <td align="center"><%= column %></td>
+        <% end %>
+      </tr>
+
+  <% end %>
+
+  </tbody>
+</table>
+
+    <%= hidden_field_tag('contents_hash', @contents_hash) %>
+    <%= hidden_field_tag('has_header', @has_header) %>
+    <%= hidden_field_tag('model', @model) %>
+
+    <div style="text-align:center">
+      <% if @has_header == 'true' %>
+          <button type="button" class="btn btn-primary" onclick="column_form.submit()">Import <%= @model %></button>
+      <% else %>
+          <button type="button" class="btn btn-primary" onclick="checkIfUserColumnDuplicate()">Import <%= @model %></button>
+      <% end %>
+    </div>
+
+<% end %>

--- a/app/views/import_file/show.html.erb
+++ b/app/views/import_file/show.html.erb
@@ -1,0 +1,18 @@
+<h2>Importing from <strong><em><%= @current_file.original_filename %></em></strong></h2>
+<h2>Please Confirm the Columns for <strong><em><%= @model %></em></strong></h2>
+
+<% if @model == 'User' %>
+    <%= render 'import_file/user' %>
+<% elsif @model == 'AssignmentTeam' || @model == 'CourseTeam'%>
+    <%= render 'import_file/team' %>
+<% elsif @model == 'ReviewResponseMap' %>
+    <%= render 'import_file/reviewer' %>
+<% elsif @model == 'MetareviewResponseMap'%>
+    <%= render 'import_file/metareviewer' %>
+<% elsif @model == 'AssignmentParticipant' || 'CourseParticipant' %>
+    <%=  render 'import_file/participant' %>
+<% else %>
+    <h3 style="color:red">There was a problem with the @model in app/views/import_file/show.html.erb.</h3>
+<% end %>
+
+<a href="/import_file/start?expected_fields=<%= @expected_fields %>&model=<%= @model %>">Back</a>

--- a/app/views/import_file/show.html.erb
+++ b/app/views/import_file/show.html.erb
@@ -1,6 +1,8 @@
 <h2>Importing from <strong><em><%= @current_file.original_filename %></em></strong></h2>
 <h2>Please Confirm the Columns for <strong><em><%= @model %></em></strong></h2>
 
+<br/>
+
 <% if @model == 'User' %>
     <%= render 'import_file/user' %>
 <% elsif @model == 'AssignmentTeam' || @model == 'CourseTeam'%>
@@ -9,8 +11,10 @@
     <%= render 'import_file/reviewer' %>
 <% elsif @model == 'MetareviewResponseMap'%>
     <%= render 'import_file/metareviewer' %>
-<% elsif @model == 'AssignmentParticipant' || 'CourseParticipant' %>
+<% elsif @model == 'AssignmentParticipant' || @model == 'CourseParticipant' %>
     <%=  render 'import_file/participant' %>
+<% elsif @model == 'SignUpTopic' %>
+  <%= render 'import_file/sign_up_topic' %>
 <% else %>
     <h3 style="color:red">There was a problem with the @model in app/views/import_file/show.html.erb.</h3>
 <% end %>

--- a/app/views/import_file/start.html.erb
+++ b/app/views/import_file/start.html.erb
@@ -108,7 +108,7 @@
       <br/>
       The import process expects the following columns:
       <br/>
-      <%= @expected_fields.html_safe %>
+      <%= @expected_fields.html_safe unless @expected_fields.nil? %>
     </p>
 
     <button type="button" class='btn btn-primary' onclick='checkForFile()'>Import</button>

--- a/app/views/import_file/start.html.erb
+++ b/app/views/import_file/start.html.erb
@@ -1,4 +1,4 @@
-<h2>Import <%= @model %> List</h2>
+<h2>Import <strong><em><%= @model %></em></strong> List</h2>
 
 <br/>
 
@@ -31,6 +31,23 @@
         </td>
       </tr>
 
+      <% if @model == 'SignUpTopic' %>
+
+          <tr><td><br/></td></tr>
+
+          <tr>
+            <td><strong>Optional Columns:</strong></td>
+          </tr>
+          <tr>
+            <td>
+              <%= check_box_tag('category', 'true') %> Topic Category<br/>
+              <%= check_box_tag('description', 'true') %> Topic Description<br/>
+              <%= check_box_tag('link', 'true') %> Topic Link<br/>
+            </td>
+          </tr>
+
+      <% end %>
+
     </table>
 
     <% if @model == 'AssignmentTeam' or @model == 'CourseTeam' %>
@@ -62,6 +79,7 @@
     <% end %>
 
     <br/>
+
     <% if @model == 'ReviewResponseMap' %>
         <table>
           <tr>
@@ -75,7 +93,6 @@
           </tr>
         </table>
         <br/>
-
     <% end %>
 
     <% if @model == 'MetareviewResponseMap' %>
@@ -91,10 +108,9 @@
           </tr>
         </table>
         <br/>
-
     <% end %>
 
-        <label for="file">File to import: </label>
+    <label for="file">File to import: </label>
     <%= file_field_tag 'file', :size => 40, :id => 'import_file' %>
 
     <br/>

--- a/app/views/import_file/start.html.erb
+++ b/app/views/import_file/start.html.erb
@@ -1,40 +1,120 @@
-<h2>Import <%= @title %></h2>
-<%= form_tag({:controller => 'import_file', :action => 'import'}, {:method => 'post', :multipart => true, :name => 'import_form'}) do %>
-  <table>
-    <tr>
-      <td valign='Top'>Delimiter:</td>
-      <td>
-        <%= radio_button_tag 'delim_type','comma',true %> Comma<br/>
-        <%= radio_button_tag 'delim_type','space' %> Space<br/>
-        <%= radio_button_tag 'delim_type','tab' %> Tab<br/>
-        <%= radio_button_tag 'delim_type','other' %> Other <%= text_field_tag 'other_char' %><br/>
-      </td>
-    </tr>
-  </table>
-  <% if @model == 'AssignmentTeam' or @model == 'CourseTeam'%>
-    <br/>
-    <label for="column_one_has_name">Interpret first column as team name:</label>
-    <%= check_box 'options','has_column_names', {:checked => 'checked'},  "true", "false"  %><br/>
-    <label for="options[handle_dups]">If a duplicate team name is found in the roster,</label></td>
-  <select id="options_handle_dups" name="options[handle_dups]">
-    <option value="ignore">ignore the new team
-    <option value="replace">replace the existing team with the new team
-    <option value="insert">insert any new members into the existing team
-    <option value="rename">rename the new team and import
-  </select>
-  <br/>
-<% end %>
+<h2>Import <%= @model %> List</h2>
+
 <br/>
-<label for="file">File to import: </label><%= file_field_tag 'file', :size => 40 %><br/><br/>
-<%= hidden_field_tag('model', @model) %>
-<%= hidden_field_tag('id', @id) %>
 
+<%= form_tag( { :controller => 'import_file', :action => 'show' },
+              { :method => 'post', :multipart => true, :name => 'import_form', :id => 'import_form' } ) do %>
 
-* The import process expects the following columns:<br/>
-&nbsp;&nbsp;&nbsp;<%= @expected_fields %>
- <br/><br/>
- <input type='submit' value='Import' onclick='if (checkIfFileExists(file)) {import_form.submit();} else {alert("Please select a file before clicking Next.");}'/>
- <% end %>
- <br/><br/>
+    <table>
 
- <a href="<%= session[:return_to]%>">Back</a>
+      <tr>
+        <td><strong>Delimiter:</strong></td>
+      </tr>
+      <tr>
+        <td>
+          <%= radio_button_tag 'delim_type','comma',true %> Comma<br/>
+          <%= radio_button_tag 'delim_type','space' %> Space<br/>
+          <%= radio_button_tag 'delim_type','tab' %> Tab<br/>
+          <%= radio_button_tag 'delim_type','other' %> Other <%= text_field_tag 'other_char' %><br/>
+        </td>
+      </tr>
+
+      <tr><td><br/></td></tr>
+
+      <tr>
+        <td><strong>Header:</strong></td>
+      </tr>
+      <tr>
+        <td>
+          <%= radio_button_tag 'has_header', 'true', true %> File has a header<br/>
+          <%= radio_button_tag 'has_header', 'false' %> File does not have a header<br/>
+        </td>
+      </tr>
+
+    </table>
+
+    <% if @model == 'AssignmentTeam' or @model == 'CourseTeam' %>
+       <br/>
+       <table>
+        <tr>
+          <td><strong>Team Name:</strong></td>
+        </tr>
+        <tr>
+          <td>
+            <%= radio_button_tag 'has_teamname', 'true_first', true %> File has a team name as first column<br/>
+            <%= radio_button_tag 'has_teamname', 'true_last' %> File has a team name as last column<br/>
+            <%= radio_button_tag 'has_teamname', 'false' %> File does not contain team names<br/>
+          </td>
+        </tr>
+       </table>
+        <br/>
+
+        <label for="options[handle_dups]">If a duplicate team name is found in the roster,</label>
+        <select id="options[handle_dups]" name="options[handle_dups]">
+          <option value="ignore">ignore the new team</option>
+          <option value="replace">replace the existing team with the new team</option>
+          <option value="insert">insert any new members into the existing team</option>
+          <option value="rename">rename the new team and import</option>
+        </select>
+
+        <br/>
+
+    <% end %>
+
+    <br/>
+    <% if @model == 'ReviewResponseMap' %>
+        <table>
+          <tr>
+            <td><strong>Contributor:</strong></td>
+          </tr>
+          <tr>
+            <td>
+              <%= radio_button_tag 'has_reviewee', 'true_first',true %> File has a contributor as first column<br/>
+              <%= radio_button_tag 'has_reviewee', 'true_last' %> File has a contributor as last column<br/>
+            </td>
+          </tr>
+        </table>
+        <br/>
+
+    <% end %>
+
+    <% if @model == 'MetareviewResponseMap' %>
+        <table>
+          <tr>
+            <td><strong>Contributor and Reviewer:</strong></td>
+          </tr>
+          <tr>
+            <td>
+              <%= radio_button_tag 'has_reviewee', 'true_first',true%> File has a contributor and reviewer as first and second columns<br/>
+              <%= radio_button_tag 'has_reviewee', 'true_last' %> File has a contributor and reviewer as last and second last columns<br/>
+            </td>
+          </tr>
+        </table>
+        <br/>
+
+    <% end %>
+
+        <label for="file">File to import: </label>
+    <%= file_field_tag 'file', :size => 40, :id => 'import_file' %>
+
+    <br/>
+
+    <%= hidden_field_tag('model', @model) %>
+
+    <%= hidden_field_tag('id', @id) %>
+
+    <p>
+      <strong>NOTE:</strong>
+      <br/>
+      The import process expects the following columns:
+      <br/>
+      <%= @expected_fields.html_safe %>
+    </p>
+
+    <button type="button" class='btn btn-primary' onclick='checkForFile()'>Import</button>
+
+<% end %>
+
+<br/>
+
+<a href="<%= session[:return_to]%>">Back</a>

--- a/app/views/participants/list.html.erb
+++ b/app/views/participants/list.html.erb
@@ -28,7 +28,7 @@
             :action=>'start', 
             :model => @model+'Participant', 
             :title => @model+' Participants',
-            :expected_fields => 'username, full name (first[ middle] last), e-mail address, password',
+            :expected_fields => 'username&nbsp;&nbsp;|&nbsp;&nbsp;full name (first [middle] last)&nbsp;&nbsp;|&nbsp;&nbsp;e-mail address&nbsp;&nbsp;|&nbsp;&nbsp;password',
             :id => @parent.id %> | 
 <%= link_to 'Export '+@model.to_s.downcase+' participants',
             :controller=>'export_file',

--- a/app/views/review_mapping/_list_review_mappings.html.erb
+++ b/app/views/review_mapping/_list_review_mappings.html.erb
@@ -158,7 +158,7 @@
     :action=>'start',
     :model => 'ReviewResponseMap',
     :title => 'Reviewer Mappings',
-    :expected_fields =>  "Contributor, Reviewer1, Reviewer2, ... , ReviewerN",
+    :expected_fields =>  "Contributor&nbsp;&nbsp;|&nbsp;&nbsp;Reviewer1&nbsp;&nbsp;|&nbsp;&nbsp;Reviewer2&nbsp;&nbsp;|&nbsp;&nbsp;...&nbsp;&nbsp;|&nbsp;&nbsp;ReviewerN",
     :id => assignment.id %>
   |
   <%= link_to 'Import metareviewer mappings',
@@ -166,7 +166,7 @@
     :action=>'start',
     :model => 'MetareviewResponseMap',
     :title => 'Metareviewer Mappings',
-    :expected_fields => 'Contributor, Reviewer, Metareviewer1, Metareviewer2, ... MetareviewerN',
+    :expected_fields => 'Contributor&nbsp;&nbsp;|&nbsp;&nbsp;Reviewer&nbsp;&nbsp;|&nbsp;&nbsp;MetaReviewer1&nbsp;&nbsp;|&nbsp;&nbsp;MetaReviewer2&nbsp;&nbsp;|&nbsp;&nbsp;...&nbsp;&nbsp;|&nbsp;&nbsp;MetaReviewerN',
     :id => assignment.id %>
   <BR/>
 

--- a/app/views/review_mapping/list_sortable.html.erb
+++ b/app/views/review_mapping/list_sortable.html.erb
@@ -41,6 +41,6 @@
   :action=>'start',
   :model => 'MetareviewresponseMap',
   :title => 'Metareviewer Mappings',
-  :expected_fields => 'Contributor, Reviewer, Metareviewer1, Metareviewer2, ... MetareviewerN',
+  :expected_fields => 'Contributor&nbsp;&nbsp;|&nbsp;&nbsp;Reviewer&nbsp;&nbsp;|&nbsp;&nbsp;MetaReviewer1&nbsp;&nbsp;|&nbsp;&nbsp;MetaReviewer2&nbsp;&nbsp;|&nbsp;&nbsp;..&nbsp;&nbsp;|&nbsp;&nbsp;MetaReviewerN',
   :id => @assignment.id %>
 | <%= link_to 'Back', :controller => 'tree_display', :action => 'list' %>

--- a/app/views/sign_up_sheet/_add_topics.html.erb
+++ b/app/views/sign_up_sheet/_add_topics.html.erb
@@ -1,7 +1,7 @@
 <% if @sign_up_topics.count == 0%>
 <%= link_to 'New topic',{:controller => 'sign_up_sheet', :action => 'new', :id => params[:id]}, :confirm => "You are adding a topic to this assignment.  Students will now have to select a topic before they submit their work.", :topic => @topics, :method => :get%> |
-<%= link_to 'Import topics', {:controller=>'import_file', :action=>'start', :model => 'SignUpTopic', :id => params[:id]}, :expected_fields => 'Topic identifier, Topic name, Max choosers, Topic Category', :confirm => "You are adding topics to this assignment.  Students will now have to select a topic before they submit their work.", :topic => @topics, :method => :get %>|
+<%= link_to 'Import topics', {:controller=>'import_file', :action=>'start', :model => 'SignUpTopic', :id => params[:id]}, :expected_fields => 'Topic identifier, Topic name, Max choosers, Topic Category', :confirm => "You are adding topics to this assignment.  Students will now have to select a topic before they submit their work.", :topic => @topics, :method => :get %> |
 <% else %>
 <%= link_to 'New topic',:controller => 'sign_up_sheet', :action => 'new', :id => params[:id]%> |
-<%= link_to 'Import topics', :controller=>'import_file', :action=>'start', :model => 'SignUpTopic', :id => params[:id], :expected_fields => 'Topic identifier, Topic name, Max choosers, Topic Category' %>|
+<%= link_to 'Import topics', :controller=>'import_file', :action=>'start', :model => 'SignUpTopic', :id => params[:id], :expected_fields => 'Topic identifier, Topic name, Max choosers, Topic Category' %> |
 <% end %>

--- a/app/views/sign_up_sheet/_add_topics.html.erb
+++ b/app/views/sign_up_sheet/_add_topics.html.erb
@@ -1,7 +1,59 @@
 <% if @sign_up_topics.count == 0%>
-<%= link_to 'New topic',{:controller => 'sign_up_sheet', :action => 'new', :id => params[:id]}, :confirm => "You are adding a topic to this assignment.  Students will now have to select a topic before they submit their work.", :topic => @topics, :method => :get%> |
-<%= link_to 'Import topics', {:controller=>'import_file', :action=>'start', :model => 'SignUpTopic', :id => params[:id]}, :expected_fields => 'Topic identifier, Topic name, Max choosers, Topic Category', :confirm => "You are adding topics to this assignment.  Students will now have to select a topic before they submit their work.", :topic => @topics, :method => :get %> |
+
+    <%= link_to 'New topic',
+                {
+                    :controller => 'sign_up_sheet',
+                    :action => 'new',
+                    :id => params[:id]
+                },
+                :confirm => "You are adding a topic to this assignment.  Students will now have to select a topic before they submit their work.",
+                :topic => @topics,
+                :method => :get%> |
+
+    <%= link_to 'Import topics',
+                {
+                    :controller => 'import_file',
+                    :action => 'start',
+                    :model => 'SignUpTopic',
+                    :id => params[:id],
+                    :expected_fields => 'Topic Identifier' +
+                        '&nbsp&nbsp|&nbsp&nbsp' +
+                        'Topic Name' +
+                        '&nbsp&nbsp|&nbsp&nbsp' +
+                        'Max Choosers' +
+                        '&nbsp&nbsp|&nbsp&nbsp' +
+                        'Topic Category <em>(optional)</em>' +
+                        '&nbsp&nbsp|&nbsp&nbsp' +
+                        'Topic Description <em>(optional)</em>' +
+                        '&nbsp&nbsp|&nbsp&nbsp' +
+                        'Topic Link <em>(optional)</em>'
+                },
+                :confirm => "You are adding topics to this assignment.  Students will now have to select a topic before they submit their work.",
+                :topic => @topics,
+                :method => :get %> |
+
 <% else %>
-<%= link_to 'New topic',:controller => 'sign_up_sheet', :action => 'new', :id => params[:id]%> |
-<%= link_to 'Import topics', :controller=>'import_file', :action=>'start', :model => 'SignUpTopic', :id => params[:id], :expected_fields => 'Topic identifier, Topic name, Max choosers, Topic Category' %> |
+
+    <%= link_to 'New topic',
+                :controller => 'sign_up_sheet',
+                :action => 'new',
+                :id => params[:id]%> |
+
+    <%= link_to 'Import topics',
+                :controller=>'import_file',
+                :action=>'start',
+                :model => 'SignUpTopic',
+                :id => params[:id],
+                :expected_fields => 'Topic Identifier' +
+                    '&nbsp&nbsp|&nbsp&nbsp' +
+                    'Topic Name' +
+                    '&nbsp&nbsp|&nbsp&nbsp' +
+                    'Max Choosers' +
+                    '&nbsp&nbsp|&nbsp&nbsp' +
+                    'Topic Category <em>(optional)</em>' +
+                    '&nbsp&nbsp|&nbsp&nbsp' +
+                    'Topic Description <em>(optional)</em>' +
+                    '&nbsp&nbsp|&nbsp&nbsp' +
+                    'Topic Link <em>(optional)</em>' %> |
+
 <% end %>

--- a/app/views/teams/list.html.erb
+++ b/app/views/teams/list.html.erb
@@ -18,12 +18,12 @@
   :action=>'start',
   :model => modelType,
   :title => 'Teams',
-  :expected_fields =>  "&lt;Team Name - optional, &gt; Team Member1, Team Member2, ... , Team Member3",
+  :expected_fields =>  "Team Name <em>(optional)</em>&nbsp;&nbsp;|&nbsp;&nbsp;TeamMember1&nbsp;&nbsp;|&nbsp;&nbsp;TeamMember2&nbsp;&nbsp;|&nbsp;&nbsp;...&nbsp;&nbsp;|&nbsp;&nbsp;TeamMemberN",
   :id => @root_node.node_object_id %>
-|<%= link_to 'Export Teams',
+| <%= link_to 'Export Teams',
   :controller=>'export_file',
   :action=>'start',
   :model=> modelType,
   :id=>@root_node.node_object_id %>
-|<%= link_to 'Delete All Teams', :action => 'delete_all', :id=> @root_node.node_object_id, :model => @model %>
-|<%= render :partial => '/shared_scripts/back' %>
+| <%= link_to 'Delete All Teams', :action => 'delete_all', :id=> @root_node.node_object_id, :model => @model %>
+| <%= render :partial => '/shared_scripts/back' %>

--- a/app/views/users/list.html.erb
+++ b/app/views/users/list.html.erb
@@ -45,7 +45,7 @@
     %>
 
   <%= link_to 'New User',:role => "Student", :action => 'new' %> |
-  <%= link_to 'Import Users', :controller=>'import_file', :action=>'start', :model => 'User', :expected_fields => 'username, full name (first[ middle] last), e-mail address' %>|
+  <%= link_to 'Import Users', :controller=>'import_file', :action=>'start', :model => 'User', :expected_fields => 'username&nbsp;&nbsp;|&nbsp;&nbsp;full name (first [middle] last)&nbsp;&nbsp;|&nbsp;&nbsp;e-mail address' %> |
   <%= link_to 'Export Users', :controller=>'export_file',:action=>'start',:model=> 'User',:id=> 1 %>
 
 </p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -147,10 +147,15 @@ Expertiza::Application.routes.draw do
     collection do
       get :start
       post :import
+
+      # MAY BE ABLE TO PUT ROUTE HERE
+
     end
   end
 
   get '/import_file/import', controller: :import_file, action: :import
+  get '/import_file/show', controller: :import_file, action: :show
+  post '/import_file/show', controller: :import_file, action: :show
 
   resources :institution do
     collection do
@@ -369,7 +374,6 @@ Expertiza::Application.routes.draw do
       get :intelligent_sign_up
       get :intelligent_save
       get :signup_as_instructor
-      get :intelligent_topic_selection
       post :signup_as_instructor_action
       post :set_priority
       post :save_topic_deadlines

--- a/spec/controllers/airbrake_exception_errors_controller_tests_spec.rb
+++ b/spec/controllers/airbrake_exception_errors_controller_tests_spec.rb
@@ -36,24 +36,30 @@ describe TeamsController do
   end
 end
 
-describe ImportFileController do
-  # Airbrake-1774360945974838307
-  describe '#importFile' do
-    it 'will catch the error info if the tempfile cannot be obtained from params[:file]' do
-      controller.params = {
-        id: 1,
-        options: {"has_column_names" => "true", "handle_dups" => "ignore"},
-        model: 'AssignmentTeam',
-        file: nil
-      }
-      session = {
-        assignment_id: 1
-      }
-      expect { controller.send(:importFile, session, controller.params) }.not_to raise_error
-      expect(controller.send(:importFile, session, controller.params).inspect).to eq("[#<NoMethodError: undefined method `each_line' for nil:NilClass>]")
-    end
-  end
-end
+# E1776 (Fall 2017)
+#
+# The tests below are no longer reflective of the current import process.
+#
+# 1. The method importFile has been replaced with import_from_hash in import_file_controller.rb
+#
+# describe ImportFileController do
+#   # Airbrake-1774360945974838307
+#   describe '#importFile' do
+#     it 'will catch the error info if the tempfile cannot be obtained from params[:file]' do
+#       controller.params = {
+#         id: 1,
+#         options: {"has_column_names" => "true", "handle_dups" => "ignore"},
+#         model: 'AssignmentTeam',
+#         file: nil
+#       }
+#       session = {
+#         assignment_id: 1
+#       }
+#       expect { controller.send(:importFile, session, controller.params) }.not_to raise_error
+#       expect(controller.send(:importFile, session, controller.params).inspect).to eq("[#<NoMethodError: undefined method `each_line' for nil:NilClass>]")
+#     end
+#   end
+# end
 
 describe MenuItemsController do
   # Airbrake-1766139777878852159

--- a/spec/features/instructor_interface_spec.rb
+++ b/spec/features/instructor_interface_spec.rb
@@ -45,23 +45,32 @@ describe "Integration tests for instructor interface" do
     end
   end
 
-  describe "Import tests for assignment topics" do
-    it 'should be valid file with 3 columns' do
-      validate_login_and_page_content("spec/features/assignment_topic_csvs/3-col-valid_topics_import.csv", %w(expertiza mozilla), true)
-    end
-
-    it 'should be a valid file with 3 or more columns' do
-      validate_login_and_page_content("spec/features/assignment_topic_csvs/3or4-col-valid_topics_import.csv", %w(capybara cucumber), true)
-    end
-
-    it 'should be a invalid csv file' do
-      validate_login_and_page_content("spec/features/assignment_topic_csvs/invalid_topics_import.csv", %w(airtable devise), false)
-    end
-
-    it 'should be an random text file' do
-      validate_login_and_page_content("spec/features/assignment_topic_csvs/random.txt", ['this is a random file which should fail'], false)
-    end
-  end
+  # E1776 (Fall 2017)
+  #
+  # The tests below are no longer reflective of the current import process for topics.
+  # 1. There is now an additional intermediary page during the import process.
+  # 2. There are now checkbox options on the initial import page to specify optional columns.
+  # 3. The intermediary data structures for imports have changed (see the pull request notes).
+  # 4. The new import process expects all rows in a file to have the same number of columns.
+  #    That is, it expects optional columns to be common across all rows within the same file.
+  #
+  # describe "Import tests for assignment topics" do
+  #   it 'should be valid file with 3 columns' do
+  #     validate_login_and_page_content("spec/features/assignment_topic_csvs/3-col-valid_topics_import.csv", %w(expertiza mozilla), true)
+  #   end
+  #
+  #   it 'should be a valid file with 3 or more columns' do
+  #     validate_login_and_page_content("spec/features/assignment_topic_csvs/3or4-col-valid_topics_import.csv", %w(capybara cucumber), true)
+  #   end
+  #
+  #   it 'should be a invalid csv file' do
+  #     validate_login_and_page_content("spec/features/assignment_topic_csvs/invalid_topics_import.csv", %w(airtable devise), false)
+  #   end
+  #
+  #   it 'should be an random text file' do
+  #     validate_login_and_page_content("spec/features/assignment_topic_csvs/random.txt", ['this is a random file which should fail'], false)
+  #   end
+  # end
 
   describe "View assignment scores" do
     it 'is able to view scores' do

--- a/spec/features/instructor_interface_spec.rb
+++ b/spec/features/instructor_interface_spec.rb
@@ -48,6 +48,7 @@ describe "Integration tests for instructor interface" do
   # E1776 (Fall 2017)
   #
   # The tests below are no longer reflective of the current import process for topics.
+  #
   # 1. There is now an additional intermediary page during the import process.
   # 2. There are now checkbox options on the initial import page to specify optional columns.
   # 3. The intermediary data structures for imports have changed (see the pull request notes).

--- a/spec/models/course_participant_spec.rb
+++ b/spec/models/course_participant_spec.rb
@@ -38,7 +38,7 @@ describe "CourseParticipant" do
       row = []
       allow(Course).to receive(:find).and_return(nil)
       allow(session[:user]).to receive(:id).and_return(1)
-      row = { :name => 'user_name', :fullname => 'user_fullname', :email => 'name@gmail.com' }
+      row = { :name => 'user_name', :fullname => 'user_fullname', :email => 'name@gmail.com', :password => 'user_password' }
       expect { CourseParticipant.import(row, nil, session, 2) }.to raise_error("The course with the id \"2\" was not found.")
     end
 

--- a/spec/models/course_participant_spec.rb
+++ b/spec/models/course_participant_spec.rb
@@ -28,7 +28,7 @@ describe "CourseParticipant" do
     end
 
     it "raise error if record does not have enough items " do
-      row = ["user_name", "user_fullname", "name@email.com"]
+      row = { :name => "user_name", :fullname => "user_fullname", :email => "name@email.com" }
       expect { CourseParticipant.import(row, nil, nil, nil) }.to raise_error("The record containing #{row[0]} does not have enough items.")
     end
 
@@ -48,7 +48,7 @@ describe "CourseParticipant" do
       row = []
       allow(Course).to receive(:find).and_return(course)
       allow(session[:user]).to receive(:id).and_return(1)
-      row = ["user_name", "user_fullname", "name@email.com", "user_role_name", "user_parent_name"]
+      row = { :name => "user_name", :fullname => "user_fullname", :email => "name@email.com", :role => "user_role_name", :parent => "user_parent_name" }
       course_part = CourseParticipant.import(row, nil, session, 2)
       expect(course_part).to be_an_instance_of(CourseParticipant)
     end

--- a/spec/models/course_participant_spec.rb
+++ b/spec/models/course_participant_spec.rb
@@ -29,7 +29,7 @@ describe "CourseParticipant" do
 
     it "raise error if record does not have enough items " do
       row = { :name => "user_name", :fullname => "user_fullname", :email => "name@email.com" }
-      expect { CourseParticipant.import(row, nil, nil, nil) }.to raise_error("The record containing #{row[0]} does not have enough items.")
+      expect { CourseParticipant.import(row, nil, nil, nil) }.to raise_error("The record containing #{row[:name]} does not have enough items.")
     end
 
     it "raise error if course with id not found" do

--- a/spec/models/course_participant_spec.rb
+++ b/spec/models/course_participant_spec.rb
@@ -38,7 +38,7 @@ describe "CourseParticipant" do
       row = []
       allow(Course).to receive(:find).and_return(nil)
       allow(session[:user]).to receive(:id).and_return(1)
-      row = ["user_name", "user_fullname", "name@email.com", "user_role_name", "user_parent_name"]
+      row = { :name => 'user_name', :fullname => 'user_fullname', :email => 'name@gmail.com' }
       expect { CourseParticipant.import(row, nil, session, 2) }.to raise_error("The course with the id \"2\" was not found.")
     end
 


### PR DESCRIPTION
**Issue #110**

Enhancements added:

* The app/user/controllers/import_file_controller.rb file now has several protected methods that, instead of importing from a file to an array, imports from a file to a hash — the keys of which are the column names (attributes) for the data to be imported. For example:

	**Previous Intermediary Structure During File Import:**
	
	```
	[ [ 'name',
	    'fullname',
	    'email ],
	  [ 'ppatel16',
	    'Pushpendra Patel',
	    'ppatel@ncsu.edu' ],
	  [ 'tkothar',
	    'Tanay Kothari',
	    'tkothar@ncsu.edu' ],
	  [ 'tmdement',
	    'Timothy Dement',
	    'tmdement@ncsu.edu' ] ]
	```
	
	**New Intermediary Structure During File Import:**
	
	```
	[ { :name => 'ppatel16',
	    :fullname => 'Pushpendra Patel',
	    :email => 'ppatel16@ncsu.edu' },
	  { :name => 'tkothar',
	    :fullname => 'Tanay Kothari',
	    :email => 'tkothar@ncsu.edu' },
	  { :name => 'tmdement',
	    :fullname => 'Timothy Dement',
	    :email => 'tmdement@ncsu.edu } ]
	```

* Through using these new methods, we are now able to import files where the data columns are arranged in arbitrary order. For each of the models with import methods (User, AssignmentParticipant, CourseParticipant, AssignmentTeam, CourseTeam, ReviewResponseMap, MetareviewResponseMap, and SignUpTopic) the import methods have been changed to take advantage of the new hash (rather than relying on specific entries in an array).

* Javascript functions were fixed in app/assets/javascripts/shared.js. The previously written functions did not work properly.  The new ones we wrote (1) block a user from attempting an import when no file has been selected, (2) block a user from importing "duplicate" columns when they are specifying the column types themselves, and (3) block a user from importing if "required" columns are not selected when they are specifying the column types themselves.

* New options have been given for the user to select during the import process.  For importing a list of Users, AssignmentParticipants, and CourseParticipants, if a file does not contain column names, the user can select the appropriate column name before finalizing the import. For importing a list of AssignmentTeams or CourseTeams, a user can also now select whether or not team names are included in the file, and if so where they are located (the beginning of each line or the end).  For importing a list of ReviewResponseMaps or MetareviewResponseMaps, the order of columns is also able to be specified.  For importing a list of SignUpTopics, checkboxes are included for a user to specify which optional columns appear in the given file.

* All import procedures have been augmented with an additional import_controller.rb method `show` and associated view `show.html.erb` so that a user may review all data to be imported before finalizing the import.  This preview is shows as a table that is generated from the file data, and it is at this stage that they can select appropriate column types (where applicable).

* Messages given at the bottom of the import page about expected columns for given import types have been made more legible.

* Three pre-existing bugs were discovered and resolved during development: (1) blocking an attempted import with no file selected was not working properly, (2) AssignmentTeam imports were failing due to a pre-exiting method `add_members` that had the wrong number of parameters defined, and (3) expected column information was not being displayed when importing topics for an assignment that had no previous topics set up.