### PR TITLE
Issue 329 Resolved

### DIFF
--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -207,7 +207,20 @@ class Team < ActiveRecord::Base
     if handle_dups == "ignore" # ignore: do not create the new team
       return nil
     end
-    if handle_dups == "rename" # rename: rename new team
+    if handle_dups == "rename" && !team.nil? # rename old team and retain name of new team
+      if teamtype.is_a?(CourseTeam)
+        s = name
+        team.name  = self.generate_team_name(Course.find(id).name)
+        team.save
+        return s
+      elsif teamtype.is_a?(AssignmentTeam)
+        s = name
+        team.name = self.generate_team_name(Assignment.find(id).name)
+        team.save
+        return s
+      end
+    end
+    if handle_dups == "new_name" # find a new name for the new team
       if teamtype.is_a?(CourseTeam)
         return self.generate_team_name(Course.find(id).name)
       elsif teamtype.is_a?(AssignmentTeam)

--- a/app/views/import_file/start.html.erb
+++ b/app/views/import_file/start.html.erb
@@ -20,7 +20,8 @@
     <option value="ignore">ignore the new team
     <option value="replace">replace the existing team with the new team
     <option value="insert">insert any new members into the existing team
-    <option value="rename">rename the new team and import
+    <option value="new_name">rename the new team and import
+    <option value="rename">rename the old team and import
   </select>
   <br/>
 <% end %>


### PR DESCRIPTION
Originally while importing teams from a file, if a (proposed) new team name (which is in the file) matched an existing team name, the only ways of resolving the ensuing conflict was by either ignoring the new team, or giving  a new name to the new team, or by deleting the old team and putting the new team in it's place. This commit adds the option of renaming the old team and importing the new team. 