### PR TITLE
E1854. Improve self-review  Link peer review & self-review to derive grades

### DIFF
--- a/app/controllers/grades_controller.rb
+++ b/app/controllers/grades_controller.rb
@@ -123,7 +123,7 @@ class GradesController < ApplicationController
       vmquestions = questionnaire.questions
       vm.add_questions(vmquestions)
       vm.add_team_members(@team)
-      vm.add_reviews(@participant, @team, @assignment.varying_rubrics_by_round?)
+      vm.add_reviews(@participant, @team, @assignment.varying_rubrics_by_round?, current_role_name)
       vm.get_number_of_comments_greater_than_10_words
       @vmlist << vm
     end

--- a/app/controllers/grades_controller.rb
+++ b/app/controllers/grades_controller.rb
@@ -80,6 +80,9 @@ class GradesController < ApplicationController
     retrieve_questions questionnaires
     # @pscore has the newest versions of response for each response map, and only one for each response map (unless it is vary rubric by round)
     @pscore = @participant.scores(@questions)
+    if @assignment.is_selfreview_enabled?
+      @cscore = @participant.scores(@questions, true)
+    end
     make_chart
     @topic_id = SignedUpTeam.topic_id(@participant.assignment.id, @participant.user_id)
     @stage = @participant.assignment.get_current_stage(@topic_id)
@@ -102,6 +105,10 @@ class GradesController < ApplicationController
     questionnaires = @assignment.questionnaires
     retrieve_questions questionnaires
     @pscore = @participant.scores(@questions)
+    # To calculate self review average
+    if @assignment.is_selfreview_enabled?
+      @cscore = @participant.scores(@questions, true)
+    end
     @vmlist = []
 
     # loop through each questionnaire, and populate the view model for all data necessary

--- a/app/models/assignment_participant.rb
+++ b/app/models/assignment_participant.rb
@@ -152,7 +152,6 @@ class AssignmentParticipant < Participant
   def reviews(composite = false)
     # ACS Always get assessments for a team
     # If self review enabled it pass self responses to calculate
-    puts composite
     if composite
       assignment_check = Assignment.find(self.team.parent_id)
       if assignment_check.is_selfreview_enabled?

--- a/app/models/author_feedback_questionnaire.rb
+++ b/app/models/author_feedback_questionnaire.rb
@@ -8,7 +8,7 @@ class AuthorFeedbackQuestionnaire < Questionnaire
     "feedback".to_sym
   end
 
-  def get_assessments_for(participant)
+  def get_assessments_for(participant, composite = false)
     participant.feedback
   end
 end

--- a/app/models/author_feedback_questionnaire.rb
+++ b/app/models/author_feedback_questionnaire.rb
@@ -8,7 +8,7 @@ class AuthorFeedbackQuestionnaire < Questionnaire
     "feedback".to_sym
   end
 
-  def get_assessments_for(participant, composite = false)
+  def get_assessments_for(participant, _composite = false)
     participant.feedback
   end
 end

--- a/app/models/response_map.rb
+++ b/app/models/response_map.rb
@@ -14,12 +14,10 @@ class ResponseMap < ActiveRecord::Base
       @array_sort = []
       @sort_to = []
       # find maps based on self review and peer reviews
-      puts pid
       if pid.nil?
         maps = where(reviewee_id: team.id)
       else
         maps = where(reviewee_id: team.id, reviewer_id: pid)
-        puts where(reviewee_id: team.id, reviewer_id: pid).to_sql
       end
       maps.each do |map|
         next if map.response.empty?

--- a/app/models/response_map.rb
+++ b/app/models/response_map.rb
@@ -17,7 +17,8 @@ class ResponseMap < ActiveRecord::Base
       maps.each do |map|
         next if map.response.empty?
         @all_resp = Response.where(map_id: map.map_id).last
-        if map.type.eql?('ReviewResponseMap')
+        #if map.type.eql?('ReviewResponseMap')
+        if map.type.eql?('ReviewResponseMap') || map.type.eql?('SelfReviewResponseMap') #New Addition
           # If its ReviewResponseMap then only consider those response which are submitted.
           @array_sort << @all_resp if @all_resp.is_submitted
         else

--- a/app/models/response_map.rb
+++ b/app/models/response_map.rb
@@ -17,8 +17,7 @@ class ResponseMap < ActiveRecord::Base
       maps.each do |map|
         next if map.response.empty?
         @all_resp = Response.where(map_id: map.map_id).last
-        #if map.type.eql?('ReviewResponseMap')
-        if map.type.eql?('ReviewResponseMap') || map.type.eql?('SelfReviewResponseMap') #New Addition
+        if map.type.eql?('ReviewResponseMap')
           # If its ReviewResponseMap then only consider those response which are submitted.
           @array_sort << @all_resp if @all_resp.is_submitted
         else

