### PR TITLE
Issue 1244 save questionnaire button

### DIFF
--- a/app/controllers/questionnaires_controller.rb
+++ b/app/controllers/questionnaires_controller.rb
@@ -140,7 +140,7 @@ class QuestionnairesController < ApplicationController
         @questionnaire.update_attributes(questionnaire_params)
 
         # Save all questions
-        if !params[:question].nil?
+        unless params[:question].nil?
           params[:question].each_pair do |k, v|
             @question = Question.find(k)
             # example of 'v' value

--- a/app/views/questionnaires/_questionnaire.html.erb
+++ b/app/views/questionnaires/_questionnaire.html.erb
@@ -20,7 +20,7 @@
      </tr>
   </table>
   <% if params[:action] == 'new' %>
-    <%= submit_tag 'Create', name:"create", class: "btn btn-default" %>
+    <%= submit_tag 'Create', class: "btn btn-default" %>
   <% end %>
 
   <!--Questions part-->

--- a/app/views/questionnaires/_questionnaire.html.erb
+++ b/app/views/questionnaires/_questionnaire.html.erb
@@ -1,5 +1,5 @@
 <%= error_messages_for 'questionnaire' %>
-<!--Questionnaire part-->
+
 <%= form_for @questionnaire do %>
   <table>
     <tr>
@@ -20,39 +20,34 @@
      </tr>
   </table>
   <% if params[:action] == 'new' %>
-    <%= submit_tag 'Create', class: "btn btn-default" %>
-  <% else %>
-    <%= submit_tag 'Update', class: "btn btn-default" %>
+    <%= submit_tag 'Create', name:"create", class: "btn btn-default" %>
   <% end %>
-<% end %>
 
-<!--Question part-->
-<hr/>
-<% if !params[:id].nil? and params[:action] == 'edit' %>
-  <table id="question_actions_table">
-    <tr>
-      <td>
-        <%= form_tag :action => 'add_new_questions', :id => params[:id], :questionnaire_type => params[:model], :private => params[:private] do %>
-         <p class="form-inline"> <%= submit_tag 'Add', class: "btn btn-default"%>
-          <%= text_field 'question', 'total_num', :size => 1, :value => "1", :class => "form-control" %> more 
-          <%= select "question", "type", 
-              {"Criterion" =>"Criterion",
-               "Scale"=>"Scale",
-               "Dropdown"=>"Dropdown",
-               "Checkbox"=>"Checkbox",
-               "TextArea"=>"TextArea",
-               "TextField"=>"TextField",
-               "UploadFile"=>"UploadFile",
-               "SectionHeader"=>"SectionHeader",
-               "TableHeader"=>"TableHeader",
-               "ColumnHeader"=>"ColumnHeader",
-               }, {}, {class: "form-control"} %> question(s)</p>
-        <% end %>
-      </td>
-    </tr>
-  </table>
-  
-  <%= form_tag :action => 'save_all_questions', :id => params[:id],  :questionnaire_type => params[:model], :private => params[:private] do %>
+  <!--Questions part-->
+  <hr/>
+  <% if !params[:id].nil? and params[:action] == 'edit' %>
+    <table id="question_actions_table">
+      <tr>
+        <td>
+          <p class="form-inline"> <%= submit_tag 'Add', name: "add_new_questions", class: "btn btn-default"%>
+            <%= text_field 'new_question', 'total_num', :size => 1, :value => "1", :class => "form-control" %> more
+            <%= select "new_question", "type",
+                {"Criterion" =>"Criterion",
+                 "Scale"=>"Scale",
+                 "Dropdown"=>"Dropdown",
+                 "Checkbox"=>"Checkbox",
+                 "TextArea"=>"TextArea",
+                 "TextField"=>"TextField",
+                 "UploadFile"=>"UploadFile",
+                 "SectionHeader"=>"SectionHeader",
+                 "TableHeader"=>"TableHeader",
+                 "ColumnHeader"=>"ColumnHeader",
+                 }, {}, {class: "form-control"} %> question(s)
+          </p>
+        </td>
+      </tr>
+    </table>
+
     <table id="questions_table">
       <tr>
         <th class="head" align="center" width="30">Action</td>
@@ -79,8 +74,7 @@
     <input type="submit" name="import" value="Import questions"/>
     <br />
     <input type="submit" name="export" value="Export questions to CSV"%>-->
+
   <% end %>
 <% end %>
-
 <BR/>
-

