### PR TITLE
CSC 630: Integration of Automated metareview metrics

### DIFF
--- a/app/controllers/response_controller.rb
+++ b/app/controllers/response_controller.rb
@@ -158,13 +158,15 @@ class ResponseController < ApplicationController
       @response.notify_instructor_on_difference
     end
     @response.email
-    redirect_to controller: 'response', action: 'saving', auto_metareview: params[:auto_metareview], id: @map.map_id, return: params[:return], msg: msg, error_msg: error_msg, save_options: params[:save_options], volume: params[:volume], plagiarism: params[:plagiarism], tone_p: params[:tone_p], tone_n: params[:tone_n], tone_ng: params[:tone_ng]  end
+    redirect_to controller: 'response', action: 'saving', auto_metareview: params[:auto_metareview], id: @map.map_id, return: params[:return], msg: msg, error_msg: error_msg, save_options: params[:save_options], volume: params[:volume], plagiarism: params[:plagiarism], tone_p: params[:tone_p], tone_n: params[:tone_n], tone_ng: params[:tone_ng]  
+  end
 
   def saving
     @map = ResponseMap.find(params[:id])
     @return = params[:return]
     @map.save
-    redirect_to action: 'redirection', auto_metareview: params[:auto_metareview], id: @map.map_id, return: params[:return], msg: params[:msg], error_msg: params[:error_msg], volume: params[:volume], plagiarism: params[:plagiarism], tone_p: params[:tone_p], tone_n: params[:tone_n], tone_ng: params[:tone_ng]  end
+    redirect_to action: 'redirection', auto_metareview: params[:auto_metareview], id: @map.map_id, return: params[:return], msg: params[:msg], error_msg: params[:error_msg], volume: params[:volume], plagiarism: params[:plagiarism], tone_p: params[:tone_p], tone_n: params[:tone_n], tone_ng: params[:tone_ng]  
+  end
 
   def redirection
     flash[:error] = params[:error_msg] unless params[:error_msg] and params[:error_msg].empty?
@@ -234,10 +236,9 @@ class ResponseController < ApplicationController
     end
   end
 
-  #this method houses all auto_meta review functionality
+  # this method houses all auto_meta review functionality
 
   def autometareview
-
     @id = params[:id]
     @reviewer_id = params[:reviewer_id]
     @assignment = Assignment.find(@id)
@@ -246,46 +247,36 @@ class ResponseController < ApplicationController
 
     # Search for all the reviewers in the current assignment
     @reviewers = ReviewResponseMap.review_response_report(@id, @assignment, @type, nil)
-
-
-    @tot_vol =0
-    @count_rev =0
-
+    @tot_vol = 0
+    @count_rev = 0
     reviewees_topic = SignedUpTeam.topic_id(@assignment.id, @reviewer_id)
     @current_round = @assignment.number_of_current_round(reviewees_topic)
 
     @reviewers.each do |r|
       overall_avg_vol, avg_vol_in_round_1, avg_vol_in_round_2, avg_vol_in_round_3 = Response.get_volume_of_review_comments(params[:id], r.id)
 
-
       if @current_round == 1 && avg_vol_in_round_1 > 0
         @tot_vol += avg_vol_in_round_1
-        @count_rev = @count_rev+1
+        @count_rev += 1
       elsif @current_round == 2 && avg_vol_in_round_2 > 0
         @tot_vol += avg_vol_in_round_2
-        @count_rev = @count_rev+1
+        @count_rev += 1
       elsif @current_round == 3 && avg_vol_in_round_3 > 0
         @tot_vol += avg_vol_in_round_3
-        @count_rev = @count_rev+1
+        @count_rev += 1
       else
         @tot_vol += overall_avg_vol
-        @count_rev = @count_rev+1
+        @count_rev += 1
       end
-
-
-
     end
 
-
-    @avg_volume = (@tot_vol.to_f/@count_rev)
-
+    @avg_volume = (@tot_vol.to_f / @count_rev)
     @volume = params[:volume]
     @plagiarism = params[:plagiarism]
     @tone_p = params[:tone_p]
     @tone_n = params[:tone_n]
     @tone_ng = params[:tone_ng]
     @map_id = params[:map_id]
-
   end
 
   private

--- a/app/controllers/response_controller.rb
+++ b/app/controllers/response_controller.rb
@@ -93,7 +93,7 @@ class ResponseController < ApplicationController
     rescue
       msg = "Your response was not saved. Cause:189 #{$ERROR_INFO}"
     end