--- a/app/models/response_map.rb
+++ b/app/models/response_map.rb
@@ -7,17 +7,25 @@ class ResponseMap < ActiveRecord::Base
   end
 
   # return latest versions of the responses
-  def self.get_assessments_for(team)
+  def self.get_assessments_for(team, pid = nil)
     responses = []
     stime = Time.now
     if team
       @array_sort = []
       @sort_to = []
-      maps = where(reviewee_id: team.id)
+      # find maps based on self review and peer reviews
+      puts pid
+      if pid.nil?
+        maps = where(reviewee_id: team.id)
+      else
+        maps = where(reviewee_id: team.id, reviewer_id: pid)
+        puts where(reviewee_id: team.id, reviewer_id: pid).to_sql
+      end
       maps.each do |map|
         next if map.response.empty?
         @all_resp = Response.where(map_id: map.map_id).last
-        if map.type.eql?('ReviewResponseMap')
+        # Add all response self + peer
+        if map.type.eql?('ReviewResponseMap') || map.type.eql?("SelfReviewResponseMap")
           # If its ReviewResponseMap then only consider those response which are submitted.
           @array_sort << @all_resp if @all_resp.is_submitted
         else

--- a/app/models/review_questionnaire.rb
+++ b/app/models/review_questionnaire.rb
@@ -8,8 +8,8 @@ class ReviewQuestionnaire < Questionnaire
     "review".to_sym
   end
 
-  def get_assessments_for(participant)
-    participant.reviews
+  def get_assessments_for(participant, composite = false)
+    participant.reviews(composite)
   end
 
   # return  the responses for specified round, for varying rubric feature -Yang

--- a/app/models/teammate_review_questionnaire.rb
+++ b/app/models/teammate_review_questionnaire.rb
@@ -8,7 +8,7 @@ class TeammateReviewQuestionnaire < Questionnaire
     "teammate".to_sym
   end
 
-  def get_assessments_for(participant)
+  def get_assessments_for(participant, composite = false)
     participant.teammate_reviews
   end
 end

--- a/app/models/teammate_review_questionnaire.rb
+++ b/app/models/teammate_review_questionnaire.rb
@@ -8,7 +8,7 @@ class TeammateReviewQuestionnaire < Questionnaire
     "teammate".to_sym
   end
 
-  def get_assessments_for(participant, composite = false)
+  def get_assessments_for(participant, _composite = false)
     participant.teammate_reviews
   end
 end

--- a/app/models/vm_question_response.rb
+++ b/app/models/vm_question_response.rb
@@ -51,7 +51,6 @@ class VmQuestionResponse
                 end
       #variable to store self review
       @store_needed_self_review = nil
-
       #find and selected self reviewers based on current user role
       self_reviews = SelfReviewResponseMap.get_assessments_for(team) # Get all Self Reviews for the team
       self_reviews.each do |review|
@@ -69,16 +68,14 @@ class VmQuestionResponse
           end
         end
       end
-
       #find and add all peer reviewers
       reviews.each do |review|
         review_mapping = ReviewResponseMap.find(review.map_id)
-        if review_mapping && review_mapping.present?  #new addition
+        if review_mapping && review_mapping.present?
           participant = Participant.find(review_mapping.reviewer_id)
           @list_of_reviewers << participant
         end
       end
-
       #add all reviews i.e self  + peer , based on the role and type of assignment
       if @store_needed_self_review != nil and current_role_name.eql? "Student"
         @list_of_reviews = reviews + [@store_needed_self_review]
@@ -87,7 +84,6 @@ class VmQuestionResponse
       else
         @list_of_reviews = reviews
       end
-
     elsif @questionnaire_type == "AuthorFeedbackQuestionnaire"
       reviews = participant.feedback # feedback reviews
       reviews.each do |review|

--- a/app/models/vm_question_response.rb
+++ b/app/models/vm_question_response.rb
@@ -49,14 +49,29 @@ class VmQuestionResponse
                 else
                   ReviewResponseMap.get_assessments_for(team)
                 end
+      self_reviews = SelfReviewResponseMap.get_assessments_for(team) #New Addition
+      self_reviews.each do |review|
+        self_review_mapping = SelfReviewResponseMap.find_by(review.map_id) #New addition
+        #if self_review_mapping.present?
+
+        if self_review_mapping && self_review_mapping.present? #New addition
+          participant = Participant.find(self_review_mapping.reviewer_id) #New addition
+          @list_of_reviewers << participant #New addition
+        end
+      end
+
       reviews.each do |review|
         review_mapping = ReviewResponseMap.find(review.map_id)
-        if review_mapping.present?
+        #self_review_mapping = SelfReviewResponseMap.find_by(review.map_id) #New addition
+        #if review_mapping.present?
+        if review_mapping && review_mapping.present?  #new addition
           participant = Participant.find(review_mapping.reviewer_id)
           @list_of_reviewers << participant
         end
+
       end
