### PR TITLE
E1908. Refactor sign_up_sheet_controller.rb

### DIFF
--- a/app/controllers/sign_up_sheet_controller.rb
+++ b/app/controllers/sign_up_sheet_controller.rb
@@ -144,6 +144,7 @@ class SignUpSheetController < ApplicationController
     redirect_to controller: 'assignments', action: 'edit', id: assignment_id
   end
 
+  # function to list all topics and bids to a participant
   def list
     @participant = AssignmentParticipant.find(params[:id].to_i)
     @assignment = @participant.assignment
@@ -155,6 +156,8 @@ class SignUpSheetController < ApplicationController
     @max_team_size = @assignment.max_team_size
     team_id = @participant.team.try(:id)
 
+    # If the assignment supports bidding, add all the bids of an 
+    # individual or team to the list of signed topics
     if @assignment.is_intelligent
       @bids = team_id.nil? ? [] : Bid.where(team_id: team_id).order(:priority)
       signed_up_topics = []
@@ -172,6 +175,7 @@ class SignUpSheetController < ApplicationController
     @drop_topic_deadline = @assignment.due_dates.find_by(deadline_type_id: 6)
     @student_bids = team_id.nil? ? [] : Bid.where(team_id: team_id)
 
+    # Show selected topics only if the assignment's deadline hasn't passed
     unless @assignment.due_dates.find_by(deadline_type_id: 1).nil?
       @show_actions = false if !@assignment.staggered_deadline? and @assignment.due_dates.find_by(deadline_type_id: 1).due_at < Time.now
 

--- a/app/controllers/sign_up_sheet_controller.rb
+++ b/app/controllers/sign_up_sheet_controller.rb
@@ -232,11 +232,11 @@ class SignUpSheetController < ApplicationController
     redirect_to controller: 'assignments', action: 'edit', id: params[:assignment_id]
   end
 
-  def can_delete_topic? is_instructor?, participant, assignment, drop_topic_deadline
+  def can_delete_topic? is_instructor, participant, assignment, drop_topic_deadline
     submission_error_message = ""
     deadline_error_message = ""
 
-    if is_instructor?
+    if is_instructor
       submission_error_message = "The student has already submitted their work, so you are not allowed to remove them"
       deadline_error_message = "You cannot drop a student after the drop topic deadline!"
     else

--- a/app/controllers/sign_up_sheet_controller.rb
+++ b/app/controllers/sign_up_sheet_controller.rb
@@ -100,7 +100,7 @@ class SignUpSheetController < ApplicationController
   # Contains links that let an admin or Instructor edit, delete, view enrolled/waitlisted members for each topic
   # Also contains links to delete topics and modify the deadlines for individual topics. Staggered means that different topics can have different deadlines.
   def add_signup_topics
-    load_add_signup_topics(params[:id])
+    get_assignment_data(params[:id])
     SignUpSheet.add_signup_topic(params[:id])
   end
 
@@ -109,7 +109,7 @@ class SignUpSheetController < ApplicationController
   end
 
   # retrieves all the data associated with the given assignment. Includes all topics,
-  def load_add_signup_topics(assignment_id)
+  def get_assignment_data(assignment_id)
     @id = assignment_id
     @sign_up_topics = SignUpTopic.where('assignment_id = ?', assignment_id)
     @slots_filled = SignUpTopic.find_slots_filled(assignment_id)
@@ -374,7 +374,7 @@ class SignUpSheetController < ApplicationController
   # This method is called when a student click on the trumpet icon. So this is a bad method name. --Yang
   def show_team
     if !(assignment = Assignment.find(params[:assignment_id])).nil? and !(topic = SignUpTopic.find(params[:id])).nil?
-      @results = ad_info(assignment.id, topic.id)
+      @results = get_ad(assignment.id, topic.id)
       @results.each do |result|
         result.keys.each do |key|
           @current_team_name = result[key] if key.equal? :name