-    redirect_to controller: 'response', action: 'saving', id: @map.map_id, return: params[:return], msg: msg, save_options: params[:save_options]
+    redirect_to controller: 'response', action: 'saving', auto_metareview: params[:auto_metareview], id: @map.map_id, return: params[:return], msg: msg, save_options: params[:save_options], volume: params[:volume], plagiarism: params[:plagiarism], tone_p: params[:tone_p], tone_n: params[:tone_n], tone_ng: params[:tone_ng]
   end
 
   def new
@@ -158,15 +158,13 @@ class ResponseController < ApplicationController
       @response.notify_instructor_on_difference
     end
     @response.email
-    redirect_to controller: 'response', action: 'saving', id: @map.map_id, return: params[:return], msg: msg, error_msg: error_msg, save_options: params[:save_options]
-  end
+    redirect_to controller: 'response', action: 'saving', auto_metareview: params[:auto_metareview], id: @map.map_id, return: params[:return], msg: msg, error_msg: error_msg, save_options: params[:save_options], volume: params[:volume], plagiarism: params[:plagiarism], tone_p: params[:tone_p], tone_n: params[:tone_n], tone_ng: params[:tone_ng]  end
 
   def saving
     @map = ResponseMap.find(params[:id])
     @return = params[:return]
     @map.save
-    redirect_to action: 'redirection', id: @map.map_id, return: params[:return], msg: params[:msg], error_msg: params[:error_msg]
-  end
+    redirect_to action: 'redirection', auto_metareview: params[:auto_metareview], id: @map.map_id, return: params[:return], msg: params[:msg], error_msg: params[:error_msg], volume: params[:volume], plagiarism: params[:plagiarism], tone_p: params[:tone_p], tone_n: params[:tone_n], tone_ng: params[:tone_ng]  end
 
   def redirection
     flash[:error] = params[:error_msg] unless params[:error_msg] and params[:error_msg].empty?
@@ -184,6 +182,8 @@ class ResponseController < ApplicationController
       redirect_to controller: 'submitted_content', action: 'edit', id: @map.response_map.reviewer_id
     elsif params[:return] == "survey"
       redirect_to controller: 'response', action: 'pending_surveys'
+    elsif params[:auto_metareview] == "Yes"
+      redirect_to controller: 'response', action: 'autometareview', map_id: @map.map_id, id: @map.response_map.assignment.id, volume: params[:volume], plagiarism: params[:plagiarism], tone_p: params[:tone_p], tone_n: params[:tone_n], tone_ng: params[:tone_ng], reviewer_id: @map.reviewer.id
     else
       redirect_to controller: 'student_review', action: 'list', id: @map.reviewer.id
     end
@@ -232,6 +232,60 @@ class ResponseController < ApplicationController
         end
       end
     end
+  end
+
+  #this method houses all auto_meta review functionality
+
+  def autometareview
+
+    @id = params[:id]
+    @reviewer_id = params[:reviewer_id]
+    @assignment = Assignment.find(@id)
+    @map_id = params[:map_id]
+    @type = "ReviewResponseMap"
+
+    # Search for all the reviewers in the current assignment
+    @reviewers = ReviewResponseMap.review_response_report(@id, @assignment, @type, nil)
+
+
+    @tot_vol =0
+    @count_rev =0
+
+    reviewees_topic = SignedUpTeam.topic_id(@assignment.id, @reviewer_id)
+    @current_round = @assignment.number_of_current_round(reviewees_topic)
+
+    @reviewers.each do |r|
+      overall_avg_vol, avg_vol_in_round_1, avg_vol_in_round_2, avg_vol_in_round_3 = Response.get_volume_of_review_comments(params[:id], r.id)
+
+
+      if @current_round == 1 && avg_vol_in_round_1 > 0
+        @tot_vol += avg_vol_in_round_1
+        @count_rev = @count_rev+1
+      elsif @current_round == 2 && avg_vol_in_round_2 > 0
+        @tot_vol += avg_vol_in_round_2
+        @count_rev = @count_rev+1
+      elsif @current_round == 3 && avg_vol_in_round_3 > 0
+        @tot_vol += avg_vol_in_round_3
+        @count_rev = @count_rev+1
+      else
+        @tot_vol += overall_avg_vol
+        @count_rev = @count_rev+1
+      end
+
+
+
+    end
+
+
+    @avg_volume = (@tot_vol.to_f/@count_rev)
+
+    @volume = params[:volume]
+    @plagiarism = params[:plagiarism]
+    @tone_p = params[:tone_p]
+    @tone_n = params[:tone_n]
+    @tone_ng = params[:tone_ng]
+    @map_id = params[:map_id]
+
   end
 
   private