-      @list_of_reviews = reviews
+      #@list_of_reviews = reviews
+      @list_of_reviews = reviews + self_reviews
     elsif @questionnaire_type == "AuthorFeedbackQuestionnaire"
       reviews = participant.feedback # feedback reviews
       reviews.each do |review|
@@ -87,6 +102,13 @@ class VmQuestionResponse
 
     reviews.each do |review|
       answers = Answer.where(response_id: review.response_id)
+      answers.each do |answer|
+        add_answer(answer)
+      end
+    end
+    #New Addition
+    if self_reviews
+      answers = Answer.where(response_id: self_reviews[0].response_id)
       answers.each do |answer|
         add_answer(answer)
       end

--- a/app/models/vm_question_response.rb
+++ b/app/models/vm_question_response.rb
@@ -49,24 +49,28 @@ class VmQuestionResponse
                 else
                   ReviewResponseMap.get_assessments_for(team)
                 end
-
+      #variable to store self review
       @store_needed_self_review = nil
-      self_reviews = SelfReviewResponseMap.get_assessments_for(team) #New Addition
+
+      #find and selected self reviewers based on current user role
+      self_reviews = SelfReviewResponseMap.get_assessments_for(team) # Get all Self Reviews for the team
       self_reviews.each do |review|
-        self_review_mapping = SelfReviewResponseMap.find(review.map_id) #New addition
+        self_review_mapping = SelfReviewResponseMap.find(review.map_id) # Find respons maps baed on map id
         if self_review_mapping && self_review_mapping.present?
+          # if the current role is not student fetch all self reviewers i.e instructor view
           if current_role_name != "Student"
             @list_of_reviewers << participant
           end
-          if participant.id == self_review_mapping.reviewer_id#New addition
-            participant = Participant.find(self_review_mapping.reviewer_id) #New addition
-            @list_of_reviewers << participant #New addition
-            @store_needed_self_review = review #New addition
+          # if it is a student view show only that particular students self review
+          if participant.id == self_review_mapping.reviewer_id
+            participant = Participant.find(self_review_mapping.reviewer_id)
+            @list_of_reviewers << participant
+            @store_needed_self_review = review
           end
         end
       end
 
-
+      #find and add all peer reviewers
       reviews.each do |review|
         review_mapping = ReviewResponseMap.find(review.map_id)
         if review_mapping && review_mapping.present?  #new addition
@@ -75,6 +79,7 @@ class VmQuestionResponse
         end
       end
 
+      #add all reviews i.e self  + peer , based on the role and type of assignment
       if @store_needed_self_review != nil and current_role_name.eql? "Student"
         @list_of_reviews = reviews + [@store_needed_self_review]
       elsif @store_needed_self_review != nil
@@ -82,8 +87,6 @@ class VmQuestionResponse
       else
         @list_of_reviews = reviews
       end
-
-
 
     elsif @questionnaire_type == "AuthorFeedbackQuestionnaire"
       reviews = participant.feedback # feedback reviews
@@ -119,7 +122,7 @@ class VmQuestionResponse
         add_answer(answer)
       end
     end
-    #New Addition
+    # Find all answers based on user role
     if current_role_name != "Student" and @store_needed_self_review != nil
       answers = Answer.where(response_id: self_reviews.each {|self_review| self_review.response_id})
       answers.each do |answer|

--- a/app/models/vm_question_response.rb
+++ b/app/models/vm_question_response.rb
@@ -49,29 +49,26 @@ class VmQuestionResponse
                 else
                   ReviewResponseMap.get_assessments_for(team)
                 end
+
+      @store_needed_self_review = nil
       self_reviews = SelfReviewResponseMap.get_assessments_for(team) #New Addition
       self_reviews.each do |review|
-        self_review_mapping = SelfReviewResponseMap.find_by(review.map_id) #New addition
-        #if self_review_mapping.present?
-
-        if self_review_mapping && self_review_mapping.present? #New addition
+        self_review_mapping = SelfReviewResponseMap.find(review.map_id) #New addition
+        if self_review_mapping && self_review_mapping.present? and participant.id == self_review_mapping.reviewer_id#New addition
           participant = Participant.find(self_review_mapping.reviewer_id) #New addition
           @list_of_reviewers << participant #New addition
+          @store_needed_self_review = review #New addition
         end
       end
 
       reviews.each do |review|
         review_mapping = ReviewResponseMap.find(review.map_id)
-        #self_review_mapping = SelfReviewResponseMap.find_by(review.map_id) #New addition
-        #if review_mapping.present?
         if review_mapping && review_mapping.present?  #new addition
           participant = Participant.find(review_mapping.reviewer_id)
           @list_of_reviewers << participant
         end
-
       end
-      #@list_of_reviews = reviews
-      @list_of_reviews = reviews + self_reviews
+      @list_of_reviews = reviews + [@store_needed_self_review]
     elsif @questionnaire_type == "AuthorFeedbackQuestionnaire"
       reviews = participant.feedback # feedback reviews
       reviews.each do |review|
