### PR TITLE
Fix Issue 1206 - Add 'has topics' checkbox

### DIFF
--- a/app/views/assignments/edit.html.erb
+++ b/app/views/assignments/edit.html.erb
@@ -5,7 +5,7 @@
     <div class= "table" id="tabs">
       <ul>
         <li><a href="#tabs-1" id="General">General</a></li>
-        <li><a href="#tabs-2" id="Topics">Topics</a></li>
+        <li id="topics_tab_header"><a href="#tabs-2" id="Topics">Topics</a></li>
         <li><a href="#tabs-3" id="Rubrics">Rubrics</a></li>
         <li><a href="#tabs-4" id="ReviewStrategy">Review strategy</a></li>
         <li><a href="#tabs-5" id="DueDates">Due dates</a></li>

--- a/app/views/assignments/edit/_general.html.erb
+++ b/app/views/assignments/edit/_general.html.erb
@@ -132,6 +132,16 @@ function microtaskChanged() {
     </td>
   </tr>
 
+  <% if current_page?(action: 'edit') %>
+  <!--Topics-->
+  <tr>
+    <td style='padding:5px' id='assignment_has_topics_field'>
+      <%= check_box_tag('assignment_has_topics', 'true', @assignment_form.assignment.topics?, {:onChange => 'topicsChanged()'}) %>
+      <%= label_tag('assignment_has_topics', 'Has topics?') %>
+    </td>
+  </tr>
+  <% end %>
+
   <!--staggered_deadline-->
   <tr>
     <td style='padding:5px' id='assignment_staggered_deadline_field'>
@@ -213,6 +223,46 @@ function microtaskChanged() {
 
 
 <script>
+    <% if current_page?(action: 'edit') %>
+    jQuery(document).ready(function () {
+        // This function determines whether the 'Topics' tab must be displayed when the page is re-loaded
+        var checkbox = jQuery('#assignment_has_topics');
+        if (checkbox.is(':checked')) {
+            // If this checkbox is checked, show the 'Topics' tab
+            jQuery("#topics_tab_header").show();
+        } else {
+            // Otherwise, hide topics tab
+            jQuery("#topics_tab_header").hide();
+        }
+    });
+
+    function topicsChanged() {
+        var msg = 'Warning! Un-checking this box will remove all topics that have been created.';
+        var checkbox = jQuery('#assignment_has_topics');
+        if (checkbox.is(':checked')) {
+            // If this box is checked, display the 'Topics' tab
+            jQuery("#topics_tab_header").show();
+        } else {
+            if (confirm(msg)) {
+                // If this box is un-checked, remove all topics and reload page
+                jQuery.ajax({
+                    url: '/sign_up_sheet/delete_all_topics_for_assignment',
+                    method: 'POST',
+                    data: {
+                        assignment_id: <%= @assignment.id %>
+                    },
+                    success: function() {
+                        // After topics are deleted, re-load page
+                        window.location.href = '<%= edit_assignment_path(@assignment.id) %>';
+                    }
+                });
+            } else {
+                checkbox.prop('checked', true);
+            }
+        }
+    }
+    <% end %>
+
     function hasTeamsChanged() {
       var msg = 'Warning! Unchecking this box will hide teams that already exist.';
         var checkbox = jQuery('#team_assignment');

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -336,6 +336,7 @@ resources :institution, except: [:destroy] do
       get :intelligent_sign_up
       get :intelligent_save
       get :signup_as_instructor
+      post :delete_all_topics_for_assignment
       post :signup_as_instructor_action
       post :set_priority
       post :save_topic_deadlines

--- a/spec/controllers/sign_up_sheet_controller_spec.rb
+++ b/spec/controllers/sign_up_sheet_controller_spec.rb
@@ -50,7 +50,7 @@ describe SignUpSheetController do
             }
           }
           post :create, params
-          expect(response).to redirect_to('/assignments/1/edit#tabs-5')
+          expect(response).to redirect_to('/assignments/1/edit#tabs-2')
         end
       end
 
@@ -105,7 +105,7 @@ describe SignUpSheetController do
           .with("The topic: \"Hello world!\" has been successfully deleted. ").and_return('OK')
         params = {id: 1, assignment_id: 1}
         post :destroy, params
-        expect(response).to redirect_to('/assignments/1/edit#tabs-5')
+        expect(response).to redirect_to('/assignments/1/edit')
       end
     end
 
@@ -117,8 +117,18 @@ describe SignUpSheetController do
         params = {id: 1, assignment_id: 1}
         post :destroy, params
         expect(flash[:error]).to eq('The topic could not be deleted.')
-        expect(response).to redirect_to('/assignments/1/edit#tabs-5')
+        expect(response).to redirect_to('/assignments/1/edit')
       end
+    end
+  end
+
+  describe '#delete_all_topics_for_assignment' do
+    it 'deletes all topics for the assignment and redirects to edit assignment page' do
+      allow(SignUpTopic).to receive(:find).with(assignment_id: '1').and_return(topic)
+      params = {assignment_id: 1}
+      post :delete_all_topics_for_assignment, params
+      expect(flash[:success]).to eq('All topics have been deleted successfully.')
+      expect(response).to redirect_to('/assignments/1/edit')
     end
   end
 
@@ -137,7 +147,7 @@ describe SignUpSheetController do
         params = {id: 1, assignment_id: 1}
         post :update, params
         expect(flash[:error]).to eq('The topic could not be updated.')
-        expect(response).to redirect_to('/assignments/1/edit#tabs-5')
+        expect(response).to redirect_to('/assignments/1/edit#tabs-2')
       end
     end
 
@@ -162,7 +172,7 @@ describe SignUpSheetController do
           }
         }
         post :update, params
