### PR TITLE
Issue 1192 too many scrollbars

### DIFF
--- a/app/assets/stylesheets/grades.scss
+++ b/app/assets/stylesheets/grades.scss
@@ -107,3 +107,12 @@ background-color: #d3d3d3;
 .spn_qsttog {
   padding-left:30px;cursor: pointer;text-decoration:underline;color:blue;font-size:small;
 }
+
+.hide-scrollbar {
+  overflow-y: hidden;
+  padding-top: 10px;
+}
+
+.hide-scrollbar th{
+  overflow-y: hidden;
+}

--- a/app/views/grades/_tabbing.html.erb
+++ b/app/views/grades/_tabbing.html.erb
@@ -8,7 +8,7 @@
   } );
   </script>
 
-<div id="<%= prefix %>_tabs" class="overflow-container">
+<div id="<%= prefix %>_tabs" class="hide-scrollbar">
   <ul>
     <li><a href="#<%= prefix %>_tabs-1">Reviews</a></li>
     <li><a href="#<%= prefix %>_tabs-2">Author Feedback</a></li>
@@ -16,19 +16,19 @@
     <li><a href="#<%= prefix %>_tabs-4">Metareviews</a></li>
     <li><a href="#<%= prefix %>_tabs-5">Statistics</a></li>
   </ul>
-  <div id="<%= prefix %>_tabs-1" class="overflow-container">
+  <div id="<%= prefix %>_tabs-1" class="hide-scrollbar">
     <%= render :partial => 'reviews_tab', :locals => {:prefix => prefix, :tscore => tscore } %>  
   </div>
-  <div id="<%= prefix %>_tabs-2" class="overflow-container">
+  <div id="<%= prefix %>_tabs-2" class="hide-scrollbar">
    <%= render :partial => 'author_feedback_tab', :locals => {:prefix => prefix, :tscore => tscore } %>
   </div>
-  <div id="<%= prefix %>_tabs-3" class="overflow-container">
+  <div id="<%= prefix %>_tabs-3" class="hide-scrollbar">
     <%= render :partial => 'teammate_reviews_tab', :locals => {:prefix => prefix, :tscore => tscore } %> 
   </div>
-  <div id="<%= prefix %>_tabs-4" class="overflow-container">
+  <div id="<%= prefix %>_tabs-4" class="hide-scrollbar">
     <%= render :partial => 'metareviews_tab', :locals => {:prefix => prefix, :tscore => tscore } %>
   </div>
-  <div id="<%= prefix %>_tabs-5" class="overflow-container">
+  <div id="<%= prefix %>_tabs-5" class="hide-scrollbar">
     <%= render :partial => 'statistics_tab', :locals => {:prefix => prefix, :tscore => tscore } %>
   </div>
 </div>

--- a/app/views/grades/_view_heatgrid.html.erb
+++ b/app/views/grades/_view_heatgrid.html.erb
@@ -106,7 +106,7 @@ function toggleFunction(elementId) {
           <table id='<%="scoresTable"+@type + @participant.id.to_s%>' class="table tbl_heat tablesorter">
             <!-- display the header row of the heatgrid table. this involves iterating through reviewers.-->
             <thead>
-            <tr>
+            <tr class="hide-scrollbar">
               <th class="sorter-true">Criterion<span></span></th>
               
               <% i = 1 %>

--- a/app/views/grades/view_team.html.erb
+++ b/app/views/grades/view_team.html.erb
@@ -92,11 +92,11 @@
 
                 fix comment end
               -->
-        <div class="overflow-container">
+        <div class="hide-scrollbar">
           <table id="scoresTable<%= vm.round.to_s  %>" class="scoresTable tbl_heat tablesorter">
             <!-- display the header row of the heatgrid table. this involves iterating through reviewers.-->
             <thead>
-            <tr>
+            <tr class="hide-scrollbar">
               <th class="sorter-true">Criterion<span></span></th>
             
               <% i = 1 %>


### PR DESCRIPTION
This fixes issue #1192 

On the **View Scores** page, the unnecessary vertical scroll bars have been removed.

Additionally, on the **Your scores** page (for a student), the unnecessary vertical scroll bars have been removed (in order to remain consistent with the instructor view).

Please see screenshots for more clarity.

@Winbobob 
@efg 