@@ -108,7 +105,8 @@ class VmQuestionResponse
     end
     #New Addition
     if self_reviews
-      answers = Answer.where(response_id: self_reviews[0].response_id)
+
+      answers = Answer.where(response_id: @store_needed_self_review.response_id)
       answers.each do |answer|
         add_answer(answer)
       end

--- a/app/models/vm_question_response.rb
+++ b/app/models/vm_question_response.rb
@@ -54,10 +54,12 @@ class VmQuestionResponse
       self_reviews = SelfReviewResponseMap.get_assessments_for(team) #New Addition
       self_reviews.each do |review|
         self_review_mapping = SelfReviewResponseMap.find(review.map_id) #New addition
-        if self_review_mapping && self_review_mapping.present? and participant.id == self_review_mapping.reviewer_id#New addition
-          participant = Participant.find(self_review_mapping.reviewer_id) #New addition
-          @list_of_reviewers << participant #New addition
-          @store_needed_self_review = review #New addition
+        if self_review_mapping && self_review_mapping.present?
+          if participant.id == self_review_mapping.reviewer_id#New addition
+            participant = Participant.find(self_review_mapping.reviewer_id) #New addition
+            @list_of_reviewers << participant #New addition
+            @store_needed_self_review = review #New addition
+          end
         end
       end
 
@@ -68,7 +70,15 @@ class VmQuestionResponse
           @list_of_reviewers << participant
         end
       end
-      @list_of_reviews = reviews + [@store_needed_self_review]
+
+      unless @store_needed_self_review.nil?
+        @list_of_reviews = reviews + [@store_needed_self_review]
+      else
+        @list_of_reviews = reviews
+      end
+
+
+
     elsif @questionnaire_type == "AuthorFeedbackQuestionnaire"
       reviews = participant.feedback # feedback reviews
       reviews.each do |review|
@@ -104,8 +114,7 @@ class VmQuestionResponse
       end
     end
     #New Addition
-    if self_reviews
-
+    unless @store_needed_self_review == nil
       answers = Answer.where(response_id: @store_needed_self_review.response_id)
       answers.each do |answer|
         add_answer(answer)

--- a/app/models/vm_question_response.rb
+++ b/app/models/vm_question_response.rb
@@ -57,7 +57,7 @@ class VmQuestionResponse
         self_review_mapping = SelfReviewResponseMap.find(review.map_id) # Find respons maps baed on map id
         if self_review_mapping && self_review_mapping.present?
           # if the current role is not student fetch all self reviewers i.e instructor view
-          if current_role_name != "Student"
+          if !current_role_name.eql? "Student"
             @list_of_reviewers << participant
           end
           # if it is a student view show only that particular students self review

--- a/app/models/vm_question_response.rb
+++ b/app/models/vm_question_response.rb
@@ -49,9 +49,9 @@ class VmQuestionResponse
                 else
                   ReviewResponseMap.get_assessments_for(team)
                 end
-      #variable to store self review
+      # variable to store self review
       @store_needed_self_review = nil
-      #find and selected self reviewers based on current user role
+      # find and selected self reviewers based on current user role
       self_reviews = SelfReviewResponseMap.get_assessments_for(team) # Get all Self Reviews for the team
       self_reviews.each do |review|
         self_review_mapping = SelfReviewResponseMap.find(review.map_id) # Find respons maps baed on map id
@@ -68,7 +68,7 @@ class VmQuestionResponse
           end
         end
       end
-      #find and add all peer reviewers
+      # Find and add all peer reviewers
       reviews.each do |review|
         review_mapping = ReviewResponseMap.find(review.map_id)
         if review_mapping && review_mapping.present?
@@ -76,10 +76,10 @@ class VmQuestionResponse
           @list_of_reviewers << participant
         end
       end
-      #add all reviews i.e self  + peer , based on the role and type of assignment
-      if @store_needed_self_review != nil and current_role_name.eql? "Student"
+      # Add all reviews i.e self  + peer , based on the role and type of assignment
+      if !@store_needed_self_review.nil? and current_role_name.eql? "Student"
         @list_of_reviews = reviews + [@store_needed_self_review]
-      elsif @store_needed_self_review != nil
+      elsif !@store_needed_self_review.nil?
         @list_of_reviews = reviews + self_reviews
       else
         @list_of_reviews = reviews
@@ -119,12 +119,12 @@ class VmQuestionResponse
       end
     end
     # Find all answers based on user role
-    if current_role_name != "Student" and @store_needed_self_review != nil
+    if current_role_name != "Student" and !@store_needed_self_review.nil?
       answers = Answer.where(response_id: self_reviews.each {|self_review| self_review.response_id})
       answers.each do |answer|
         add_answer(answer)
       end