-        expect(response).to redirect_to('/assignments/1/edit#tabs-5')
+        expect(response).to redirect_to('/assignments/1/edit#tabs-2')
       end
     end
   end

--- a/spec/features/assignment_creation_spec.rb
+++ b/spec/features/assignment_creation_spec.rb
@@ -517,7 +517,7 @@ describe "assignment function" do
       expect(topics_exist).to be_eql 0
     end
 
-    it "hides topics tab when has topics is un-checked", js:true do
+    it "hides topics tab when has topics is un-checked", js: true do
       click_link 'General'
       uncheck("assignment_has_topics")
       # The below line is used to accept the js confirmation popup

--- a/spec/features/assignment_creation_spec.rb
+++ b/spec/features/assignment_creation_spec.rb
@@ -442,6 +442,7 @@ describe "assignment function" do
       assignment = create(:assignment, name: 'public assignment for test')
       login_as("instructor6")
       visit "/assignments/#{assignment.id}/edit"
+      check("assignment_has_topics")
       click_link 'Topics'
     end
 
@@ -514,6 +515,16 @@ describe "assignment function" do
 
       topics_exist = SignUpTopic.where(assignment_id: assignment.id).count
       expect(topics_exist).to be_eql 0
+    end
+
+    it "hides topics tab when has topics is un-checked", js:true do
+      click_link 'General'
+      uncheck("assignment_has_topics")
+      # The below line is used to accept the js confirmation popup
+      page.driver.browser.switch_to.alert.accept
+      # Wait for topics to be removed and page to re-load
+      sleep 3
+      expect(page).not_to have_link('Topics')
     end
   end
 


### PR DESCRIPTION
This adds a 'has topics' checkbox to the general tab while editing assignments.

**Note**: This box only appears AFTER an assignment has been created (to remain consistent with the existing behavior)

1. The '_Topics_' tab is now by default hidden.
2. Checking the 'has topics' checkbox brings up the '_Topics_' tab, where an instructor can add a topic as usual.
3. Un-checking the 'has topics' checkbox brings up a confirmation dialog, and then removes all existing topics from the assignment and reloads the page.

Some feature and controller tests have been updated to expect this new behavior.

@Winbobob 
@efg 
