### PR TITLE
Issue Fix 1246 - links should appear at top and bottom of the list

### DIFF
--- a/app/views/participants/_links.html.erb
+++ b/app/views/participants/_links.html.erb
@@ -1,0 +1,27 @@
+<%=
+  render :partial => '/shared_scripts/add_individual',
+         :locals => {:form_action => "add",
+                     :remote => true,
+                     :obj_type => "id",
+                     :obj_id => @parent.id,
+                     :model => @model,
+                     :authorization => @authorization}
+%>
+<br/>
+<% if params[:model] == 'Assignment' and @parent.course_id and  @parent.course_id > 0 %>
+  <%= link_to 'Copy participants from course', :action => 'inherit', :id => @root_node.node_object_id %>  |
+  <%= link_to 'Copy participants to course', :action => 'bequeath_all', :id => @root_node.node_object_id %><BR/>
+<% end %>
+<%= link_to 'Import '+@model.to_s.downcase+' participants',
+            :controller=>'import_file',
+            :action=>'start',
+            :model => @model+'Participant',
+            :title => @model+' Participants',
+            :expected_fields => 'username&nbsp;&nbsp;|&nbsp;&nbsp;full name (first [middle] last)&nbsp;&nbsp;|&nbsp;&nbsp;e-mail address&nbsp;&nbsp;|&nbsp;&nbsp;password',
+            :id => @parent.id %> |
+<%= link_to 'Export '+@model.to_s.downcase+' participants',
+            :controller=>'export_file',
+            :action=>'start',
+            :model=>@model+'Participant',
+            :id=>@parent.id %> |
+<%= render :partial => '/shared_scripts/back' %>

--- a/app/views/participants/list.html.erb
+++ b/app/views/participants/list.html.erb
@@ -2,39 +2,12 @@
 <h1><%= @model %> Participants: <%= @parent.name %></h1>
 
 <br/>
+<%= render :partial => 'links' %>
 <div id="part_list" >
 <%= render :partial => '/shared_scripts/user_list',
            :locals => {:controller => 'participants', 
                        :user_list => @participants} %>
 <br/>
 </div>
-<%= 
-	render :partial => '/shared_scripts/add_individual',
-		   :locals => {:form_action => "add",
-                   :remote => true,
-					   :obj_type => "id", 
-					   :obj_id => @parent.id,
-					   :model => @model,
-                       :authorization => @authorization}
-%>
-<br/>
 <% session[:return_to] = request.url %>
-<% if params[:model] == 'Assignment' and @parent.course_id and  @parent.course_id > 0 %>
-  <%= link_to 'Copy participants from course', :action => 'inherit', :id => @root_node.node_object_id %>  |
-  <%= link_to 'Copy participants to course', :action => 'bequeath_all', :id => @root_node.node_object_id %><BR/>
-<% end %>
-<%= link_to 'Import '+@model.to_s.downcase+' participants',
-            :controller=>'import_file', 
-            :action=>'start', 
-            :model => @model+'Participant', 
-            :title => @model+' Participants',
-            :expected_fields => 'username&nbsp;&nbsp;|&nbsp;&nbsp;full name (first [middle] last)&nbsp;&nbsp;|&nbsp;&nbsp;e-mail address&nbsp;&nbsp;|&nbsp;&nbsp;password',
-            :id => @parent.id %> | 
-<%= link_to 'Export '+@model.to_s.downcase+' participants',
-            :controller=>'export_file',
-            :action=>'start',
-            :model=>@model+'Participant',
-            :id=>@parent.id %> |
-<%= render :partial => '/shared_scripts/back' %>
-<hr/>
-
+<%= render :partial => 'links' %>

--- a/app/views/users/_links.html.erb
+++ b/app/views/users/_links.html.erb
@@ -1,0 +1,5 @@
+<p>
+  <%= link_to 'New User',:role => "Student", :action => 'new' %> |
+  <%= link_to 'Import Users', :controller=>'import_file', :action=>'start', :model => 'User', :expected_fields => 'username&nbsp;&nbsp;|&nbsp;&nbsp;full name (first [middle] last)&nbsp;&nbsp;|&nbsp;&nbsp;e-mail address' %> |
+  <%= link_to 'Export Users', :controller=>'export_file',:action=>'start',:model=> 'User',:id=> 1 %>
+</p>

--- a/app/views/users/list.html.erb
+++ b/app/views/users/list.html.erb
@@ -12,6 +12,7 @@
 <%= submit_tag("Search") %>
 <% end %>
 
+<%= render :partial => 'links' %>
 
 <div class="exp">
   <table>
@@ -42,9 +43,6 @@
   <%
       session[:return_to] = "#{request.protocol}#{request.host_with_port}#{request.fullpath}"
     %>
-
-  <%= link_to 'New User',:role => "Student", :action => 'new' %> |
-  <%= link_to 'Import Users', :controller=>'import_file', :action=>'start', :model => 'User', :expected_fields => 'username&nbsp;&nbsp;|&nbsp;&nbsp;full name (first [middle] last)&nbsp;&nbsp;|&nbsp;&nbsp;e-mail address' %> |
-  <%= link_to 'Export Users', :controller=>'export_file',:action=>'start',:model=> 'User',:id=> 1 %>
-
 </p>
+
+<%= render :partial => 'links' %>


### PR DESCRIPTION
Fixes issue #1246 

The code for the links on the users/list and participants page have been separated into partials and added to the top and bottom of the table.

@efg 
@Winbobob 