-    elsif @store_needed_self_review != nil
+    elsif !@store_needed_self_review.nil?
       answers = Answer.where(response_id: @store_needed_self_review.response_id)
       answers.each do |answer|
         add_answer(answer)

--- a/app/models/vm_question_response_row.rb
+++ b/app/models/vm_question_response_row.rb
@@ -51,11 +51,9 @@ class VmQuestionResponseRow
     @total_avg_score = average_score_for_row
     @peer_total = (@total_avg_score * @no_of_columns) - @self_review_score_of_row
     @peer_avg = @peer_total / (@no_of_columns - 1)
-
-    unless @peer_avg.nan?
-      #apply your formula here
-      #composite_score = (@self_review_score_of_row + @peer_avg)/ 100
-      composite_score = (100 - (@self_review_score_of_row - @peer_avg).abs) * (@peer_avg/100)
+    if !@peer_avg.nan?
+      # Apply your formula here
+      composite_score = (100 - (@self_review_score_of_row - @peer_avg).abs) * (@peer_avg / 100)
       composite_score.round(2)
     else
       composite_score = "Not applicable"

--- a/app/models/vm_question_response_row.rb
+++ b/app/models/vm_question_response_row.rb
@@ -33,16 +33,33 @@ class VmQuestionResponseRow
 
   def average_score_for_row
     row_average_score = 0.0
-    no_of_columns = 0.0 # Counting reviews that are not null
+    @no_of_columns = 0.0 # Counting reviews that are not null
+    @self_review_score_of_row = @score_row[-1].score_value
     @score_row.each do |score|
       if score.score_value.is_a? Numeric
-        no_of_columns += 1
+        @no_of_columns += 1
         row_average_score += score.score_value.to_f
       end
     end
-    unless no_of_columns.zero?
-      row_average_score /= no_of_columns
+    unless @no_of_columns.zero?
+      row_average_score /= @no_of_columns
       row_average_score.round(2)
     end
   end
+
+  def composite_score_for_row
+    @total_avg_score = average_score_for_row
+    @peer_total = (@total_avg_score * @no_of_columns) - @self_review_score_of_row
+    @peer_avg = @peer_total / (@no_of_columns - 1)
+
+    unless @peer_avg.nan?
+      #apply your formula here
+      #composite_score = (@self_review_score_of_row + @peer_avg)/ 100
+      composite_score = (100 - (@self_review_score_of_row - @peer_avg).abs) * (@peer_avg/100)
+      composite_score.round(2)
+    else
+      composite_score = "Not applicable"
+    end
+  end
 end
+

--- a/app/views/grades/_participant.html.erb
+++ b/app/views/grades/_participant.html.erb
@@ -8,6 +8,7 @@
 <% 
     participant = pscore[:participant]
     rscore_review = Rscore.new(pscore,:review) if pscore[:review]
+    cscore_review = Rscore.new(@cscore,:review) if @cscore[:review]
     rscore_metareview = Rscore.new(pscore,:metareview) if pscore[:metareview]
     rscore_feedback = Rscore.new(pscore,:feedback) if pscore[:feedback]
     rscore_teammate = Rscore.new(pscore,:teammate) if pscore[:teammate]
@@ -142,6 +143,9 @@
       <% end %>
       </TD>
     <% end %>
+  <TD align="center">
+    <%= cscore_review.my_avg.is_a?(Float)?sprintf("%.2f",cscore_review.my_avg):cscore_review.my_avg %><%= score_postfix %>
+  </TD>
 </TR>
 
 <% if (controller.action_name != "view_my_scores" and index == team_size - 1) or controller.action_name == "view_my_scores" %>

--- a/app/views/grades/_participant_charts.html.erb
+++ b/app/views/grades/_participant_charts.html.erb
@@ -61,7 +61,11 @@
           
   </div>
 </th>
-  
+
+<th style="text-align:center;" WIDTH="<%= colwidth %>%">&nbsp;
+  <div class="circle" id="self-review-circle">
+  </div>
+</th>
 </TR>
 
 <script type="text/javascript">
@@ -93,7 +97,17 @@
     duration:       700,
     textClass:      'circles-final'  
   });
-
+  var myCircle = Circles.create({
+      id:           'self-review-circle',
+      radius:       35,
+      value:        <%= @cscore[:total_score].to_i %>,
+      maxValue:     100,
+      width:        15,
+      text:         '<%=@cscore[:total_score].to_i==-1? "N/A":@cscore[:total_score].to_i%>',
+      colors:       ['#99ffa4', '#077512'],
+      duration:       700,
+      textClass:      'circles-final'
+  });
 </script> 
 
 <style>

--- a/app/views/grades/_participant_title.html.erb
+++ b/app/views/grades/_participant_title.html.erb
@@ -12,6 +12,10 @@
 	<% colwidth = 15 %>
 <% end %>
 