--- a/app/views/response/autometareview.html.erb
+++ b/app/views/response/autometareview.html.erb
@@ -1,0 +1,195 @@
+<head>
+  <script type="text/javascript" src="https://www.gstatic.com/charts/loader.js"></script>
+  <script type="text/javascript">
+      google.charts.load("current", {packages:["corechart", "bar"]});
+      google.charts.setOnLoadCallback(drawChart);
+      google.charts.setOnLoadCallback(drawBarColors);
+      function drawChart() {
+          var data = google.visualization.arrayToDataTable([
+              ['Tone', 'Value', { role: 'style' }],
+              ['Postive',     parseFloat(jQuery(pos).val()), 'green'],
+              ['Negative',      parseFloat(jQuery(neg).val()), 'red'],
+              ['Neutral',  parseFloat(jQuery(neut).val()), 'yellow']
+          ]);
+
+          var options = {
+              title: 'Tone',
+              chartArea: {width: '50%', height: '40%'},
+              bar: {groupWidth: "50%"},
+              legend: { position: "none" }
+              //colors: ['#b0120a']
+          };
+
+          var chart = new google.visualization.BarChart(document.getElementById('piechart_3d'));
+          chart.draw(data, options);
+      }
+      //var vl = parseInt(jQuery('#vol').val());
+
+      function drawBarColors() {
+          var data = google.visualization.arrayToDataTable([
+              ['Volume', 'Volume', { role: 'style' }],
+              ['Your Review',parseInt(jQuery('#vol').val()), 'c53711'],
+              ['Avg. Volume',parseInt(jQuery('#avg_vol').val()), '0000ff']
+              //['Benchmark Volume',58]
+          ]);
+
+          var options = {
+              title: 'Review Volume',
+              chartArea: {width: '50%'},
+              bar: {groupWidth: "40%"},
+              legend: {position: 'none'}
+
+              //colors: ['#00ff00']
+
+          };
+          var chart = new google.visualization.BarChart(document.getElementById('chart_div'));
+          chart.draw(data, options);
+      }
+  </script>
+</head>
+
+
+
+<h2> Automated Metareview Metrics </h2>
+<br>
+<table class ="metrics">
+  <tr>
+    <th>Metric</th>
+    <th>Score</th>
+
+  </tr>
+  <tr>
+    <td>Review volume:</td>
+    <td id="chart_div" style="width: 500px; height: 180px;"><br>Volume: <%= @volume %></td>
+  </tr>
+  <tr>
+    <td>Plagiarism:</td>
+    <td class ="upper" style="color: green"><b><%= @plagiarism %></b></td>
+
+  </tr>
+  <tr>
+    <td>Tone:</td>
+    <!--<td></td>-->
+    <td  id="piechart_3d" style="width: 500px; height: 200px;"></td>
+  </tr>
+
+
+
+
+</table>
+<%= hidden_field_tag "pos", @tone_p, { :id => "pos" } %>
+<%= hidden_field_tag "neg", @tone_ng, { :id => "neg" } %>
+<%= hidden_field_tag "neut", @tone_n, { :id => "neut" } %>
+<%= hidden_field_tag "vol", @volume, { :id => "vol" } %>
+<%= hidden_field_tag "avg_vol", @avg_volume, { :id => "avg_vol" } %>
+
+<% array_not_empty = 0 %>
+<% @sorted_responses = Array.new %>
+<% @prev = Response.where(:map_id => @map_id) %>
+<% for element in @prev %>
+    <% array_not_empty = 1 %>
+    <% @sorted_responses << element %>
+<% end %>
+
+<% if (array_not_empty == 1) %>
+    <% @sorted_responses = @sorted_responses.sort_by {|obj| obj.updated_at} # the latest should be at the last%>
+    <% @latest_response = @sorted_responses.last %>
+<% end %>
+<!--%= @response_id = Response.find_by_map_id(@map_id) %-->
+<%= link_to "Edit", {:controller => 'response', :action => 'edit', :id => @latest_response.id } %>
+<br>
+<br>
+<%= link_to 'Back to Reviews List', :controller => 'student_review', :action =>'list', :id => @reviewer_id %>
+<style>
+  /*table, th, td {*/
+  /*border: 1px solid black;*/
+  /*}*/
+  table {
+    font-family:Arial, Helvetica, sans-serif;
+    color:#666;
+    font-size:12px;
+    text-shadow: 1px 1px 0px #fff;
+    background:#eaebec;
+    margin:20px;
+    border:#ccc 1px solid;
+    -moz-border-radius:3px;
+    -webkit-border-radius:3px;
+    border-radius:3px;
+    height: 45%;
+    width: 50%;
+
+    -moz-box-shadow: 0 1px 2px #d1d1d1;
+    -webkit-box-shadow: 0 1px 2px #d1d1d1;
+    box-shadow: 0 1px 2px #d1d1d1;
+  }
+  table th {
+    padding:21px 25px 22px 25px;
+    border-top:1px solid #fafafa;
+    border-bottom:1px solid #e0e0e0;
+
+    background: #ededed;
+    background: -webkit-gradient(linear, left top, left bottom, from(#ededed), to(#ebebeb));
+    background: -moz-linear-gradient(top,  #ededed,  #ebebeb);
+  }
+  table th:first-child {
+    text-align: left;
+    padding-left:20px;
+  }
+  table tr:first-child th:first-child {
+    -moz-border-radius-topleft:3px;
+    -webkit-border-top-left-radius:3px;
+    border-top-left-radius:3px;
+  }
+  table tr:first-child th:last-child {
+    -moz-border-radius-topright:3px;
+    -webkit-border-top-right-radius:3px;
+    border-top-right-radius:3px;
+  }
+  table tr {
+    text-align: center;
+    padding-left:20px;
+  }
+  table td:first-child {
+    text-align: left;
+    padding-left:20px;
+    border-left: 0;
+  }
+  table td {
+    padding:18px;
+    border-top: 1px solid #ffffff;
+    border-bottom:1px solid #e0e0e0;
+    border-left: 1px solid #e0e0e0;
+
+    background: #fafafa;
+    background: -webkit-gradient(linear, left top, left bottom, from(#fbfbfb), to(#fafafa));
+    background: -moz-linear-gradient(top,  #fbfbfb,  #fafafa);
+  }
+  table tr.even td {
+    background: #f6f6f6;
+    background: -webkit-gradient(linear, left top, left bottom, from(#f8f8f8), to(#f6f6f6));
+    background: -moz-linear-gradient(top,  #f8f8f8,  #f6f6f6);
+  }
+  table tr:last-child td {
+    border-bottom:0;
+  }
+  table tr:last-child td:first-child {
+    -moz-border-radius-bottomleft:3px;
+    -webkit-border-bottom-left-radius:3px;
+    border-bottom-left-radius:3px;
+  }
+  table tr:last-child td:last-child {
+    -moz-border-radius-bottomright:3px;
+    -webkit-border-bottom-right-radius:3px;
+    border-bottom-right-radius:3px;
+  }
+  table tr:hover td {
+    background: #f2f2f2;
+    background: -webkit-gradient(linear, left top, left bottom, from(#f2f2f2), to(#f0f0f0));
+    background: -moz-linear-gradient(top,  #f2f2f2,  #f0f0f0);
+  }
+  td.upper {
+    text-transform: uppercase;
+  }
+</style>
+
+

--- a/app/views/response/response.html.erb
+++ b/app/views/response/response.html.erb
@@ -15,6 +15,82 @@ jQuery(document).ready(function() {
             autoRelease: true
         }); 
     });
+
+    jQuery('#save').click(function(e){
+
+        var respData = [];
+        $('textarea').each(function () {
+            respData.push($(this).val());
+        });
+        var rev = {submission: "my submission", reviews: respData.join(' ').toString(), rubric: "my rubric"};
+
+        //alert(JSON.stringify(rev));
+        var volReq = $.ajax({
+            url: "http://peerlogic.csc.ncsu.edu/metareview/metareviewgenerator/volume",
+            type: "POST",
+            contentType: "application/json; charset=utf-8",
+            dataType: 'json',
+            async: false,
+            data: JSON.stringify(rev),
+            success: function (data) {
+                //alert("Volume is: "+data.volume);
+            },
+            failure: function (errMsg) {
+                //alert('nope!');
+                alert(errMsg);
+            }
+        });
+        var toneReq = $.ajax({
+            url: "http://peerlogic.csc.ncsu.edu/metareview/metareviewgenerator/tone",
+            type: "POST",
+            contentType: "application/json; charset=utf-8",
+            dataType: 'json',
+            async: false,
+            data: JSON.stringify(rev),
+            success: function (data) {
+            },
+            failure: function (errMsg) {
+                //alert('nope!');
+                alert(errMsg);
+            }
+        });
+
+        var plagReq = $.ajax({
+            url: "http://peerlogic.csc.ncsu.edu/metareview/metareviewgenerator/plagiarism",
+            type: "POST",
+            contentType: "application/json; charset=utf-8",
+            dataType: 'json',
+            async: false,
+            data: JSON.stringify(rev),
+            success: function (data) {
+                //alert("Postive Tone is: "+data.tone_positive + ", Neg tone is: "+data.tone_negative + ", Neutral tone is: "+data.tone_neutral );
+            },
+            failure: function (errMsg) {
+                //alert('nope!');
+                alert(errMsg);
+            }
+        });
+
+        $.when(volReq, toneReq, plagReq).then(function (d1, d2, d4) {
+            //alert("AutoMetaReview metrics: \nVolume is:" + d1[0].volume + "\nPostive Tone is: " + d2[0].tone_positive + ", Neg tone is: " + d2[0].tone_negative + ", Neutral tone is: " + d2[0].tone_neutral + "\n" + "Plagiarism: " + d4[0].plagiarism);
+            jQuery('#isSubmit').val('No');
+            jQuery('#volume').val(d1[0].volume);
+            jQuery('#plagiarism').val(d4[0].plagiarism);
+            jQuery('#tone_p').val(d2[0].tone_positive);
+            jQuery('#tone_n').val(d2[0].tone_neutral);
+            jQuery('#tone_ng').val(d2[0].tone_negative);
+            jQuery('#auto_metareview').val('Yes');
+        });
+
+    })
+
+    $(function(){
+        $("form").sisyphus({
+            locationBased: true,
+            autoRelease: true
+        });
+    });
+
 })
 </script>
 
@@ -103,7 +179,8 @@ jQuery(document).ready(function() {
 
     <br/>
     <br>
-    <%= submit_tag "Save "+@title, :name => "save" %>
+    <b>Note: Save the review to see the meta-review metrics before you submit </b><br>
+    <%= submit_tag "Save "+@title, :name => "save", :id => "save" %>
     <!--#E1600 check title for selfreview to show submit button-->
     <% if @title && ((@title.eql? 'Review') || (@title.eql? 'Self Review')) %>
         <%= submit_tag "Submit "+@title, :name => "Submit", :id => "Submit" %>
@@ -111,6 +188,12 @@ jQuery(document).ready(function() {
     <% end %>
     <%= hidden_field_tag('return', @return) %>
     <%= hidden_field_tag  "isSubmit", :id=>"isSubmit" %>
+    <%= hidden_field_tag "auto_metareview", :id=>"auto_metareview" %>
+    <%= hidden_field_tag "volume", :id=>"volume" %>
+    <%= hidden_field_tag "plagiarism", :id=>"plagiarism" %>
+    <%= hidden_field_tag "tone_p", :id=>"tone_p" %>
+    <%= hidden_field_tag "tone_n", :id=>"tone_n" %>
+    <%= hidden_field_tag "tone_ng", :id=>"tone_ng" %>
 <% end %>
 <!--Check whether there is a UploadFile question.-->
 <%@questions.each do |question| %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -311,6 +311,7 @@ Expertiza::Application.routes.draw do
       get :show_calibration_results_for_student
       post :custom_create
       get :pending_surveys
+      get :autometareview
     end
   end
 


### PR DESCRIPTION
As part of the CSC 630 Independent Study under Prof. Ed Gehringer, I have added/ changed the following views and controllers:

1. Views/autometareview.html.erb -> Added the new view for automated meta review metrics that shows up when a reviewer **saves** a review. It displays the metrics of volume, plagiarism and tone. The volume metric is also compared with the average volume of reviews for that round.

2. controllers/response_controller.rb -> added the autometareview method that contains the instance variables of metrics that are used by the view and also calculates the average volume of the reviews for that round.

3. views/response.html.erb -> added the code that calls the Peerlogic webservice when a user clicks the save button. The review comments are concatenated and sent to the webservice which then returns the metrics which are sent as params to the #create method in response controller. These params are then propagated along other methods to the autometareview method.

4. routes.rb -> added the route for the new view.
