### PR TITLE
E1821. Regularize Expertiza DB schema

### DIFF
--- a/db/migrate/20180427030840_remove_duplicates_deadline_types.rb
+++ b/db/migrate/20180427030840_remove_duplicates_deadline_types.rb
@@ -1,0 +1,18 @@
+class RemoveDuplicatesDeadlineTypes < ActiveRecord::Migration
+  def up
+
+     execute <<-SQL
+      update due_dates set deadline_type_id=7 where deadline_type_id=9     
+     SQL
+
+     execute <<-SQL
+      delete from deadline_types where id=9     
+     SQL
+	
+  end
+
+  def down
+     
+  end
+ 
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180104141248) do
+ActiveRecord::Schema.define(version: 20180427030840) do
 
   create_table "answer_tags", force: :cascade do |t|
     t.integer  "answer_id",                limit: 4


### PR DESCRIPTION
E1821 - Regularization of Expertiza Database

Proposed Changes:-

-Created a rails migration for deadline_types table to remove duplicate entry (Signup, ID = 9).
-Updated records in due_dates tables which referenced deadline_types table with ID = 9.

@Winbobob