+<%if @cscore %>
+  <% colwidth = 10 %>
+<%end%>
+
 <tr <% if prefix %>id='<%= prefix %>_1' style="background-color: #f9f9f9;"<% end %>>
 <th style="text-align:center;" WIDTH="<%= namecolwidth %>%">&nbsp;</th>
 <th style="text-align:center;" COLSPAN="2" WIDTH="<%= colwidth*2 %>%">Submitted work</th>
@@ -22,7 +26,8 @@
 <% if has_team_and_metareview?[:has_team] %>
   <th style="text-align:center;" COLSPAN="2" WIDTH="<%= colwidth*2 %>%">Teammate Review</th>
 <% end %>
-<th style="text-align:center;" WIDTH="<%= colwidth %>%">&nbsp;</th></tr>           
+<th style="text-align:center;" WIDTH="<%= colwidth %>%">&nbsp;</th></tr>
+<th style="text-align:center;" WIDTH="<%= colwidth %>%">&nbsp;</th></tr>
 
 <tr <% if prefix %>id='<%= prefix %>_2' style="display:none; background-color: #f9f9f9;"<% end %>>
 <th style="text-align:left;" WIDTH="<%= namecolwidth %>%" ALIGN="LEFT">Contributor</th>
@@ -39,5 +44,9 @@
 	<th style="text-align:center;" WIDTH="<%= colwidth %>%">Average</th>
 	<th style="text-align:center;" WIDTH="<%= colwidth %>%">Range </th>
 <% end %>   
-<th style="text-align:center;" WIDTH="<%= colwidth %>%">Final Score</th></tr>    
-    
+<th style="text-align:center;" WIDTH="<%= colwidth %>%">Final Score</th>
+
+<%if @cscore%>
+  <th style="text-align:center;"  WIDTH="<%= colwidth %>%">Final Self Review Score</th>
+<%end%>
+</tr>

--- a/app/views/grades/view_team.html.erb
+++ b/app/views/grades/view_team.html.erb
@@ -28,6 +28,7 @@
 <% end %>
 <!--Obtain only review scores-->
 <% rscore_review = Rscore.new(@pscore,:review) if @pscore[:review] %>
+<%= %>
 <h4>Average peer review score: <span class = "c5"><%= rscore_review.my_avg.is_a?(Float)? sprintf("%.2f",rscore_review.my_avg): rscore_review.my_avg %></span></h4>
 <!--Toggle submission-->
 <button onclick="toggleFunction('<%= @participant.id.to_s%>')" class="btn btn-default">Show Submission</button>
@@ -124,7 +125,11 @@
 
                   <% else %>
                       <% user_name = User.find(Participant.find(ResponseMap.find(Response.find(review.id).map_id).reviewer_id).user_id).fullname(session[:ip]).to_s %>
-                      <th class="sorter-false"> <a target="_blank" href="../response/view?id=<%= review.id.to_s %>"  data-toggle="tooltip" data-placement="right" title="Click to see details"><%= user_name.to_s %></a>  </th>
+                      <% if review_type == 'SelfReviewResponseMap' %>
+                        <th class="sorter-false", bgcolor="aqua"> <a target="_blank" href="../response/view?id=<%= review.id.to_s %>"  data-toggle="tooltip" data-placement="right" title="Click to see details"><%= user_name.to_s %></a>  </th>
+                      <%else %>
+                        <th class="sorter-false"> <a target="_blank" href="../response/view?id=<%= review.id.to_s %>"  data-toggle="tooltip" data-placement="right" title="Click to see details"><%= user_name.to_s %></a>  </th>
+                      <%end%>
                   <% end %>
                   <% i += 1 %>
               <% end %>
@@ -175,7 +180,11 @@
                     <%= row.countofcomments.to_s %>
                   </td>
                   <td  class = 'cf' align="center">
-                    <%= row.composite_score_for_row.to_s %>
+                    <%if @assignment.is_selfreview_enabled and @current_role_name.eql? "Student"%>
+                      <%= row.composite_score_for_row.to_s %>
+                    <%else %>
+                      <%= "Not applicable" %>
+                    <%end %>
                   </td>
                 </tr>
                 <!--loop that creates the collapsed-by-default row, which lists all comments. -->

--- a/app/views/grades/view_team.html.erb
+++ b/app/views/grades/view_team.html.erb
@@ -111,13 +111,17 @@
 
                   <!-- instructors (or higher level users) see reviewer name, students see anonymized string -->
                   <% if (['Student'].include? @current_role_name) && @assignment.is_anonymous%>
-                      <th class="sorter-false"> <a target="_blank" href="../response/view?id=<%= review.id.to_s %>"  data-toggle="tooltip" data-placement="right" title="Click to see details">
-                      <% if review_type == 'SelfReviewResponseMap' %>
-                        <%= "Self Review "%>
-                      <%else%>
-                        <%= "Review " +   i.to_s %>
+                      <% if review_type == 'ReviewResponseMap' %>
+                          <th class="sorter-false"> <a target="_blank" href="../response/view?id=<%= review.id.to_s %>"  data-toggle="tooltip" data-placement="right" title="Click to see details">
+                          <%= "Review " +   i.to_s %>
+                          </a></th>
                       <%end%>