--- a/spec/controllers/questionnaires_controller_spec.rb
+++ b/spec/controllers/questionnaires_controller_spec.rb
@@ -271,20 +271,20 @@ describe QuestionnairesController do
                                  display_type: 'Review',
                                  instructor_loc: ''}}
       @params_with_question = {id: 1,
-                                questionnaire: {name: 'test questionnaire',
-                                                instructor_id: 6,
-                                                private: 0,
-                                                min_question_score: 0,
-                                                max_question_score: 5,
-                                                type: 'ReviewQuestionnaire',
-                                                display_type: 'Review',
-                                                instructor_loc: ''},
-                                question: {'1' => {seq: 66.0,
-                                                   txt: 'WOW',
-                                                   weight: 10,
-                                                   size: '50,3',
-                                                   max_label: 'Strong agree',
-                                                   min_label: 'Not agree'}}}
+                               questionnaire: {name: 'test questionnaire',
+                                               instructor_id: 6,
+                                               private: 0,
+                                               min_question_score: 0,
+                                               max_question_score: 5,
+                                               type: 'ReviewQuestionnaire',
+                                               display_type: 'Review',
+                                               instructor_loc: ''},
+                               question: {'1' => {seq: 66.0,
+                                                  txt: 'WOW',
+                                                  weight: 10,
+                                                  size: '50,3',
+                                                  max_label: 'Strong agree',
+                                                  min_label: 'Not agree'}}}
     end
     context 'successfully updates the attributes of questionnaire' do
       it 'redirects to questionnaires#edit page after updating' do
@@ -330,9 +330,9 @@ describe QuestionnairesController do
         params = {id: 1,
                   add_new_questions: true,
                   new_question: {total_num: 2,
-                             type: 'Criterion'}}
+                                 type: 'Criterion'}}
         post :update, params
-        expect(response).to redirect_to :action => :add_new_questions, :id => params[:id], :question => params[:new_question]
+        expect(response).to redirect_to action: 'add_new_questions', id: params[:id], question: params[:new_question]
       end
     end
   end

--- a/spec/controllers/questionnaires_controller_spec.rb
+++ b/spec/controllers/questionnaires_controller_spec.rb
@@ -270,6 +270,21 @@ describe QuestionnairesController do
                                  type: 'ReviewQuestionnaire',
                                  display_type: 'Review',
                                  instructor_loc: ''}}
+      @params_with_question = {id: 1,
+                                questionnaire: {name: 'test questionnaire',
+                                                instructor_id: 6,
+                                                private: 0,
+                                                min_question_score: 0,
+                                                max_question_score: 5,
+                                                type: 'ReviewQuestionnaire',
+                                                display_type: 'Review',
+                                                instructor_loc: ''},
+                                question: {'1' => {seq: 66.0,
+                                                   txt: 'WOW',
+                                                   weight: 10,
+                                                   size: '50,3',
+                                                   max_label: 'Strong agree',
+                                                   min_label: 'Not agree'}}}
     end
     context 'successfully updates the attributes of questionnaire' do
       it 'redirects to questionnaires#edit page after updating' do
@@ -287,6 +302,37 @@ describe QuestionnairesController do
         post :update, @params
         expect(flash[:error].to_s).to eq 'This is an error!'
         expect(response).to redirect_to('/questionnaires/1/edit')
+      end
+    end
+
+    context 'successfully updates the questions in a questionnaire' do
+      it 'redirects to questionnaires#edit page after saving all questions' do
+        allow(Question).to receive(:find).with('1').and_return(question)
+        allow(question).to receive(:save).and_return(true)
+        allow(@questionnaire1).to receive(:update_attributes).with(any_args).and_return(true)
+        post :update, @params_with_question
+        expect(flash[:success]).to eq('The questionnaire has been successfully updated!')
+        expect(response).to redirect_to('/questionnaires/1/edit')
+      end
+    end
+
+    context 'when params[:view_advice] is not nil' do
+      it 'redirects to advice#edit_advice page' do
+        params = {id: 1,
+                  view_advice: true}
+        post :update, params
+        expect(response).to redirect_to('/advice/edit_advice/1')
+      end
+    end
+
+    context 'when params[:add_new_questions] is not nil' do
+      it 'redirects to questionnaire#add_new_questions' do
+        params = {id: 1,
+                  add_new_questions: true,
+                  new_question: {total_num: 2,
+                             type: 'Criterion'}}
+        post :update, params
+        expect(response).to redirect_to :action => :add_new_questions, :id => params[:id], :question => params[:new_question]
       end
     end
   end
@@ -369,36 +415,6 @@ describe QuestionnairesController do
                              type: 'Dropdown'}}
         post :add_new_questions, params
         expect(response).to redirect_to('/questionnaires/1/edit')
