### PR TITLE
Issue Fix 1332 - When a grade is saved, confirmation is needed

### DIFF
--- a/app/controllers/grades_controller.rb
+++ b/app/controllers/grades_controller.rb
@@ -174,10 +174,11 @@ class GradesController < ApplicationController
     @team.comment_for_submission = params[:comment_for_submission]
     begin
       @team.save
+      flash[:success] = 'Grade and comment for submission successfully saved!'
     rescue StandardError
       flash[:error] = $ERROR_INFO
     end
-    redirect_to controller: 'assignments', action: 'list_submissions', id: @team.parent_id
+    redirect_to controller: 'grades', action: 'view_team', id: participant.id
   end
 
   private

--- a/app/controllers/review_mapping_controller.rb
+++ b/app/controllers/review_mapping_controller.rb
@@ -370,11 +370,14 @@ class ReviewMappingController < ApplicationController
     review_grade.reviewer_id = session[:user].id
     begin
       review_grade.save!
+      flash[:success] = 'Grade and comment for reviewer successfully saved!'
     rescue StandardError
       flash[:error] = $ERROR_INFO
     end
-    # redirect_to controller: 'review_mapping', action: 'response_report', id: params[:assignment_id]
-    redirect_to controller: 'reports', action: 'response_report', id: params[:assignment_id]
+    respond_to do |format|
+      format.js {render action: 'save_grade_and_comment_for_reviewer.js.erb', layout: false}
+      format.html {redirect_to controller: 'reports', action: 'response_report', id: params[:assignment_id]}
+    end
   end
 
   # E1600

--- a/app/views/assignments/list_submissions.html.erb
+++ b/app/views/assignments/list_submissions.html.erb
@@ -38,7 +38,7 @@
           <% team_name_color = get_team_name_color_in_list_submission(team) %>
           <td><p style = <%="color:#{team_name_color}"%>><%= team.name %></p>
           <% unless participants.empty? %>
-            <%= link_to 'Assign Grade', { controller: 'grades', action: 'view_team', id: participants.first.id }, target: '_blank' %></td>
+            <%= link_to 'Assign Grade', { controller: 'grades', action: 'view_team', id: participants.first.id}, target: '_blank' %></td>
           <% end %>
         <% end %>
 

--- a/app/views/grades/view_team.html.erb
+++ b/app/views/grades/view_team.html.erb
@@ -235,7 +235,7 @@
   Grade: <%= label_tag 'grade_for_submission', @team.try(:grade_for_submission) %><br/>
   Comment: <%= label_tag 'comment_for_submission', @team.try(:comment_for_submission) %>
 <% else %>
-  <%= form_tag 'save_grade_and_comment_for_submission', remote: true do %>
+  <%= form_tag 'save_grade_and_comment_for_submission' do %>
     <%= hidden_field_tag :participant_id, params[:id] %>
     <%= number_field_tag 'grade_for_submission', @team.try(:grade_for_submission) ,min: 0, max: 100, maxlength: 3, size: 3, class: "form-control width-150", placeholder: 'Grade' %><br/>
     <%= text_area_tag 'comment_for_submission', @team.try(:comment_for_submission), size: '75x10', placeholder: 'Comment', class: "form-control width-500" %><br>

--- a/app/views/reports/_review_report.html.erb
+++ b/app/views/reports/_review_report.html.erb
@@ -5,8 +5,21 @@
   <script type='text/javascript'>
       $(window).load(function () {
           $("#myTable tbody").sortable().disableSelection();
+          $("#dialog").dialog({
+            autoOpen: false,
+            modal: true,
+            show: "blind",
+            hide: "blind",
+            buttons: {
+              Ok: function() {
+                $(this).dialog("close");
+              }
+            }
+          });
       });
   </script>
+
+  <div id="dialog" title="Success">Grade and comment for reviewer successfully saved!</div>
 
   <p> **In "Team reviewed" column text in:</p>
     <ul style="list-style-type:square">
@@ -108,7 +121,7 @@
           </td>
           <!--Assign grade and write comments-->
           <td align='left'>
-            <%= form_tag 'save_grade_and_comment_for_reviewer', remote: true do %>
+            <%= form_tag save_grade_and_comment_for_reviewer_review_mapping_index_path, remote: true do %>
               <%= hidden_field_tag :participant_id, r.id %>
               <%= hidden_field_tag :assignment_id, @id %>
               <%= number_field_tag 'grade_for_reviewer', r.review_grade.try(:grade_for_reviewer), min: 0, max: 100, maxlength: 3, size: 3, placeholder: 'Grade' %>

--- a/app/views/review_mapping/save_grade_and_comment_for_reviewer.js.erb
+++ b/app/views/review_mapping/save_grade_and_comment_for_reviewer.js.erb
@@ -1,0 +1,5 @@
+<% if flash[:success] %>
+$(function() {
+	$("#dialog").dialog("open");
+});
+<% end %>

--- a/spec/controllers/grades_controller_spec.rb
+++ b/spec/controllers/grades_controller_spec.rb
@@ -180,7 +180,7 @@ describe GradesController do
   end
 
   describe '#save_grade_and_comment_for_submission' do
-    it 'saves grade and comment for submission and redirects to assignments#list_submissions page' do
+    it 'saves grade and comment for submission and refreshes the grades#view_team page' do
       allow(AssignmentParticipant).to receive(:find_by).with(id: '1').and_return(participant)
       allow(participant).to receive(:team).and_return(build(:assignment_team, id: 2, parent_id: 8))
       params = {
@@ -190,7 +190,7 @@ describe GradesController do
       }
       post :save_grade_and_comment_for_submission, params
       expect(flash[:error]).to be nil
-      expect(response).to redirect_to('/assignments/list_submissions?id=8')
+      expect(response).to redirect_to('/grades/view_team?id=1')
     end
   end
 end


### PR DESCRIPTION
The following changes have been made:
1. When saving a submission grade, a flash message is displayed. The code has also been modified so that the grades#view_team page refreshes, instead of the view_submissions page. The test related to this change has also been updated.

2. When saving a review grade, a dialog box showing confirmation is displayed. 

@efg 
@Winbobob 

