### PR TITLE
Disable 'Other's work' link when assignment does not expect peer reviews

### DIFF
--- a/app/helpers/student_task_helper.rb
+++ b/app/helpers/student_task_helper.rb
@@ -38,7 +38,7 @@ module StudentTaskHelper
     info.html_safe
   end
 
-  def has_review_deadline?(assignment)
-    return assignment.find_due_dates('review').present?
+  def review_deadline?(assignment)
+    assignment.find_due_dates('review').present?
   end
 end

--- a/app/helpers/student_task_helper.rb
+++ b/app/helpers/student_task_helper.rb
@@ -37,4 +37,8 @@ module StudentTaskHelper
     end
     info.html_safe
   end
+
+  def has_review_deadline?(assignment)
+    return assignment.find_due_dates('review').present?
+  end
 end

--- a/app/views/student_task/view.html.erb
+++ b/app/views/student_task/view.html.erb
@@ -64,7 +64,8 @@ to display the label "Your team" in the student assignment tasks-->
         <% @alias_name = "Your readings" %>
       <% end %>
       <!--Zhewei: professor mentioned that a submission is reviewable if the submission is in a stage where reviews can be done. It does not depend on the stage of the topic the reviewer is writing on-->
-      <% if check_reviewable_topics(@assignment) or @assignment.metareview_allowed(nil) or @assignment.get_current_stage(@topic_id) == "Finished" %>
+      <!--Akshay: Fix Issue 1218 - this link is disabled if assignment does not require any peer reviews-->
+      <% if has_review_deadline?(@assignment) and (check_reviewable_topics(@assignment) or @assignment.metareview_allowed(nil) or @assignment.get_current_stage(@topic_id) == "Finished") %>
         <%= link_to "#{@alias_name}",{:controller => 'student_review', :action => 'list', :id => @participant.id} %>
       <% else %>
         <font color="gray"><%= @alias_name%></font>

--- a/app/views/student_task/view.html.erb
+++ b/app/views/student_task/view.html.erb
@@ -65,7 +65,7 @@ to display the label "Your team" in the student assignment tasks-->
       <% end %>
       <!--Zhewei: professor mentioned that a submission is reviewable if the submission is in a stage where reviews can be done. It does not depend on the stage of the topic the reviewer is writing on-->
       <!--Akshay: Fix Issue 1218 - this link is disabled if assignment does not require any peer reviews-->
-      <% if has_review_deadline?(@assignment) and (check_reviewable_topics(@assignment) or @assignment.metareview_allowed(nil) or @assignment.get_current_stage(@topic_id) == "Finished") %>
+      <% if review_deadline?(@assignment) and (check_reviewable_topics(@assignment) or @assignment.metareview_allowed(nil) or @assignment.get_current_stage(@topic_id) == "Finished") %>
         <%= link_to "#{@alias_name}",{:controller => 'student_review', :action => 'list', :id => @participant.id} %>
       <% else %>
         <font color="gray"><%= @alias_name%></font>

--- a/spec/features/review_assignment_spec.rb
+++ b/spec/features/review_assignment_spec.rb
@@ -14,6 +14,7 @@ describe "peer review testing" do
     create(:deadline_right, name: 'Late')
     create(:deadline_right, name: 'OK')
     create(:assignment_due_date, deadline_type: DeadlineType.where(name: "submission").first, due_at: DateTime.now.in_time_zone + 1.day)
+    create(:assignment_due_date, deadline_type: DeadlineType.where(name: "review").first, due_at: DateTime.now.in_time_zone + 1.day)
   end
 
   def signup_topic


### PR DESCRIPTION
This fixes issue #1218. Now, when an assignment is created without a review deadline (this can happen if the assignment does not expect peer reviews), then a student cannot see an active "Other's work" link.

@efg 
@Winbobob 