-      end
-    end
-  end
-
-  describe '#save_all_questions' do
-    context 'when params[:save] is not nil, params[:view_advice] is nil' do
-      it 'redirects to questionnaires#edit page after saving all questions' do
-        allow(Question).to receive(:find).with('1').and_return(question)
-        allow(question).to receive(:save).and_return(true)
-        params = {id: 1,
-                  save: true,
-                  question: {'1' => {seq: 66.0,
-                                     txt: 'WOW',
-                                     weight: 10,
-                                     size: '50,3',
-                                     max_label: 'Strong agree',
-                                     min_label: 'Not agree'}}}
-        post :save_all_questions, params
-        expect(flash[:success]).to eq('All questions has been successfully saved!')
-        expect(response).to redirect_to('/questionnaires/1/edit')
-      end
-    end
-
-    context 'when params[:save] is nil, params[:view_advice] is not nil' do
-      it 'redirects to advice#edit_advice page' do
-        params = {id: 1,
-                  view_advice: true,
-                  question: {}}
-        post :save_all_questions, params
-        expect(response).to redirect_to('/advice/edit_advice/1')
       end
     end
   end

--- a/spec/features/airbrake_expection_errors_feature_tests_spec.rb
+++ b/spec/features/airbrake_expection_errors_feature_tests_spec.rb
@@ -108,7 +108,6 @@ describe "Airbrake expection errors" do
     click_button('Save review questionnaire')
     expect { page }.not_to raise_error
     expect(page).to have_current_path("/questionnaires/#{questionnaire.id}/edit")
-    expect(page).to have_content("undefined method `each_pair' for nil:NilClass")
   end
 end
 

--- a/spec/features/assignment_survey_spec.rb
+++ b/spec/features/assignment_survey_spec.rb
@@ -59,14 +59,14 @@ describe "Survey questionnaire tests for instructor interface" do
 
     # adding some questions for the deployed survey
     visit '/questionnaires/' + survey_questionnaire_1.id.to_s + '/edit'
-    fill_in('question_total_num', with: '1')
-    select('Criterion', from: 'question_type')
+    fill_in('new_question_total_num', with: '1')
+    select('Criterion', from: 'new_question_type')
     click_button "Add"
     expect(page).to have_content('Remove')
 
     fill_in "Edit question content here", with: "Test question 1"
     click_button "Save assignment survey questionnaire"