@@ -457,7 +457,7 @@ class SignUpSheetController < ApplicationController
 
   # get info related to the ad for partners so that it can be displayed when an assignment_participant
   # clicks to see ads related to a topic
-  def ad_info(_assignment_id, topic_id)
+  def get_ad(_assignment_id, topic_id)
     # List that contains individual result object
     @result_list = []
     # Get the results

--- a/app/controllers/sign_up_sheet_controller.rb
+++ b/app/controllers/sign_up_sheet_controller.rb
@@ -232,7 +232,7 @@ class SignUpSheetController < ApplicationController
     redirect_to controller: 'assignments', action: 'edit', id: params[:assignment_id]
   end
 
-  def can_delete_topic? is_instructor, participant, assignment, drop_topic_deadline
+  def can_delete_topic? is_instructor?, participant, assignment, drop_topic_deadline
     submission_error_message = ""
     deadline_error_message = ""
 

--- a/app/controllers/sign_up_sheet_controller.rb
+++ b/app/controllers/sign_up_sheet_controller.rb
@@ -204,6 +204,7 @@ class SignUpSheetController < ApplicationController
   end
 
   # routes to new page to specficy student
+  # Specifies the student and displays a new page, its called via a get request. 
   def signup_as_instructor; end
 
   def signup_student user
@@ -216,6 +217,7 @@ class SignUpSheetController < ApplicationController
     end
   end
 
+  # This is an action called via a post request, whose aim to signup the student.
   def signup_as_instructor_action
     user = User.find_by(name: params[:username])
     if user.nil? # validate invalid user

--- a/app/controllers/sign_up_sheet_controller.rb
+++ b/app/controllers/sign_up_sheet_controller.rb
@@ -120,7 +120,7 @@ class SignUpSheetController < ApplicationController
     # to treat all assignments as team assignments
     # Though called participants, @participants are actually records in signed_up_teams table, which
     # is a mapping table between teams and topics (waitlisted recored are also counted)
-    @participants = SignedUpTeam.find_team_participants(assignment_id, session[:ip])
+    @teams = SignedUpTeam.find_team_participants(assignment_id, session[:ip])
   end
 
   def set_values_for_new_topic

--- a/app/controllers/sign_up_sheet_controller.rb
+++ b/app/controllers/sign_up_sheet_controller.rb
@@ -69,7 +69,7 @@ class SignUpSheetController < ApplicationController
       @topic.destroy
       undo_link("The topic: \"#{@topic.topic_name}\" has been successfully deleted. ")
     else
-      flash[:error] = "The topic could not be deleted."
+      flash[:error] = "The topic could not be found."
     end
     # changing the redirection url to topics tab in edit assignment view.
     redirect_to edit_assignment_path(params[:assignment_id]) + "#tabs-5"

--- a/app/controllers/sign_up_sheet_controller.rb
+++ b/app/controllers/sign_up_sheet_controller.rb
@@ -104,10 +104,6 @@ class SignUpSheetController < ApplicationController
     SignUpSheet.add_signup_topic(params[:id])
   end
 
-  def add_signup_topics_staggered
-    add_signup_topics
-  end
-
   # retrieves all the data associated with the given assignment. Includes all topics,
   def get_assignment_data(assignment_id)
     @id = assignment_id
@@ -133,11 +129,12 @@ class SignUpSheetController < ApplicationController
     @assignment = Assignment.find(params[:id])
   end
 
-  # simple function that redirects ti the /add_signup_topics or the /add_signup_topics_staggered page depending on assignment type
+  # simple function that redirects to the /add_signup_topics or the /add_signup_topics_staggered page depending on assignment type
   # staggered means that different topics can have different deadlines.
+  # changed to redirect only to signup_topics because staggered functionality might not have been implemented yet
   def redirect_to_sign_up(assignment_id)
     assignment = Assignment.find(assignment_id)