-                      </a>  </th>
+                      <% if review_type == 'SelfReviewResponseMap' %>
+                        <th class="sorter-false", bgcolor="aqua"> <a target="_blank" href="../response/view?id=<%= review.id.to_s %>"  data-toggle="tooltip" data-placement="right" title="Click to see details">
+                        <%= "Self-Review"%>
+                        </a></th>
+                      <%end%>
+
                   <% else %>
                       <% user_name = User.find(Participant.find(ResponseMap.find(Response.find(review.id).map_id).reviewer_id).user_id).fullname(session[:ip]).to_s %>
                       <th class="sorter-false"> <a target="_blank" href="../response/view?id=<%= review.id.to_s %>"  data-toggle="tooltip" data-placement="right" title="Click to see details"><%= user_name.to_s %></a>  </th>

--- a/app/views/grades/view_team.html.erb
+++ b/app/views/grades/view_team.html.erb
@@ -30,6 +30,12 @@
 <% rscore_review = Rscore.new(@pscore,:review) if @pscore[:review] %>
 <%= %>
 <h4>Average peer review score: <span class = "c5"><%= rscore_review.my_avg.is_a?(Float)? sprintf("%.2f",rscore_review.my_avg): rscore_review.my_avg %></span></h4>
+<%if @current_role_name.eql? "Student"%>
+  <% rscore_review = Rscore.new(@cscore,:review) if @pscore[:review] %>
+  <%= %>
+  <h4>Average Self review score: <span class = "c5"><%= rscore_review.my_avg.is_a?(Float)? sprintf("%.2f",rscore_review.my_avg): rscore_review.my_avg %></span></h4>
+<%end %>
+
 <!--Toggle submission-->
 <button onclick="toggleFunction('<%= @participant.id.to_s%>')" class="btn btn-default">Show Submission</button>
 <div id="<%= @participant.id.to_s%>" style="display:none;">

--- a/app/views/grades/view_team.html.erb
+++ b/app/views/grades/view_team.html.erb
@@ -98,7 +98,7 @@
             <thead>
             <tr>
               <th class="sorter-true">Criterion<span></span></th>
-            
+
               <% i = 1 %>
               <% vm.list_of_reviews.each do |review| %>
               <%
@@ -135,6 +135,9 @@
               <th class="sorter-false">
                 <span  data-toggle="tooltip" data-placement="right" title="A count of comments, for the respective question, which have word count > 10. The purpose of this metric is to represent how many comments for the question are of a substantial length to provide quality feedback.">metric-1</span>
               </th>
+              <th class="sorter-true" align="right" >
+              Composite Score<span></span>
+              </th>
 
             </tr>
             </thead>
@@ -145,7 +148,6 @@
             <!-- here, starts a series of nested loops. loops for the rows, and for the cells of the rows.-->
             <!-- additionally, there are hidden rows (expandable) which are also generated via iteration. -->
             <% vm.list_of_rows.each do |row| %>
-
                 <!-- notice the data-target. because we're toggling via looped code, we need to dynamically generate the identifier. -->
                 <tr data-toggle="collapse" class="accordion-toggle" data-target="#hid<%= row.question_id.to_s + vm.round.to_s %>">
                   <td class = 'cf' data-toggle="tooltip" title="<%= row.question_text %>"> <div style='float: left'><%= j.to_s %></div><div style='float: right'> &#<%= type_and_max(row) %>;</div>  </td>
@@ -171,6 +173,9 @@
                   </td>
                   <td  class = 'cf' align="center">
                     <%= row.countofcomments.to_s %>
+                  </td>
+                  <td  class = 'cf' align="center">
+                    <%= row.composite_score_for_row.to_s %>
                   </td>
                 </tr>
                 <!--loop that creates the collapsed-by-default row, which lists all comments. -->

--- a/app/views/grades/view_team.html.erb
+++ b/app/views/grades/view_team.html.erb
@@ -101,9 +101,23 @@
             
               <% i = 1 %>
               <% vm.list_of_reviews.each do |review| %>
+              <%
+                  review_map = ResponseMap.find(review.map_id)
+                  review_type = nil
+                  if review_map
+                    review_type =  review_map.type
+                  end
+              %>
+
                   <!-- instructors (or higher level users) see reviewer name, students see anonymized string -->
                   <% if (['Student'].include? @current_role_name) && @assignment.is_anonymous%>