-    expect(page).to have_content('All questions has been successfully saved!')
+    expect(page).to have_content('The questionnaire has been successfully updated!')
 
     survey_deployment = SurveyDeployment.where(questionnaire_id: survey_questionnaire_1.id).first
     question = Question.find_by_sql(\

--- a/spec/features/course_survey_spec.rb
+++ b/spec/features/course_survey_spec.rb
@@ -55,13 +55,13 @@ describe "Course Survey questionnaire tests for instructor interface" do
     survey_questionnaire = Questionnaire.where(name: survey_name).first
     # adding some questions for the deployed survey
     visit '/questionnaires/' + survey_questionnaire.id.to_s + '/edit'
-    fill_in('question_total_num', with: '1')
-    select('Criterion', from: 'question_type')
+    fill_in('new_question_total_num', with: '1')
+    select('Criterion', from: 'new_question_type')
     click_button "Add"
     expect(page).to have_content('Remove')
     fill_in "Edit question content here", with: "Test question 1"
     click_button "Save course survey questionnaire"
-    expect(page).to have_content('All questions has been successfully saved!')
+    expect(page).to have_content('The questionnaire has been successfully updated!')
   end
 
   it "is able to delete question from a course survey" do
@@ -69,13 +69,13 @@ describe "Course Survey questionnaire tests for instructor interface" do
     deploy_course_survey(@next_day, @next_to_next_day, survey_name)
     survey_questionnaire = Questionnaire.where(name: survey_name).first
     visit '/questionnaires/' + survey_questionnaire.id.to_s + '/edit'
-    fill_in('question_total_num', with: '1')
-    select('Criterion', from: 'question_type')
+    fill_in('new_question_total_num', with: '1')
+    select('Criterion', from: 'new_question_type')
     click_button "Add"
     expect(page).to have_content('Remove')
     fill_in "Edit question content here", with: "Test question 1"
     click_button "Save course survey questionnaire"
-    expect(page).to have_content('All questions has been successfully saved!')
+    expect(page).to have_content('The questionnaire has been successfully updated!')
     question = Question.find_by_sql("select * from questions where questionnaire_id = " + survey_questionnaire.id.to_s)
     click_link('Remove')
     expect(page).to have_content("You have successfully deleted the question!")

--- a/spec/features/global_survey_spec.rb
+++ b/spec/features/global_survey_spec.rb
@@ -57,13 +57,13 @@ describe "Global Survey questionnaire tests for instructor interface" do
 
     # adding some questions for the deployed survey
     visit '/questionnaires/' + survey_questionnaire.id.to_s + '/edit'
-    fill_in('question_total_num', with: '1')
-    select('Criterion', from: 'question_type')
+    fill_in('new_question_total_num', with: '1')
+    select('Criterion', from: 'new_question_type')
     click_button "Add"
     expect(page).to have_content('Remove')
     fill_in "Edit question content here", with: "Test question 1"
     click_button "Save course survey questionnaire"
-    expect(page).to have_content('All questions has been successfully saved!')
+    expect(page).to have_content('The questionnaire has been successfully updated!')
   end
 
   it "is able to delete question from a global survey" do
@@ -71,13 +71,13 @@ describe "Global Survey questionnaire tests for instructor interface" do
     deploy_global_survey(@next_day, @next_to_next_day, survey_name)
     survey_questionnaire = Questionnaire.where(name: survey_name).first
     visit '/questionnaires/' + survey_questionnaire.id.to_s + '/edit'
-    fill_in('question_total_num', with: '1')
-    select('Criterion', from: 'question_type')
+    fill_in('new_question_total_num', with: '1')
+    select('Criterion', from: 'new_question_type')
     click_button "Add"
     expect(page).to have_content('Remove')
     fill_in "Edit question content here", with: "Test question 1"
     click_button "Save course survey questionnaire"
-    expect(page).to have_content('All questions has been successfully saved!')
+    expect(page).to have_content('The questionnaire has been successfully updated!')
     question = Question.find_by_sql("select * from questions where questionnaire_id = " + survey_questionnaire.id.to_s)
     click_link('Remove')
     expect(page).to have_content("You have successfully deleted the question!")

--- a/spec/features/questionnaire_spec.rb
+++ b/spec/features/questionnaire_spec.rb
@@ -58,8 +58,8 @@ describe "Questionnaire tests for instructor interface" do
 
   def load_question question_type
     load_questionnaire
-    fill_in('question_total_num', with: '1')
-    select(question_type, from: 'question_type')
+    fill_in('new_question_total_num', with: '1')
+    select(question_type, from: 'new_question_type')
     click_button "Add"
   end
 
@@ -69,7 +69,7 @@ describe "Questionnaire tests for instructor interface" do
         load_question q_type
         expect(page).to have_content('Remove')
         click_button "Save review questionnaire"
-        expect(page).to have_content('All questions has been successfully saved!')
+        expect(page).to have_content('The questionnaire has been successfully updated!')
       end
     end
   end
@@ -77,7 +77,7 @@ describe "Questionnaire tests for instructor interface" do
   def edit_created_question
     first("textarea[placeholder='Edit question content here']").set "Question edit"
     click_button "Save review questionnaire"
-    expect(page).to have_content('All questions has been successfully saved!')
+    expect(page).to have_content('The questionnaire has been successfully updated!')
     expect(page).to have_content('Question edit')
   end
 

--- a/spec/features/survey_spec.rb
+++ b/spec/features/survey_spec.rb
@@ -60,14 +60,14 @@ describe "Survey questionnaire tests for instructor interface" do
 
     # adding some questions for the deployed survey
     visit '/questionnaires/' + survey_questionnaire_1.id.to_s + '/edit'
-    fill_in('question_total_num', with: '1')
-    select('Criterion', from: 'question_type')
+    fill_in('new_question_total_num', with: '1')
+    select('Criterion', from: 'new_question_type')
     click_button "Add"
     expect(page).to have_content('Remove')
 
     fill_in "Edit question content here", with: "Test question 1"
     click_button "Save assignment survey questionnaire"
-    expect(page).to have_content('All questions has been successfully saved!')
+    expect(page).to have_content('The questionnaire has been successfully updated!')
 
     survey_deployment = SurveyDeployment.where(questionnaire_id: survey_questionnaire_1.id).first
     question = Question.find_by_sql("select * from questions where questionnaire_id = " + survey_questionnaire_1.id.to_s +


### PR DESCRIPTION
This fixes Issue #1244 

The "Save questionnaire" button now saves all information on the Edit Questionnaire page. The "Update" button has been removed.

Some tests have been updated to account for the new behavior.

@efg 
@Winbobob 