-    assignment.staggered_deadline == true ? (redirect_to action: 'add_signup_topics_staggered', id: assignment_id) : (redirect_to action: 'add_signup_topics', id: assignment_id)
+    redirect_to action: 'add_signup_topics', id: assignment_id
   end
 
   # simple function that redirects to assignment->edit->topic panel to display /add_signup_topics or the /add_signup_topics_staggered page

--- a/app/controllers/sign_up_sheet_controller.rb
+++ b/app/controllers/sign_up_sheet_controller.rb
@@ -56,7 +56,7 @@ class SignUpSheetController < ApplicationController
     if topic.nil?
       setup_new_topic
     else
-      update_existing_topic topic
+      flash[:error] = "The topic already exists."
     end
   end
 

--- a/app/controllers/sign_up_sheet_controller.rb
+++ b/app/controllers/sign_up_sheet_controller.rb
@@ -56,6 +56,7 @@ class SignUpSheetController < ApplicationController
     if topic.nil?
       setup_new_topic
     else
+      # Removed call to update method
       flash[:error] = "The topic already exists."
     end
   end
@@ -85,12 +86,8 @@ class SignUpSheetController < ApplicationController
     if @topic
       @topic.topic_identifier = params[:topic][:topic_identifier]
       update_max_choosers @topic
-      @topic.category = params[:topic][:category]
-      @topic.topic_name = params[:topic][:topic_name]
-      @topic.micropayment = params[:topic][:micropayment]
-      @topic.description = params[:topic][:description]
-      @topic.link = params[:topic][:link]
-      @topic.save
+      # Replaced unnecessary variables and save with a single update call for all the parameters
+      @topic.update_attributes(topic_identifier: params[:topic][:topic_identifier], category: params[:topic][:category], topic_name: params[:topic][:topic_name], micropayment: params[:topic][:micropayment], description: params[:topic][:description], link: params[:topic][:link])
       undo_link("The topic: \"#{@topic.topic_name}\" has been successfully updated. ")
     else
       flash[:error] = "The topic could not be updated."

--- a/app/controllers/sign_up_sheet_controller.rb
+++ b/app/controllers/sign_up_sheet_controller.rb
@@ -237,7 +237,7 @@ class SignUpSheetController < ApplicationController
     deadline_error_message = ""
 
     if is_instructor
-      submission_error_message = "The student has already submitted their work, so you are not allowed to remove them"
+      submission_error_message = "The student has already submitted their work, so you are not allowed to remove them."
       deadline_error_message = "You cannot drop a student after the drop topic deadline!"
     else
       submission_error_message = "You have already submitted your work, so you are not allowed to drop your topic."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -326,7 +326,6 @@ resources :institution, except: [:destroy] do
       get :signup
       get :delete_signup
       get :add_signup_topics
-      get :add_signup_topics_staggered
       get :delete_signup
       get :list
       get :signup_topics


### PR DESCRIPTION
Fixed the following issues in sign_up_sheet_controller:

- Create method has an if-else condition determining if create or update should be called. Create method should not be responsible for calling update. Rectified this method by removing call to update and flashing an error instead.
- Update method has a plethora of instance variables defined before updating. These are not necessary (For e.g., look at update method of bookmarks_controller). Refactored the variables not needed out.
- Destroy has a misleading else flash message.  Fixed it.
- Several method names are renamed to be more intuitive. load_add_signup_topics is renamed to get_assignment_data and ad_info is renamed to get_ad.
- Added comments to signup_as_instructor and signup_as_instructor_action methods.
- The list method is too long and is sparsely commented. Provided comments.
- Refactored participants variable to 'teams' in  load_add_signup_topics.
- Signup_as_instructor_action has if-else ladder. It has been made more elegant using a helper function.
- Delete_signup and delete_signup_as_instructor have much in common and violates the DRY principle. Refactored them by moving the duplicate code to a helper function.