-                      <th class="sorter-false"> <a target="_blank" href="../response/view?id=<%= review.id.to_s %>"  data-toggle="tooltip" data-placement="right" title="Click to see details"><%= "Review " + i.to_s %></a>  </th>
+                      <th class="sorter-false"> <a target="_blank" href="../response/view?id=<%= review.id.to_s %>"  data-toggle="tooltip" data-placement="right" title="Click to see details">
+                      <% if review_type == 'SelfReviewResponseMap' %>
+                        <%= "Self Review "%>
+                      <%else%>
+                        <%= "Review " +   i.to_s %>
+                      <%end%>
+                      </a>  </th>
                   <% else %>
                       <% user_name = User.find(Participant.find(ResponseMap.find(Response.find(review.id).map_id).reviewer_id).user_id).fullname(session[:ip]).to_s %>
                       <th class="sorter-false"> <a target="_blank" href="../response/view?id=<%= review.id.to_s %>"  data-toggle="tooltip" data-placement="right" title="Click to see details"><%= user_name.to_s %></a>  </th>

--- a/spec/controllers/grades_controller_spec.rb
+++ b/spec/controllers/grades_controller_spec.rb
@@ -43,7 +43,7 @@ describe GradesController do
 
     context 'when current assignment does not vary rubric by round' do
       it 'calculates scores and renders grades#view page' do
-        allow(Asrspec specsignmentQuestionnaire).to receive(:where).with(assignment_id: 1, used_in_round: 2).and_return([])
+        allow(AssignmentQuestionnaire).to receive(:where).with(assignment_id: 1, used_in_round: 2).and_return([])
         allow(ReviewResponseMap).to receive(:get_assessments_for).with(team).and_return([review_response])
         params = {id: 1}
         get :view, params

--- a/spec/controllers/grades_controller_spec.rb
+++ b/spec/controllers/grades_controller_spec.rb
@@ -43,7 +43,7 @@ describe GradesController do
 
     context 'when current assignment does not vary rubric by round' do
       it 'calculates scores and renders grades#view page' do
-        allow(AssignmentQuestionnaire).to receive(:where).with(assignment_id: 1, used_in_round: 2).and_return([])
+        allow(Asrspec specsignmentQuestionnaire).to receive(:where).with(assignment_id: 1, used_in_round: 2).and_return([])
         allow(ReviewResponseMap).to receive(:get_assessments_for).with(team).and_return([review_response])
         params = {id: 1}
         get :view, params
@@ -105,7 +105,7 @@ describe GradesController do
       allow(AssignmentQuestionnaire).to receive(:where).with(assignment_id: 1, used_in_round: 2).and_return([])
       assignment_questionnaire.used_in_round = nil
       allow(AssignmentQuestionnaire).to receive(:find_by).with(assignment_id: 1, questionnaire_id: 1).and_return(assignment_questionnaire)
-      allow(review_questionnaire).to receive(:get_assessments_for).with(participant).and_return([review_response])
+      allow(review_questionnaire).to receive(:get_assessments_for).with(participant, false).and_return([review_response])
       allow(Answer).to receive(:compute_scores).with([review_response], [question]).and_return(max: 95, min: 88, avg: 90)
       allow(assignment).to receive(:compute_total_score).with(any_args).and_return(100)
       params = {id: 1}

--- a/spec/models/assignment_particpant_spec.rb
+++ b/spec/models/assignment_particpant_spec.rb
@@ -108,7 +108,7 @@ describe AssignmentParticipant do
         score_map = {max: 100, min: 100, avg: 100}
         allow(AssignmentQuestionnaire).to receive(:find_by).with(assignment_id: 1, questionnaire_id: 1)
                                                            .and_return(double('AssignmentQuestionnaire', used_in_round: nil))
-        allow(review_questionnaire).to receive(:get_assessments_for).with(participant).and_return([response])
+        allow(review_questionnaire).to receive(:get_assessments_for).with(participant, false).and_return([response])
         allow(Answer).to receive(:compute_scores).with(any_args).and_return(score_map)
         participant.compute_assignment_score(question_hash, scores)
         expect(scores[:review][:assessments]).to eq([response])


### PR DESCRIPTION
Our project adds the ability see self reviews juxtaposed with peer reviews in the view my scores page(view/grades/view_team.html.erb) when seen from a students point of view if the self reviews have been enabled for that assignment. 

We also display the individuals composite scores for each question in the review based on a formula that takes the input as the average peer review score of that question and self review score.

We also propose a fix for the instructor's view for the assign grade view page(view/grades/view_team.html.erb)). Here we display the peer reviews of the team and the individual self reviews of the students who are a part of that team.

Future work would be to display the composite scores as well for each student member in that team view.
Also the total composite score needs to be available as a single value. Right now the composite score is calculate for each question individually. 

@team:
Ojas Barve (ovbarve@ncsu.edu) 
Senthil Kumar Sankar (ssankar9@ncsu.edu)
Sandeep Ghanta (sghanta@ncsu.edu)
Abhishu Mishra (amishra6@ncsu.edu)