### PR TITLE
E1926. Improve self-review  Link peer review & self-review to derive grades

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -496,7 +496,7 @@ end
   num_of_expect_key_words = added_lines.scan(/\s*expect\s*[\(\{]/).count
   num_of_commented_out_expect_key_words = added_lines.scan(/#\s*expect/).count
   num_of_expectation_without_machers = added_lines_arr.count{ |loc| loc.scan(/\s*expect\s*[\(\{]/).count > 0 and loc.scan(/\.(to|not_to|to_not)/).count == 0}
-  num_of_expectation_not_focus_on_real_value = added_lines_arr.count{ |loc| loc.scan(/\s*expect\s*[\(\{]/).count > 0 and loc.scan(/\.(to|not_to|to_not)\s*(be_nil|be_empty|eq 0|eql 0|equal 0)/) > 0 }
+  num_of_expectation_not_focus_on_real_value = added_lines_arr.count{ |loc| loc.scan(/\s*expect\s*[\(\{]/).count > 0 and loc.scan(/\.(not_to|to_not)\s*(be_nil|be_empty|eq 0|eql 0|equal 0)/).count > 0 }
   num_of_wildcard_argument_matchers = added_lines.scan(/\((anything|any_args)\)/).count
   num_of_expectations_on_page = added_lines.scan(/\s*expect\s*\(page\)/).count
   

--- a/Dangerfile
+++ b/Dangerfile
@@ -212,12 +212,12 @@ end
                 .select{|loc| loc.start_with? '+' and !loc.include? '+++ b'}
                 .join('')
   if added_lines.include? "xdescribe" or
-     added_lines.include? "xspecify" or
-     added_lines.include? "xexample" or
-     added_lines.include? "xit" or
-     added_lines.include? "skip(" or
-     added_lines.include? "skip " or
-     added_lines.include? "pending(" or
+     added_lines.include? "xspecify"  or
+     added_lines.include? "xexample"  or
+     added_lines.include? "xit"       or
+     added_lines.include? "skip("     or
+     added_lines.include? "skip "     or
+     added_lines.include? "pending("  or
      added_lines.include? "fdescribe" or
      added_lines.include? "fit"
     TEST_SKIPPED_MESSAGE =
@@ -276,15 +276,25 @@ end
 # ------------------------------------------------------------------------------
 # 14. Your RSpec testing files do not need to require helper files (e.g., rails_helper.rb, spec_helper.rb). 
 # ------------------------------------------------------------------------------
-if !CURRENT_MAINTAINERS.include? PR_AUTHOR and
-  ((ADDED_FILES + MODIFIED_FILES + RENAMED_FILES).grep(/rails_helper\.rb/).any? or 
-   (ADDED_FILES + MODIFIED_FILES + RENAMED_FILES).grep(/spec_helper\.rb/).any?)
-  TEST_HELPER_FILE_MESSAGE =
-    markdown <<-MARKDOWN
-You should not change `rails_helper.rb` or `spec_helper.rb` file; please revert these changes.
-    MARKDOWN
+if PR_ADDED.include? "require 'rspec'"                or
+   PR_ADDED.include? "require \"rspec\""              or
+   PR_ADDED.include? "require 'spec_helper'"          or
+   PR_ADDED.include? "require \"spec_helper\""        or
+   PR_ADDED.include? "require 'rails_helper'"         or
+   PR_ADDED.include? "require \"rails_helper\""       or
+   PR_ADDED.include? "require 'test_helper'"          or
+   PR_ADDED.include? "require \"test_helper\""        or
+   PR_ADDED.include? "require 'factory_girl_rails'"   or
+   PR_ADDED.include? "require \"factory_girl_rails\"" or
+   PR_ADDED.include? "require 'factory_bot_rails'"    or
+   PR_ADDED.include? "require \"factory_bot_rails\""
+  RSPEC_REQUIRE_MESSAGE =
+  markdown <<-MARKDOWN
+You are requiring `rspec` gem, fixture-related gem(s) or different helper methods in RSpec tests.
+There have already been included, you do not need to require them again. Please remove them.
+   MARKDOWN
 
-  warn(TEST_HELPER_FILE_MESSAGE, sticky: true)
+  warn(RSPEC_REQUIRE_MESSAGE, sticky: true)
 end
 
 # ------------------------------------------------------------------------------
@@ -312,8 +322,8 @@ end
 # 17. Your pull request should not change DB schema unless there is new DB migrations.
 # ------------------------------------------------------------------------------
 if !CURRENT_MAINTAINERS.include? PR_AUTHOR and
-  ((ADDED_FILES + MODIFIED_FILES + RENAMED_FILES).grep(/db\/migrate/).empty? and
-  ((MODIFIED_FILES.grep(/schema\.rb/).any? or (ADDED_FILES + MODIFIED_FILES + RENAMED_FILES).grep(/schema\.json/).any?)))
+  (TOUCHED_FILES.grep(/db\/migrate/).empty? and
+  (MODIFIED_FILES.grep(/schema\.rb/).any? or (ADDED_FILES + MODIFIED_FILES + RENAMED_FILES).grep(/schema\.json/).any?))
   DB_SCHEMA_CHANGE_MESSAGE =
     markdown <<-MARKDOWN
 You should commit changes to the DB schema (`db/schema.rb`) only if you have created new DB migrations.
@@ -338,25 +348,14 @@ end
 # ------------------------------------------------------------------------------
 # 19. Your pull request should not modify test-related helper files.
 # ------------------------------------------------------------------------------
-if PR_ADDED.include? "require 'rspec'" or
-   PR_ADDED.include? "require \"rspec\"" or
-   PR_ADDED.include? "require 'spec_helper'" or
-   PR_ADDED.include? "require \"spec_helper\"" or
-   PR_ADDED.include? "require 'rails_helper'" or
-   PR_ADDED.include? "require \"rails_helper\"" or
-   PR_ADDED.include? "require 'test_helper'" or
-   PR_ADDED.include? "require \"test_helper\"" or
-   PR_ADDED.include? "require 'factory_girl_rails'" or
-   PR_ADDED.include? "require \"factory_girl_rails\"" or
-   PR_ADDED.include? "require 'factory_bot_rails'" or
-   PR_ADDED.include? "require \"factory_bot_rails\""
-  RSPEC_REQUIRE_MESSAGE =
+if !CURRENT_MAINTAINERS.include? PR_AUTHOR and
+  (MODIFIED_FILES.grep(/rails_helper\.rb/).any? or MODIFIED_FILES.grep(/spec_helper\.rb/).any?)
+  TEST_HELPER_FILE_MESSAGE =
     markdown <<-MARKDOWN
-You are requiring `rspec` gem, fixture-related gem(s) or different helper methods in RSpec tests.
-There have already been included, you do not need to require them again. Please remove them.
+You should not change `rails_helper.rb` or `spec_helper.rb` file; please revert these changes.
     MARKDOWN
 
-  warn(RSPEC_REQUIRE_MESSAGE, sticky: true)
+  warn(TEST_HELPER_FILE_MESSAGE, sticky: true)
 end
 
 # ------------------------------------------------------------------------------
@@ -477,11 +476,12 @@ end
 
 # ------------------------------------------------------------------------------
 # RSpec tests should avoid shallow tests
-# 37. Not writing expectations for the tests.
-# 38. Test expectations do not include matchers, such as comparisons (e.g.,equal(expected_value)),
+# 37. Including too many wildcard argument matchers (e.g., anything, any_args).
+# 38. Not writing/commenting out expectations for the tests.
+# 39. Test expectations do not include matchers, such as comparisons (e.g.,equal(expected_value)),
 #     the status change of objects (e.g.,change(object, :value).by(delta)), error handlings (e.g.,raise_error("message")).
-# 39. Including too many wildcard argument matchers (e.g., anything, any_args)
-# 40. In feature tests, expectations only focus on words appearance on the view(e.g.,expect(page).to have_content(word)),
+# 40. Test expectations only focus on the return value not being nil, empty or not equal to 0 without testing the real value.
+# 41. In feature tests, expectations only focus on words appearance on the view(e.g.,expect(page).to have_content(word)),
 #     and without otherevidence, such as the new creation of the object, new record in DB.
 # ------------------------------------------------------------------------------
 (ADDED_FILES + MODIFIED_FILES + RENAMED_FILES).each do |file|
@@ -494,14 +494,26 @@ end
   added_lines = added_lines_arr.join('')
   num_of_tests = added_lines.scan(/\s*it\s*['"]/).count
   num_of_expect_key_words = added_lines.scan(/\s*expect\s*[\(\{]/).count
+  num_of_commented_out_expect_key_words = added_lines.scan(/#\s*expect/).count
   num_of_expectation_without_machers = added_lines_arr.count{ |loc| loc.scan(/\s*expect\s*[\(\{]/).count > 0 and loc.scan(/\.(to|not_to|to_not)/).count == 0}
-  num_of_wildcard_argument_matchers = PR_ADDED.scan(/\((anything|any_args)\)/).count
+  num_of_expectation_not_focus_on_real_value = added_lines_arr.count{ |loc| loc.scan(/\s*expect\s*[\(\{]/).count > 0 and loc.scan(/\.(to|not_to|to_not)\s*(be_nil|be_empty|eq 0|eql 0|equal 0)/) > 0 }
+  num_of_wildcard_argument_matchers = added_lines.scan(/\((anything|any_args)\)/).count
   num_of_expectations_on_page = added_lines.scan(/\s*expect\s*\(page\)/).count
-  if num_of_expect_key_words < num_of_tests
+  
+  if num_of_wildcard_argument_matchers >= 5
+    WILDCARD_ARGUMENT_MATCHERS_MESSAGE =
+      markdown <<-MARKDOWN
+There are many wildcard argument matchers (e.g., `anything`, `any_args`) in your tests.
+To avoid `shallow tests` -- tests concentrating on irrelevant, unlikely-to-fail conditions -- please avoid wildcard matchers.
+      MARKDOWN
+
+    warn(WILDCARD_ARGUMENT_MATCHERS_MESSAGE, sticky: true)
+    break
+  elsif num_of_expect_key_words < num_of_tests or num_of_commented_out_expect_key_words > 0
     NOT_WRITING_EXPECTATIONS_FOR_TESTS_MESSAGE =
       markdown <<-MARKDOWN
-One or more of your tests do not have expectations.
-To avoid `shallow tests` -- tests concentrating on irrelevant, unlikely-to-fail conditions -- please write at least one expectation for each test.
+One or more of your tests do not have expectations or you commented out some expectations.
+To avoid `shallow tests` -- tests concentrating on irrelevant, unlikely-to-fail conditions -- please write at least one expectation for each test and do not comment out expectations.
       MARKDOWN
 
     warn(NOT_WRITING_EXPECTATIONS_FOR_TESTS_MESSAGE, sticky: true)
@@ -515,15 +527,15 @@ To avoid `shallow tests` -- tests concentrating on irrelevant, unlikely-to-fail 
 
     warn(EXPECTATION_WITHOUT_MATCHERS_MESSAGE, sticky: true)
     break
-  elsif num_of_wildcard_argument_matchers >= 5
-    WILDCARD_ARGUMENT_MATCHERS_MESSAGE =
+  elsif num_of_expectation_not_focus_on_real_value > 0
+    EXPECTATION_NOT_FOCUS_ON_REAL_VALUE = 
       markdown <<-MARKDOWN
-There are many wildcard argument matchers (e.g., `anything`, `any_args`) in your tests.
-To avoid `shallow tests` -- tests concentrating on irrelevant, unlikely-to-fail conditions -- please avoid wildcard matchers.
+One or more of your test expectations only focus on the return value not being `nil`, `empty` or not equal to `0` without testing the `real` value.
+To avoid `shallow tests` -- tests concentrating on irrelevant, unlikely-to-fail conditions -- please write expectations to test the `real` value.
       MARKDOWN
 
-    warn(WILDCARD_ARGUMENT_MATCHERS_MESSAGE, sticky: true)
-    break
+      warn(EXPECTATION_NOT_FOCUS_ON_REAL_VALUE, sticky: true)
+      break
   elsif num_of_expect_key_words - num_of_expectations_on_page < num_of_tests
     EXPECT_ON_OBJ_ON_PAGE_MESSAGE =
       markdown <<-MARKDOWN

--- a/Dangerfile
+++ b/Dangerfile
@@ -88,13 +88,13 @@ end
 # 3. Your pull request should not touch too many files (more than 30 files).
 # ------------------------------------------------------------------------------
 if TOUCHED_FILES.size > 30
-  BIG_PR_MESSAGE2 =
+  BIG_PR_MESSAGE =
     markdown <<-MARKDOWN
 Your pull request touches more than 30 files.
 Please make sure you did not commit unnecessary changes, such as `node_modules`, `change logs`.
     MARKDOWN
 
-  warn(BIG_PR_MESSAGE2, sticky: true)
+  warn(BIG_PR_MESSAGE, sticky: true)
 end
 
 # ------------------------------------------------------------------------------
@@ -167,23 +167,13 @@ end
 # ------------------------------------------------------------------------------
 # 8. Your pull request should avoid using global variables and/or class variables.
 # ------------------------------------------------------------------------------
-(ADDED_FILES + MODIFIED_FILES + RENAMED_FILES).each do |file|
-  next unless file =~ /.*\.rb$/
-  added_lines = git
-                .diff_for_file(file)
-                .patch
-                .split("\n")
-                .select{|loc| loc.start_with? '+' and !loc.include? '+++ b'}
-                .join('')
-  if added_lines =~ /\$[A-Za-z0-9_]+/ or added_lines =~ /@@[A-Za-z0-9_]+/
-    GLOBAL_CLASS_VARIABLE_MESSAGE =
-      markdown <<-MARKDOWN
+if PR_ADDED =~ /\$[A-Za-z0-9_]+/ or PR_ADDED =~ /@@[A-Za-z0-9_]+/
+  GLOBAL_CLASS_VARIABLE_MESSAGE =
+    markdown <<-MARKDOWN
 You are using global variables (`$`) or class variables (`@@`); please double-check whether this is necessary.
     MARKDOWN
 
-    warn(GLOBAL_CLASS_VARIABLE_MESSAGE, sticky: true)
-    break
-  end
+  warn(GLOBAL_CLASS_VARIABLE_MESSAGE, sticky: true)
 end
 
 # ------------------------------------------------------------------------------
@@ -284,7 +274,7 @@ Even in test descriptions, please avoid using `should`.
 end
 
 # ------------------------------------------------------------------------------
-# 14. Your RSpec testing files do not need to require helper files (e.g., rails_helper.rb, spec_helper.rb).
+# 14. Your RSpec testing files do not need to require helper files (e.g., rails_helper.rb, spec_helper.rb). 
 # ------------------------------------------------------------------------------
 if PR_ADDED.include? "require 'rspec'"                or
    PR_ADDED.include? "require \"rspec\""              or
@@ -310,7 +300,7 @@ end
 # ------------------------------------------------------------------------------
 # 15. You should avoid committing text files for RSpec tests.
 # ------------------------------------------------------------------------------
-if (ADDED_FILES + MODIFIED_FILES + RENAMED_FILES).grep(/.*spec.*\.txt/).any? or
+if (ADDED_FILES + MODIFIED_FILES + RENAMED_FILES).grep(/.*spec.*\.txt/).any? or 
    (ADDED_FILES + MODIFIED_FILES + RENAMED_FILES).grep(/.*spec.*\.csv/).any?
   warn("You committed text files (`*.txt` or `*.csv`) for RSpec tests; please double-check whether this is necessary.", sticky: true)
 end
@@ -502,14 +492,14 @@ end
                     .split("\n")
                     .select{|loc| loc.start_with? '+' and !loc.include? '+++ b'}
   added_lines = added_lines_arr.join('')
-  num_of_tests = added_lines.scan(/\+\s*it\s*['"]/).count
-  num_of_expect_key_words = added_lines.scan(/\+\s*expect\s*(\(|\{|do)/).count
-  num_of_commented_out_expect_key_words = added_lines.scan(/\+\s*#\s*expect\s*(\(|\{|do)/).count
-  num_of_expectation_without_machers = added_lines_arr.count{ |loc| loc.scan(/^\+\s*expect\s*[\(\{]/).count > 0 and loc.scan(/\.(to|not_to|to_not)/).count == 0}
-  num_of_expectation_not_focus_on_real_value = added_lines_arr.count{ |loc| loc.scan(/^\+\s*expect\s*[\(\{]/).count > 0 and loc.scan(/\.(not_to|to_not)\s*(be_nil|be_empty|eq 0|eql 0|equal 0)/).count > 0 }
+  num_of_tests = added_lines.scan(/\s*it\s*['"]/).count
+  num_of_expect_key_words = added_lines.scan(/\s*expect\s*[\(\{]/).count
+  num_of_commented_out_expect_key_words = added_lines.scan(/#\s*expect/).count
+  num_of_expectation_without_machers = added_lines_arr.count{ |loc| loc.scan(/\s*expect\s*[\(\{]/).count > 0 and loc.scan(/\.(to|not_to|to_not)/).count == 0}
+  num_of_expectation_not_focus_on_real_value = added_lines_arr.count{ |loc| loc.scan(/\s*expect\s*[\(\{]/).count > 0 and loc.scan(/\.(not_to|to_not)\s*(be_nil|be_empty|eq 0|eql 0|equal 0)/).count > 0 }
   num_of_wildcard_argument_matchers = added_lines.scan(/\((anything|any_args)\)/).count
-  num_of_expectations_on_page = added_lines.scan(/\+\s*expect\s*\(page\)/).count
-
+  num_of_expectations_on_page = added_lines.scan(/\s*expect\s*\(page\)/).count
+  
   if num_of_wildcard_argument_matchers >= 5
     WILDCARD_ARGUMENT_MATCHERS_MESSAGE =
       markdown <<-MARKDOWN
@@ -538,7 +528,7 @@ To avoid `shallow tests` -- tests concentrating on irrelevant, unlikely-to-fail 
     warn(EXPECTATION_WITHOUT_MATCHERS_MESSAGE, sticky: true)
     break
   elsif num_of_expectation_not_focus_on_real_value > 0
-    EXPECTATION_NOT_FOCUS_ON_REAL_VALUE =
+    EXPECTATION_NOT_FOCUS_ON_REAL_VALUE = 
       markdown <<-MARKDOWN
 One or more of your test expectations only focus on the return value not being `nil`, `empty` or not equal to `0` without testing the `real` value.
 To avoid `shallow tests` -- tests concentrating on irrelevant, unlikely-to-fail conditions -- please write expectations to test the `real` value.

--- a/Dangerfile
+++ b/Dangerfile
@@ -88,13 +88,13 @@ end
 # 3. Your pull request should not touch too many files (more than 30 files).
 # ------------------------------------------------------------------------------
 if TOUCHED_FILES.size > 30
-  BIG_PR_MESSAGE =
+  BIG_PR_MESSAGE2 =
     markdown <<-MARKDOWN
 Your pull request touches more than 30 files.
 Please make sure you did not commit unnecessary changes, such as `node_modules`, `change logs`.
     MARKDOWN
 
-  warn(BIG_PR_MESSAGE, sticky: true)
+  warn(BIG_PR_MESSAGE2, sticky: true)
 end
 
 # ------------------------------------------------------------------------------
@@ -167,13 +167,23 @@ end
 # ------------------------------------------------------------------------------
 # 8. Your pull request should avoid using global variables and/or class variables.
 # ------------------------------------------------------------------------------
-if PR_ADDED =~ /\$[A-Za-z0-9_]+/ or PR_ADDED =~ /@@[A-Za-z0-9_]+/
-  GLOBAL_CLASS_VARIABLE_MESSAGE =
-    markdown <<-MARKDOWN
+(ADDED_FILES + MODIFIED_FILES + RENAMED_FILES).each do |file|
+  next unless file =~ /.*\.rb$/
+  added_lines = git
+                .diff_for_file(file)
+                .patch
+                .split("\n")
+                .select{|loc| loc.start_with? '+' and !loc.include? '+++ b'}
+                .join('')
+  if added_lines =~ /\$[A-Za-z0-9_]+/ or added_lines =~ /@@[A-Za-z0-9_]+/
+    GLOBAL_CLASS_VARIABLE_MESSAGE =
+      markdown <<-MARKDOWN
 You are using global variables (`$`) or class variables (`@@`); please double-check whether this is necessary.
     MARKDOWN
 
-  warn(GLOBAL_CLASS_VARIABLE_MESSAGE, sticky: true)
+    warn(GLOBAL_CLASS_VARIABLE_MESSAGE, sticky: true)
+    break
+  end
 end
 
 # ------------------------------------------------------------------------------
@@ -274,7 +284,7 @@ Even in test descriptions, please avoid using `should`.
 end
 
 # ------------------------------------------------------------------------------
-# 14. Your RSpec testing files do not need to require helper files (e.g., rails_helper.rb, spec_helper.rb). 
+# 14. Your RSpec testing files do not need to require helper files (e.g., rails_helper.rb, spec_helper.rb).
 # ------------------------------------------------------------------------------
 if PR_ADDED.include? "require 'rspec'"                or
    PR_ADDED.include? "require \"rspec\""              or
@@ -300,7 +310,7 @@ end
 # ------------------------------------------------------------------------------
 # 15. You should avoid committing text files for RSpec tests.
 # ------------------------------------------------------------------------------
-if (ADDED_FILES + MODIFIED_FILES + RENAMED_FILES).grep(/.*spec.*\.txt/).any? or 
+if (ADDED_FILES + MODIFIED_FILES + RENAMED_FILES).grep(/.*spec.*\.txt/).any? or
    (ADDED_FILES + MODIFIED_FILES + RENAMED_FILES).grep(/.*spec.*\.csv/).any?
   warn("You committed text files (`*.txt` or `*.csv`) for RSpec tests; please double-check whether this is necessary.", sticky: true)
 end
@@ -492,14 +502,14 @@ end
                     .split("\n")
                     .select{|loc| loc.start_with? '+' and !loc.include? '+++ b'}
   added_lines = added_lines_arr.join('')
-  num_of_tests = added_lines.scan(/\s*it\s*['"]/).count
-  num_of_expect_key_words = added_lines.scan(/\s*expect\s*[\(\{]/).count
-  num_of_commented_out_expect_key_words = added_lines.scan(/#\s*expect/).count
-  num_of_expectation_without_machers = added_lines_arr.count{ |loc| loc.scan(/\s*expect\s*[\(\{]/).count > 0 and loc.scan(/\.(to|not_to|to_not)/).count == 0}
-  num_of_expectation_not_focus_on_real_value = added_lines_arr.count{ |loc| loc.scan(/\s*expect\s*[\(\{]/).count > 0 and loc.scan(/\.(not_to|to_not)\s*(be_nil|be_empty|eq 0|eql 0|equal 0)/).count > 0 }
+  num_of_tests = added_lines.scan(/\+\s*it\s*['"]/).count
+  num_of_expect_key_words = added_lines.scan(/\+\s*expect\s*(\(|\{|do)/).count
+  num_of_commented_out_expect_key_words = added_lines.scan(/\+\s*#\s*expect\s*(\(|\{|do)/).count
+  num_of_expectation_without_machers = added_lines_arr.count{ |loc| loc.scan(/^\+\s*expect\s*[\(\{]/).count > 0 and loc.scan(/\.(to|not_to|to_not)/).count == 0}
+  num_of_expectation_not_focus_on_real_value = added_lines_arr.count{ |loc| loc.scan(/^\+\s*expect\s*[\(\{]/).count > 0 and loc.scan(/\.(not_to|to_not)\s*(be_nil|be_empty|eq 0|eql 0|equal 0)/).count > 0 }
   num_of_wildcard_argument_matchers = added_lines.scan(/\((anything|any_args)\)/).count
-  num_of_expectations_on_page = added_lines.scan(/\s*expect\s*\(page\)/).count
-  
+  num_of_expectations_on_page = added_lines.scan(/\+\s*expect\s*\(page\)/).count
+
   if num_of_wildcard_argument_matchers >= 5
     WILDCARD_ARGUMENT_MATCHERS_MESSAGE =
       markdown <<-MARKDOWN
@@ -528,7 +538,7 @@ To avoid `shallow tests` -- tests concentrating on irrelevant, unlikely-to-fail 
     warn(EXPECTATION_WITHOUT_MATCHERS_MESSAGE, sticky: true)
     break
   elsif num_of_expectation_not_focus_on_real_value > 0
-    EXPECTATION_NOT_FOCUS_ON_REAL_VALUE = 
+    EXPECTATION_NOT_FOCUS_ON_REAL_VALUE =
       markdown <<-MARKDOWN
 One or more of your test expectations only focus on the return value not being `nil`, `empty` or not equal to `0` without testing the `real` value.
 To avoid `shallow tests` -- tests concentrating on irrelevant, unlikely-to-fail conditions -- please write expectations to test the `real` value.

--- a/Dangerfile
+++ b/Dangerfile
@@ -88,13 +88,13 @@ end
 # 3. Your pull request should not touch too many files (more than 30 files).
 # ------------------------------------------------------------------------------
 if TOUCHED_FILES.size > 30
-  BIG_PR_MESSAGE2 =
+  BIG_PR_MESSAGE =
     markdown <<-MARKDOWN
 Your pull request touches more than 30 files.
 Please make sure you did not commit unnecessary changes, such as `node_modules`, `change logs`.
     MARKDOWN
 
-  warn(BIG_PR_MESSAGE2, sticky: true)
+  warn(BIG_PR_MESSAGE, sticky: true)
 end
 
 # ------------------------------------------------------------------------------
@@ -167,23 +167,13 @@ end
 # ------------------------------------------------------------------------------
 # 8. Your pull request should avoid using global variables and/or class variables.
 # ------------------------------------------------------------------------------
-(ADDED_FILES + MODIFIED_FILES + RENAMED_FILES).each do |file|
-  next unless file =~ /.*\.rb$/
-  added_lines = git
-                .diff_for_file(file)
-                .patch
-                .split("\n")
-                .select{|loc| loc.start_with? '+' and !loc.include? '+++ b'}
-                .join('')
-  if added_lines =~ /\$[A-Za-z0-9_]+/ or added_lines =~ /@@[A-Za-z0-9_]+/
-    GLOBAL_CLASS_VARIABLE_MESSAGE =
-      markdown <<-MARKDOWN
+if PR_ADDED =~ /\$[A-Za-z0-9_]+/ or PR_ADDED =~ /@@[A-Za-z0-9_]+/
+  GLOBAL_CLASS_VARIABLE_MESSAGE =
+    markdown <<-MARKDOWN
 You are using global variables (`$`) or class variables (`@@`); please double-check whether this is necessary.
     MARKDOWN
 
-    warn(GLOBAL_CLASS_VARIABLE_MESSAGE, sticky: true)
-    break
-  end
+  warn(GLOBAL_CLASS_VARIABLE_MESSAGE, sticky: true)
 end
 
 # ------------------------------------------------------------------------------
@@ -502,13 +492,13 @@ end
                     .split("\n")
                     .select{|loc| loc.start_with? '+' and !loc.include? '+++ b'}
   added_lines = added_lines_arr.join('')
-  num_of_tests = added_lines.scan(/\+\s*it\s*['"]/).count
-  num_of_expect_key_words = added_lines.scan(/\+\s*expect\s*(\(|\{|do)/).count
-  num_of_commented_out_expect_key_words = added_lines.scan(/\+\s*#\s*expect\s*(\(|\{|do)/).count
-  num_of_expectation_without_machers = added_lines_arr.count{ |loc| loc.scan(/^\+\s*expect\s*[\(\{]/).count > 0 and loc.scan(/\.(to|not_to|to_not)/).count == 0}
-  num_of_expectation_not_focus_on_real_value = added_lines_arr.count{ |loc| loc.scan(/^\+\s*expect\s*[\(\{]/).count > 0 and loc.scan(/\.(not_to|to_not)\s*(be_nil|be_empty|eq 0|eql 0|equal 0)/).count > 0 }
+  num_of_tests = added_lines.scan(/\s*it\s*['"]/).count
+  num_of_expect_key_words = added_lines.scan(/\s*expect\s*[\(\{]/).count
+  num_of_commented_out_expect_key_words = added_lines.scan(/#\s*expect/).count
+  num_of_expectation_without_machers = added_lines_arr.count{ |loc| loc.scan(/\s*expect\s*[\(\{]/).count > 0 and loc.scan(/\.(to|not_to|to_not)/).count == 0}
+  num_of_expectation_not_focus_on_real_value = added_lines_arr.count{ |loc| loc.scan(/\s*expect\s*[\(\{]/).count > 0 and loc.scan(/\.(not_to|to_not)\s*(be_nil|be_empty|eq 0|eql 0|equal 0)/).count > 0 }
   num_of_wildcard_argument_matchers = added_lines.scan(/\((anything|any_args)\)/).count
-  num_of_expectations_on_page = added_lines.scan(/\+\s*expect\s*\(page\)/).count
+  num_of_expectations_on_page = added_lines.scan(/\s*expect\s*\(page\)/).count
 
   if num_of_wildcard_argument_matchers >= 5
     WILDCARD_ARGUMENT_MATCHERS_MESSAGE =

--- a/Dangerfile
+++ b/Dangerfile
@@ -88,13 +88,13 @@ end
 # 3. Your pull request should not touch too many files (more than 30 files).
 # ------------------------------------------------------------------------------
 if TOUCHED_FILES.size > 30
-  BIG_PR_MESSAGE =
+  BIG_PR_MESSAGE2 =
     markdown <<-MARKDOWN
 Your pull request touches more than 30 files.
 Please make sure you did not commit unnecessary changes, such as `node_modules`, `change logs`.
     MARKDOWN
 
-  warn(BIG_PR_MESSAGE, sticky: true)
+  warn(BIG_PR_MESSAGE2, sticky: true)
 end
 
 # ------------------------------------------------------------------------------
@@ -167,13 +167,23 @@ end
 # ------------------------------------------------------------------------------
 # 8. Your pull request should avoid using global variables and/or class variables.
 # ------------------------------------------------------------------------------
-if PR_ADDED =~ /\$[A-Za-z0-9_]+/ or PR_ADDED =~ /@@[A-Za-z0-9_]+/
-  GLOBAL_CLASS_VARIABLE_MESSAGE =
-    markdown <<-MARKDOWN
+(ADDED_FILES + MODIFIED_FILES + RENAMED_FILES).each do |file|
+  next unless file =~ /.*\.rb$/
+  added_lines = git
+                .diff_for_file(file)
+                .patch
+                .split("\n")
+                .select{|loc| loc.start_with? '+' and !loc.include? '+++ b'}
+                .join('')
+  if added_lines =~ /\$[A-Za-z0-9_]+/ or added_lines =~ /@@[A-Za-z0-9_]+/
+    GLOBAL_CLASS_VARIABLE_MESSAGE =
+      markdown <<-MARKDOWN
 You are using global variables (`$`) or class variables (`@@`); please double-check whether this is necessary.
     MARKDOWN
 
-  warn(GLOBAL_CLASS_VARIABLE_MESSAGE, sticky: true)
+    warn(GLOBAL_CLASS_VARIABLE_MESSAGE, sticky: true)
+    break
+  end
 end
 
 # ------------------------------------------------------------------------------
@@ -492,13 +502,13 @@ end
                     .split("\n")
                     .select{|loc| loc.start_with? '+' and !loc.include? '+++ b'}
   added_lines = added_lines_arr.join('')
-  num_of_tests = added_lines.scan(/\s*it\s*['"]/).count
-  num_of_expect_key_words = added_lines.scan(/\s*expect\s*[\(\{]/).count
-  num_of_commented_out_expect_key_words = added_lines.scan(/#\s*expect/).count
-  num_of_expectation_without_machers = added_lines_arr.count{ |loc| loc.scan(/\s*expect\s*[\(\{]/).count > 0 and loc.scan(/\.(to|not_to|to_not)/).count == 0}
-  num_of_expectation_not_focus_on_real_value = added_lines_arr.count{ |loc| loc.scan(/\s*expect\s*[\(\{]/).count > 0 and loc.scan(/\.(not_to|to_not)\s*(be_nil|be_empty|eq 0|eql 0|equal 0)/).count > 0 }
+  num_of_tests = added_lines.scan(/\+\s*it\s*['"]/).count
+  num_of_expect_key_words = added_lines.scan(/\+\s*expect\s*(\(|\{|do)/).count
+  num_of_commented_out_expect_key_words = added_lines.scan(/\+\s*#\s*expect\s*(\(|\{|do)/).count
+  num_of_expectation_without_machers = added_lines_arr.count{ |loc| loc.scan(/^\+\s*expect\s*[\(\{]/).count > 0 and loc.scan(/\.(to|not_to|to_not)/).count == 0}
+  num_of_expectation_not_focus_on_real_value = added_lines_arr.count{ |loc| loc.scan(/^\+\s*expect\s*[\(\{]/).count > 0 and loc.scan(/\.(not_to|to_not)\s*(be_nil|be_empty|eq 0|eql 0|equal 0)/).count > 0 }
   num_of_wildcard_argument_matchers = added_lines.scan(/\((anything|any_args)\)/).count
-  num_of_expectations_on_page = added_lines.scan(/\s*expect\s*\(page\)/).count
+  num_of_expectations_on_page = added_lines.scan(/\+\s*expect\s*\(page\)/).count
   
   if num_of_wildcard_argument_matchers >= 5
     WILDCARD_ARGUMENT_MATCHERS_MESSAGE =

--- a/app/controllers/grades_controller.rb
+++ b/app/controllers/grades_controller.rb
@@ -67,6 +67,11 @@ class GradesController < ApplicationController
     @questions = retrieve_questions questionnaires, @assignment.id
     # @pscore has the newest versions of response for each response map, and only one for each response map (unless it is vary rubric by round)
     @pscore = @participant.scores(@questions)
+
+    #Changes by Rahul Sethi
+    @new_derived_scores = @participant.scores(@questions)
+    #Changes End
+
     make_chart
     @topic_id = SignedUpTeam.topic_id(@participant.assignment.id, @participant.user_id)
     @stage = @participant.assignment.get_current_stage(@topic_id)
@@ -88,6 +93,11 @@ class GradesController < ApplicationController
     questionnaires = @assignment.questionnaires
     @questions = retrieve_questions questionnaires, @assignment.id
     @pscore = @participant.scores(@questions)
+
+    # Changes by Rahul Sethi
+    @new_derived_scores = @participant.scores(@questions)
+    # Changes End
+
     @vmlist = []
 
     # loop through each questionnaire, and populate the view model for all data necessary

--- a/app/controllers/grades_controller.rb
+++ b/app/controllers/grades_controller.rb
@@ -68,9 +68,11 @@ class GradesController < ApplicationController
     # @pscore has the newest versions of response for each response map, and only one for each response map (unless it is vary rubric by round)
     @pscore = @participant.scores(@questions)
 
-    #Changes by Rahul Sethi
-    @new_derived_scores = @participant.scores(@questions)
-    #Changes End
+    # Changes by Rahul Sethi
+    if @assignment.is_selfreview_enabled?
+      @new_derived_scores = @participant.scores(@questions)
+    end
+    # Changes End
 
     make_chart
     @topic_id = SignedUpTeam.topic_id(@participant.assignment.id, @participant.user_id)
@@ -95,7 +97,9 @@ class GradesController < ApplicationController
     @pscore = @participant.scores(@questions)
 
     # Changes by Rahul Sethi
-    @new_derived_scores = @participant.scores(@questions)
+    if @assignment.is_selfreview_enabled?
+      @new_derived_scores = @participant.scores(@questions)
+    end
     # Changes End
 
     @vmlist = []

--- a/app/controllers/grades_controller.rb
+++ b/app/controllers/grades_controller.rb
@@ -36,15 +36,6 @@ class GradesController < ApplicationController
   # an assignment. It lists all participants of an assignment and all the reviews they received.
   # It also gives a final score, which is an average of all the reviews and greatest difference
   # in the scores of all the reviews.
-  #
-  # Changes by Rahul Sethi
-  def derived_final_score(avg_self_review_score, actual_score)
-    sapa_factor = Math.sqrt(avg_self_review_score / actual_score)
-    final_score_after = sapa_factor * actual_score
-    final_report = final_score_after.round(2).to_s + ' (SRC- ' + avg_self_review_score.to_s + ', SAPA: ' + sapa_factor.round(2).to_s + ')'
-    final_report.to_s
-  end
-  # Changes end
 
   def view
     @assignment = Assignment.find(params[:id])
@@ -81,7 +72,11 @@ class GradesController < ApplicationController
     # Changes by Rahul Sethi
     if @assignment.is_selfreview_enabled?
       @self_review_scores = @participant.scores(@questions, true)
-      @new_derived_scores = derived_final_score(Rscore.new(@self_review_scores, :review).my_avg, Rscore.new(@pscore, :review).my_avg)
+      avg_self_review_score = Rscore.new(@self_review_scores, :review).my_avg
+      actual_score = Rscore.new(@pscore, :review).my_avg
+      sapa_factor = Math.sqrt(avg_self_review_score / actual_score)
+      final_score_after = sapa_factor * actual_score
+      @new_derived_scores = final_score_after.round(2).to_s + ' (SRC- ' + avg_self_review_score.to_s + ', SAPA: ' + sapa_factor.round(2).to_s + ')'
     end
     # Changes End
 
@@ -109,7 +104,11 @@ class GradesController < ApplicationController
     # Changes by Rahul Sethi
     if @assignment.is_selfreview_enabled?
       @self_review_scores = @participant.scores(@questions, true)
-      @new_derived_scores = derived_final_score(Rscore.new(@self_review_scores, :review).my_avg, Rscore.new(@pscore, :review).my_avg)
+      avg_self_review_score = Rscore.new(@self_review_scores, :review).my_avg
+      actual_score = Rscore.new(@pscore, :review).my_avg
+      sapa_factor = Math.sqrt(avg_self_review_score / actual_score)
+      final_score_after = sapa_factor * actual_score
+      @new_derived_scores = final_score_after.round(2).to_s + ' (SRC- ' + avg_self_review_score.to_s + ', SAPA: ' + sapa_factor.round(2).to_s + ')'
     end
     # Changes End
 

--- a/app/controllers/grades_controller.rb
+++ b/app/controllers/grades_controller.rb
@@ -36,17 +36,20 @@ class GradesController < ApplicationController
   # an assignment. It lists all participants of an assignment and all the reviews they received.
   # It also gives a final score, which is an average of all the reviews and greatest difference
   # in the scores of all the reviews.
+  #
+  # Changes by Rahul Sethi
   def derived_final_score(avg_self_review_score, actual_score)
     participant = AssignmentParticipant.find(params[:id])
     maps = ResponseMap.where(reviewee_id: participant.team.id)
     ctr = 0
-    maps.each do |map|
+    maps.each do
       ctr += 1
     end
     final_score_after = (avg_self_review_score + actual_score * (ctr - 1))
-    final_score_after = final_score_after / ctr
+    final_score_after /= ctr
     final_score_after.round(2)
   end
+  # Changes end
 
   def view
     @assignment = Assignment.find(params[:id])

--- a/app/controllers/grades_controller.rb
+++ b/app/controllers/grades_controller.rb
@@ -39,15 +39,10 @@ class GradesController < ApplicationController
   #
   # Changes by Rahul Sethi
   def derived_final_score(avg_self_review_score, actual_score)
-    participant = AssignmentParticipant.find(params[:id])
-    maps = ResponseMap.where(reviewee_id: participant.team.id)
-    ctr = 0
-    maps.each do
-      ctr += 1
-    end
-    final_score_after = (avg_self_review_score + actual_score * (ctr - 1))
-    final_score_after /= ctr
-    final_score_after.round(2)
+    sapa_factor = Math.sqrt(avg_self_review_score / actual_score)
+    final_score_after = sapa_factor * actual_score
+    final_report = final_score_after.round(2).to_s + ' (SRC- ' + avg_self_review_score.to_s + ', SAPA: ' + sapa_factor.round(2).to_s + ')'
+    final_report.to_s
   end
   # Changes end
 

--- a/app/controllers/sign_up_sheet_controller.rb
+++ b/app/controllers/sign_up_sheet_controller.rb
@@ -64,20 +64,14 @@ class SignUpSheetController < ApplicationController
   # Renaming delete method to destroy for rails 4 compatible
   def destroy
     @topic = SignUpTopic.find(params[:id])
-    assignment = Assignment.find(params[:assignment_id])
     if @topic
       @topic.destroy
       undo_link("The topic: \"#{@topic.topic_name}\" has been successfully deleted. ")
     else
       flash[:error] = "The topic could not be deleted."
     end
-    # Akshay - redirect to topics tab if there are still any topics left, otherwise redirect to
-    # assignment's edit page
-    if assignment.topics?
-      redirect_to edit_assignment_path(params[:assignment_id]) + "#tabs-2"
-    else
-      redirect_to edit_assignment_path(params[:assignment_id])
-    end
+    # changing the redirection url to topics tab in edit assignment view.
+    redirect_to edit_assignment_path(params[:assignment_id]) + "#tabs-5"
   end
 
   # prepares the page. shows the form which can be used to enter new values for the different properties of an assignment
@@ -101,19 +95,8 @@ class SignUpSheetController < ApplicationController
     else
       flash[:error] = "The topic could not be updated."
     end
-    # Akshay - correctly changing the redirection url to topics tab in edit assignment view.
-    redirect_to edit_assignment_path(params[:assignment_id]) + "#tabs-2"
-  end
-
-  # This deletes all topics for the given assignment
-  def delete_all_topics_for_assignment
-    topics = SignUpTopic.where(assignment_id: params[:assignment_id])
-    topics.each(&:destroy)
-    flash[:success] = "All topics have been deleted successfully."
-    respond_to do |format|
-      format.html { redirect_to edit_assignment_path(params[:assignment_id]) }
-      format.js {}
-    end
+    # changing the redirection url to topics tab in edit assignment view.
+    redirect_to edit_assignment_path(params[:assignment_id]) + "#tabs-5"
   end
 
   # This displays a page that lists all the available topics for an assignment.
@@ -429,8 +412,7 @@ class SignUpSheetController < ApplicationController
     end
     if @sign_up_topic.save
       undo_link "The topic: \"#{@sign_up_topic.topic_name}\" has been created successfully. "
-      # Akshay - correctly changing the redirection url to topics tab in edit assignment view.
-      redirect_to edit_assignment_path(@sign_up_topic.assignment_id) + "#tabs-2"
+      redirect_to edit_assignment_path(@sign_up_topic.assignment_id) + "#tabs-5"
     else
       render action: 'new', id: params[:id]
     end

--- a/app/models/assignment_participant.rb
+++ b/app/models/assignment_participant.rb
@@ -53,7 +53,6 @@ class AssignmentParticipant < Participant
   def scores(questions)
     scores = {}
     scores[:participant] = self
-    # compute_assignment_score(questions, scores)
     compute_assignment_score(questions, scores)
     scores[:total_score] = self.assignment.compute_total_score(scores)
     # merge scores[review#] (for each round) to score[review]  -Yang
@@ -153,12 +152,15 @@ class AssignmentParticipant < Participant
     # ACS Always get assessments for a team
     # removed check to see if it is a team assignment
     # ReviewResponseMap.get_assessments_for(self.team)
-    assignment_check = Assignment.find(self.team.parent_id)
-    if assignment_check.is_selfreview_enabled?
+
+    # Changes made by Rahul Sethi
+    current_assignment = Assignment.find(self.team.parent_id)
+    if current_assignment.is_selfreview_enabled?
       ResponseMap.get_assessments_for(self.team, self.id)
     else
       ReviewResponseMap.get_assessments_for(self.team)
     end
+    # Changes End
   end
 
   def reviews_by_reviewer(reviewer)

--- a/app/models/assignment_participant.rb
+++ b/app/models/assignment_participant.rb
@@ -53,6 +53,7 @@ class AssignmentParticipant < Participant
   def scores(questions)
     scores = {}
     scores[:participant] = self
+    # compute_assignment_score(questions, scores)
     compute_assignment_score(questions, scores)
     scores[:total_score] = self.assignment.compute_total_score(scores)
     # merge scores[review#] (for each round) to score[review]  -Yang
@@ -151,7 +152,13 @@ class AssignmentParticipant < Participant
   def reviews
     # ACS Always get assessments for a team
     # removed check to see if it is a team assignment
-    ReviewResponseMap.get_assessments_for(self.team)
+    # ReviewResponseMap.get_assessments_for(self.team)
+    assignment_check = Assignment.find(self.team.parent_id)
+    if assignment_check.is_selfreview_enabled?
+      ResponseMap.get_assessments_for(self.team, self.id)
+    else
+      ReviewResponseMap.get_assessments_for(self.team)
+    end
   end
 
   def reviews_by_reviewer(reviewer)

--- a/app/models/assignment_participant.rb
+++ b/app/models/assignment_participant.rb
@@ -50,10 +50,10 @@ class AssignmentParticipant < Participant
 
   # Return scores that this participant has been given
   # methods extracted from scores method: merge_scores, topic_total_scores, calculate_scores
-  def scores(questions)
+  def scores(questions, requesting_score = false)
     scores = {}
     scores[:participant] = self
-    compute_assignment_score(questions, scores)
+    compute_assignment_score(questions, scores, requesting_score)
     scores[:total_score] = self.assignment.compute_total_score(scores)
     # merge scores[review#] (for each round) to score[review]  -Yang
     merge_scores(scores) if self.assignment.varying_rubrics_by_round?
@@ -76,7 +76,7 @@ class AssignmentParticipant < Participant
     calculate_scores(scores)
   end
 
-  def compute_assignment_score(questions, scores)
+  def compute_assignment_score(questions, scores, requesting_score = false)
     self.assignment.questionnaires.each do |questionnaire|
       round = AssignmentQuestionnaire.find_by(assignment_id: self.assignment.id, questionnaire_id: questionnaire.id).used_in_round
       # create symbol for "varying rubrics" feature -Yang
@@ -89,7 +89,7 @@ class AssignmentParticipant < Participant
       scores[questionnaire_symbol] = {}
 
       scores[questionnaire_symbol][:assessments] = if round.nil?
-                                                     questionnaire.get_assessments_for(self)
+                                                     questionnaire.get_assessments_for(self, requesting_score)
                                                    else
                                                      questionnaire.get_assessments_round_for(self, round)
                                                    end
@@ -148,14 +148,14 @@ class AssignmentParticipant < Participant
     FeedbackResponseMap.get_assessments_for(self)
   end
 
-  def reviews
+  def reviews(requesting_score = false)
     # ACS Always get assessments for a team
     # removed check to see if it is a team assignment
     # ReviewResponseMap.get_assessments_for(self.team)
 
     # Changes made by Rahul Sethi
     current_assignment = Assignment.find(self.team.parent_id)
-    if current_assignment.is_selfreview_enabled?
+    if requesting_score && current_assignment.is_selfreview_enabled?
       ResponseMap.get_assessments_for(self.team, self.id)
     else
       ReviewResponseMap.get_assessments_for(self.team)

--- a/app/models/author_feedback_questionnaire.rb
+++ b/app/models/author_feedback_questionnaire.rb
@@ -14,7 +14,7 @@ class AuthorFeedbackQuestionnaire < Questionnaire
     "feedback".to_sym
   end
 
-  def get_assessments_for(participant, requesting_score)
+  def get_assessments_for(participant, _requesting_score = false)
     participant.feedback
   end
 end

--- a/app/models/author_feedback_questionnaire.rb
+++ b/app/models/author_feedback_questionnaire.rb
@@ -14,7 +14,7 @@ class AuthorFeedbackQuestionnaire < Questionnaire
     "feedback".to_sym
   end
 
-  def get_assessments_for(participant)
+  def get_assessments_for(participant, requesting_score)
     participant.feedback
   end
 end

--- a/app/models/response_map.rb
+++ b/app/models/response_map.rb
@@ -7,29 +7,33 @@ class ResponseMap < ActiveRecord::Base
   end
 
   # return latest versions of the responses
-  def self.get_assessments_for(team , pid = nil)
+  def self.get_assessments_for(team , user_id = nil)
     responses = []
     stime = Time.now
     if team
       @array_sort = []
       @sort_to = []
-      # maps = where(reviewee_id: team.id)
-      # find maps based on self review and peer reviews
-      if pid.nil?
-        maps = where(reviewee_id: team.id)
-      else
-        maps = where(reviewee_id: team.id, reviewer_id: pid)
-      end
+
+      # Changes made by Rahul Sethi
+      maps = if user_id.nil?
+               where(reviewee_id: team.id)
+             else
+               where(reviewee_id: team.id, reviewer_id: user_id)
+             end
+      # Changes End
 
       maps.each do |map|
         next if map.response.empty?
         @all_resp = Response.where(map_id: map.map_id).last
+        # Changes made by Rahul Sethi
         if map.type.eql?('ReviewResponseMap') || map.type.eql?("SelfReviewResponseMap")
           # If its ReviewResponseMap then only consider those response which are submitted.
           @array_sort << @all_resp if @all_resp.is_submitted
         else
           @array_sort << @all_resp
         end
+        # Changes End
+
         # sort all versions in descending order and get the latest one.
         # @sort_to=@array_sort.sort { |m1, m2| (m1.version_num and m2.version_num) ? m2.version_num <=> m1.version_num : (m1.version_num ? -1 : 1) }
         @sort_to = @array_sort.sort # { |m1, m2| (m1.updated_at and m2.updated_at) ? m2.updated_at <=> m1.updated_at : (m1.version_num ? -1 : 1) }

--- a/app/models/response_map.rb
+++ b/app/models/response_map.rb
@@ -7,17 +7,24 @@ class ResponseMap < ActiveRecord::Base
   end
 
   # return latest versions of the responses
-  def self.get_assessments_for(team)
+  def self.get_assessments_for(team , pid = nil)
     responses = []
     stime = Time.now
     if team
       @array_sort = []
       @sort_to = []
-      maps = where(reviewee_id: team.id)
+      # maps = where(reviewee_id: team.id)
+      # find maps based on self review and peer reviews
+      if pid.nil?
+        maps = where(reviewee_id: team.id)
+      else
+        maps = where(reviewee_id: team.id, reviewer_id: pid)
+      end
+
       maps.each do |map|
         next if map.response.empty?
         @all_resp = Response.where(map_id: map.map_id).last
-        if map.type.eql?('ReviewResponseMap')
+        if map.type.eql?('ReviewResponseMap') || map.type.eql?("SelfReviewResponseMap")
           # If its ReviewResponseMap then only consider those response which are submitted.
           @array_sort << @all_resp if @all_resp.is_submitted
         else

--- a/app/models/response_map.rb
+++ b/app/models/response_map.rb
@@ -7,7 +7,7 @@ class ResponseMap < ActiveRecord::Base
   end
 
   # return latest versions of the responses
-  def self.get_assessments_for(team , user_id = nil)
+  def self.get_assessments_for(team, user_id = nil)
     responses = []
     stime = Time.now
     if team

--- a/app/models/response_map.rb
+++ b/app/models/response_map.rb
@@ -26,6 +26,7 @@ class ResponseMap < ActiveRecord::Base
         next if map.response.empty?
         @all_resp = Response.where(map_id: map.map_id).last
         # Changes made by Rahul Sethi
+
         if map.type.eql?('ReviewResponseMap') || map.type.eql?("SelfReviewResponseMap")
           # If its ReviewResponseMap then only consider those response which are submitted.
           @array_sort << @all_resp if @all_resp.is_submitted

--- a/app/models/review_questionnaire.rb
+++ b/app/models/review_questionnaire.rb
@@ -22,7 +22,6 @@ class ReviewQuestionnaire < Questionnaire
   def get_assessments_round_for(participant, round)
     team = AssignmentTeam.team(participant)
     return nil unless team
-
     team_id = team.id
     responses = []
     if participant
@@ -33,7 +32,6 @@ class ReviewQuestionnaire < Questionnaire
           responses << response if response.round == round && response.is_submitted
         end
       end
-      # responses = Response.find(:all, :include => :map, :conditions => ['reviewee_id = ? and type = ?',participant.id, self.to_s])
       responses.sort! {|a, b| a.map.reviewer.fullname <=> b.map.reviewer.fullname }
     end
     responses

--- a/app/models/review_questionnaire.rb
+++ b/app/models/review_questionnaire.rb
@@ -14,8 +14,8 @@ class ReviewQuestionnaire < Questionnaire
     "review".to_sym
   end
 
-  def get_assessments_for(participant)
-    participant.reviews
+  def get_assessments_for(participant, requesting_score)
+    participant.reviews(requesting_score)
   end
 
   # return  the responses for specified round, for varying rubric feature -Yang

--- a/app/models/vm_question_response.rb
+++ b/app/models/vm_question_response.rb
@@ -49,21 +49,25 @@ class VmQuestionResponse
                 else
                   ReviewResponseMap.get_assessments_for(team)
                 end
-      # variable to store self review
-      @store_needed_self_review = nil
-      # find and selected self reviewers based on current user role
-      self_reviews = SelfReviewResponseMap.get_assessments_for(team) # Get all Self Reviews for the team
-      self_reviews.each do |review|
-        self_review_mapping = SelfReviewResponseMap.find(review.map_id) # Find respons maps baed on map id
-        if self_review_mapping && self_review_mapping.present?
-          # if it is a student view show only that particular students self review
-          if participant.id == self_review_mapping.reviewer_id
-            participant = Participant.find(self_review_mapping.reviewer_id)
-            @list_of_reviewers << participant
-            @store_needed_self_review = review
-          end
-        end
+
+      # Changes by Rahul Sethi
+      @self_review_answers = nil
+      # review_map = SelfReviewResponseMap.get_assessments_for(team)
+      review_map = if vary
+                     ReviewResponseMap.get_responses_for_team_round(team, @round)
+                   else
+                     ReviewResponseMap.get_assessments_for(team)
+                   end
+      review_map.each do |review|
+        next unless SelfReviewResponseMap.exists?(review.map_id)
+        mapping = SelfReviewResponseMap.find(review.map_id)
+        next unless mapping && mapping.present?
+        next unless participant.id == mapping.reviewer_id
+        participant = Participant.find(mapping.reviewer_id)
+        @list_of_reviewers << participant
+        @self_review_answers = review
       end
+      # Changes End
 
       reviews.each do |review|
         review_mapping = ReviewResponseMap.find(review.map_id)
@@ -72,15 +76,14 @@ class VmQuestionResponse
           @list_of_reviewers << participant
         end
       end
-      # @list_of_reviews = reviews
-      # Add all reviews i.e self  + peer , based on the role and type of assignment
-      if !@store_needed_self_review.nil?
-        @list_of_reviews = reviews + [@store_needed_self_review]
-      elsif !@store_needed_self_review.nil?
-        @list_of_reviews = reviews + self_reviews
-      else
-        @list_of_reviews = reviews
-      end
+
+      # Changes by Rahul Sethi
+      @list_of_reviews = if !@self_review_answers.nil?
+                           reviews + [@self_review_answers]
+                         else
+                           reviews
+                         end
+      # Changes End
     elsif @questionnaire_type == "AuthorFeedbackQuestionnaire"
       reviews = participant.feedback # feedback reviews
       reviews.each do |review|
@@ -115,18 +118,14 @@ class VmQuestionResponse
         add_answer(answer)
       end
     end
-    # Find all answers based on user role
-    if !@store_needed_self_review.nil?
-      answers = Answer.where(response_id: self_reviews.each {|self_review| self_review.response_id})
-      answers.each do |answer|
-        add_answer(answer)
-      end
-    elsif !@store_needed_self_review.nil?
-      answers = Answer.where(response_id: @store_needed_self_review.response_id)
-      answers.each do |answer|
-        add_answer(answer)
-      end
+
+    # Changes by Rahul Sethi
+    return unless !@self_review_answers.nil?
+    answers = Answer.where(response_id: @self_review_answers.response_id)
+    answers.each do |answer|
+      add_answer(answer)
     end
+    # Changes End
   end
 
   def display_team_members

--- a/app/models/vm_question_response.rb
+++ b/app/models/vm_question_response.rb
@@ -120,7 +120,7 @@ class VmQuestionResponse
     end
 
     # Changes by Rahul Sethi
-    return unless !@self_review_answers.nil?
+    return if @self_review_answers.nil?
     answers = Answer.where(response_id: @self_review_answers.response_id)
     answers.each do |answer|
       add_answer(answer)

--- a/app/models/vm_question_response_row.rb
+++ b/app/models/vm_question_response_row.rb
@@ -28,16 +28,31 @@ class VmQuestionResponseRow
 
   def average_score_for_row
     row_average_score = 0.0
-    no_of_columns = 0.0 # Counting reviews that are not null
+    # no_of_columns = 0.0 # Counting reviews that are not null
+    @no_of_columns = 0.0 # Counting reviews that are not null
+    @self_review_score_of_row = @score_row[-1].score_value
     @score_row.each do |score|
       if score.score_value.is_a? Numeric
-        no_of_columns += 1
+        @no_of_columns += 1
         row_average_score += score.score_value.to_f
       end
     end
-    unless no_of_columns.zero?
-      row_average_score /= no_of_columns
+    unless @no_of_columns.zero?
+      row_average_score /= @no_of_columns
       row_average_score.round(2)
+    end
+  end
+
+  def composite_score_for_row
+    @total_avg_score = average_score_for_row
+    @peer_total = (@total_avg_score * @no_of_columns) - @self_review_score_of_row
+    @peer_avg = @peer_total / (@no_of_columns - 1)
+    if !@peer_avg.nan?
+      # Apply your formula here
+      composite_score = (100 - (@self_review_score_of_row - @peer_avg).abs) * (@peer_avg / 100)
+      composite_score.round(2)
+    else
+      composite_score = "Not applicable"
     end
   end
 end

--- a/app/models/vm_question_response_row.rb
+++ b/app/models/vm_question_response_row.rb
@@ -28,7 +28,8 @@ class VmQuestionResponseRow
 
   def average_score_for_row
     row_average_score = 0.0
-    # no_of_columns = 0.0 # Counting reviews that are not null
+    # Changes By Rahul Sethi
+    # Making global so that new function can access them
     @no_of_columns = 0.0 # Counting reviews that are not null
     @self_review_score_of_row = @score_row[-1].score_value
     @score_row.each do |score|
@@ -37,22 +38,18 @@ class VmQuestionResponseRow
         row_average_score += score.score_value.to_f
       end
     end
-    unless @no_of_columns.zero?
-      row_average_score /= @no_of_columns
-      row_average_score.round(2)
-    end
+    return unless @no_of_columns.zero?
+    row_average_score /= @no_of_columns
+    row_average_score.round(2)
+    # Changes End
   end
 
-  def composite_score_for_row
-    @total_avg_score = average_score_for_row
-    @peer_total = (@total_avg_score * @no_of_columns) - @self_review_score_of_row
-    @peer_avg = @peer_total / (@no_of_columns - 1)
-    if !@peer_avg.nan?
-      # Apply your formula here
-      composite_score = (100 - (@self_review_score_of_row - @peer_avg).abs) * (@peer_avg / 100)
-      composite_score.round(2)
-    else
-      composite_score = "Not applicable"
-    end
+  def new_derived_score
+    @self_review_score = ((average_score_for_row * @no_of_columns) - @self_review_score_of_row) / (@no_of_columns - 1)
+    @final_score_after = "Self Review Not Enabled"
+    return unless @self_review_score.nan?
+    deviated_score = (100 - (@self_review_score_of_row - @self_review_score).abs) / 100;
+    @final_score_after = deviated_score * @self_review_score
+    @final_score_after.round(2)
   end
 end

--- a/app/models/vm_question_response_row.rb
+++ b/app/models/vm_question_response_row.rb
@@ -38,9 +38,10 @@ class VmQuestionResponseRow
         row_average_score += score.score_value.to_f
       end
     end
-    return unless @no_of_columns.zero?
-    row_average_score /= @no_of_columns
-    row_average_score.round(2)
+    unless @no_of_columns.zero?
+      row_average_score /= @no_of_columns
+      row_average_score.round(2)
+    end
     # Changes End
   end
 

--- a/app/models/vm_question_response_row.rb
+++ b/app/models/vm_question_response_row.rb
@@ -28,34 +28,16 @@ class VmQuestionResponseRow
 
   def average_score_for_row
     row_average_score = 0.0
-    # Changes By Rahul Sethi
-    # Making global so that new function can access them
-    @no_of_columns = 0.0 # Counting reviews that are not null
-    @self_review_score_of_row = @score_row[-1].score_value
+    no_of_columns = 0.0 # Counting reviews that are not null
     @score_row.each do |score|
       if score.score_value.is_a? Numeric
-        @no_of_columns += 1
+        no_of_columns += 1
         row_average_score += score.score_value.to_f
       end
     end
-    unless @no_of_columns.zero?
-      row_average_score /= @no_of_columns
+    unless no_of_columns.zero?
+      row_average_score /= no_of_columns
       row_average_score.round(2)
     end
-    # Changes End
-  end
-
-  def new_derived_score
-    # puts('Self Review Score: ' + @self_review_score_of_row.to_s)
-    # puts('Actual Score: ' + average_score_for_row.to_s)
-    @self_review_score_of_row = 4.0
-    puts(@no_of_columns)
-    @self_review_score = ((average_score_for_row * @no_of_columns) - @self_review_score_of_row) / (@no_of_columns - 1)
-    @final_score_after = "Self Review Not Enabled"
-    return if @self_review_score.nan?
-    deviated_score = (100 - (@self_review_score_of_row - @self_review_score).abs) / 100
-    @final_score_after = deviated_score * @self_review_score
-    # puts('New Derived Score: ' + @final_score_after.to_s)
-    @final_score_after.round(2)
   end
 end

--- a/app/models/vm_question_response_row.rb
+++ b/app/models/vm_question_response_row.rb
@@ -46,11 +46,16 @@ class VmQuestionResponseRow
   end
 
   def new_derived_score
+    # puts('Self Review Score: ' + @self_review_score_of_row.to_s)
+    # puts('Actual Score: ' + average_score_for_row.to_s)
+    @self_review_score_of_row = 4.0
+    puts(@no_of_columns)
     @self_review_score = ((average_score_for_row * @no_of_columns) - @self_review_score_of_row) / (@no_of_columns - 1)
     @final_score_after = "Self Review Not Enabled"
-    return unless @self_review_score.nan?
-    deviated_score = (100 - (@self_review_score_of_row - @self_review_score).abs) / 100;
+    return if @self_review_score.nan?
+    deviated_score = (100 - (@self_review_score_of_row - @self_review_score).abs) / 100
     @final_score_after = deviated_score * @self_review_score
+    # puts('New Derived Score: ' + @final_score_after.to_s)
     @final_score_after.round(2)
   end
 end

--- a/app/views/assignments/edit.html.erb
+++ b/app/views/assignments/edit.html.erb
@@ -5,7 +5,7 @@
     <div class= "table" id="tabs">
       <ul>
         <li><a href="#tabs-1" id="General">General</a></li>
-        <li id="topics_tab_header"><a href="#tabs-2" id="Topics">Topics</a></li>
+        <li><a href="#tabs-2" id="Topics">Topics</a></li>
         <li><a href="#tabs-3" id="Rubrics">Rubrics</a></li>
         <li><a href="#tabs-4" id="ReviewStrategy">Review strategy</a></li>
         <li><a href="#tabs-5" id="DueDates">Due dates</a></li>

--- a/app/views/assignments/edit/_general.html.erb
+++ b/app/views/assignments/edit/_general.html.erb
@@ -132,16 +132,6 @@ function microtaskChanged() {
     </td>
   </tr>
 
-  <% if current_page?(action: 'edit') %>
-  <!--Topics-->
-  <tr>
-    <td style='padding:5px' id='assignment_has_topics_field'>
-      <%= check_box_tag('assignment_has_topics', 'true', @assignment_form.assignment.topics?, {:onChange => 'topicsChanged()'}) %>
-      <%= label_tag('assignment_has_topics', 'Has topics?') %>
-    </td>
-  </tr>
-  <% end %>
-
   <!--staggered_deadline-->
   <tr>
     <td style='padding:5px' id='assignment_staggered_deadline_field'>
@@ -223,46 +213,6 @@ function microtaskChanged() {
 
 
 <script>
-    <% if current_page?(action: 'edit') %>
-    jQuery(document).ready(function () {
-        // This function determines whether the 'Topics' tab must be displayed when the page is re-loaded
-        var checkbox = jQuery('#assignment_has_topics');
-        if (checkbox.is(':checked')) {
-            // If this checkbox is checked, show the 'Topics' tab
-            jQuery("#topics_tab_header").show();
-        } else {
-            // Otherwise, hide topics tab
-            jQuery("#topics_tab_header").hide();
-        }
-    });
-
-    function topicsChanged() {
-        var msg = 'Warning! Un-checking this box will remove all topics that have been created.';
-        var checkbox = jQuery('#assignment_has_topics');
-        if (checkbox.is(':checked')) {
-            // If this box is checked, display the 'Topics' tab
-            jQuery("#topics_tab_header").show();
-        } else {
-            if (confirm(msg)) {
-                // If this box is un-checked, remove all topics and reload page
-                jQuery.ajax({
-                    url: '/sign_up_sheet/delete_all_topics_for_assignment',
-                    method: 'POST',
-                    data: {
-                        assignment_id: <%= @assignment.id %>
-                    },
-                    success: function() {
-                        // After topics are deleted, re-load page
-                        window.location.href = '<%= edit_assignment_path(@assignment.id) %>';
-                    }
-                });
-            } else {
-                checkbox.prop('checked', true);
-            }
-        }
-    }
-    <% end %>
-
     function hasTeamsChanged() {
       var msg = 'Warning! Unchecking this box will hide teams that already exist.';
         var checkbox = jQuery('#team_assignment');

--- a/app/views/grades/_participant.html.erb
+++ b/app/views/grades/_participant.html.erb
@@ -8,6 +8,7 @@
 <% 
     participant = pscore[:participant]
     rscore_review = Rscore.new(pscore,:review) if pscore[:review]
+    cscore_review = Rscore.new(@new_derived_scores,:review) if @new_derived_scores[:review]
     rscore_metareview = Rscore.new(pscore,:metareview) if pscore[:metareview]
     rscore_feedback = Rscore.new(pscore,:feedback) if pscore[:feedback]
     rscore_teammate = Rscore.new(pscore,:teammate) if pscore[:teammate]
@@ -142,6 +143,9 @@
       <% end %>
       </TD>
     <% end %>
+    <TD align="center">
+      <%= cscore_review.my_avg.is_a?(Float)?sprintf("%.2f",cscore_review.my_avg):cscore_review.my_avg %><%= score_postfix %>
+    </TD>
 </TR>
 
 <% if (controller.action_name != "view_my_scores" and index == team_size - 1) or controller.action_name == "view_my_scores" %>

--- a/app/views/grades/_participant.html.erb
+++ b/app/views/grades/_participant.html.erb
@@ -8,7 +8,9 @@
 <% 
     participant = pscore[:participant]
     rscore_review = Rscore.new(pscore,:review) if pscore[:review]
-    cscore_review = Rscore.new(@new_derived_scores,:review) if @new_derived_scores[:review]
+    if !@new_derived_scores.nil?
+      ndscore_review = Rscore.new(@new_derived_scores,:review) if @new_derived_scores[:review]
+    end
     rscore_metareview = Rscore.new(pscore,:metareview) if pscore[:metareview]
     rscore_feedback = Rscore.new(pscore,:feedback) if pscore[:feedback]
     rscore_teammate = Rscore.new(pscore,:teammate) if pscore[:teammate]
@@ -143,9 +145,11 @@
       <% end %>
       </TD>
     <% end %>
-    <TD align="center">
-      <%= cscore_review.my_avg.is_a?(Float)?sprintf("%.2f",cscore_review.my_avg):cscore_review.my_avg %><%= score_postfix %>
-    </TD>
+    <% if !@new_derived_scores.nil? %>
+      <TD align="center">
+        <%= ndscore_review.my_avg.is_a?(Float)?sprintf("%.2f",ndscore_review.my_avg):ndscore_review.my_avg %><%= score_postfix %>
+      </TD>
+    <%end %>
 </TR>
 
 <% if (controller.action_name != "view_my_scores" and index == team_size - 1) or controller.action_name == "view_my_scores" %>

--- a/app/views/grades/_participant.html.erb
+++ b/app/views/grades/_participant.html.erb
@@ -9,7 +9,7 @@
     participant = pscore[:participant]
     rscore_review = Rscore.new(pscore,:review) if pscore[:review]
     if !@new_derived_scores.nil?
-      ndscore_review = Rscore.new(@new_derived_scores,:review) if @new_derived_scores[:review]
+      ndscore_review = @new_derived_scores
     end
     rscore_metareview = Rscore.new(pscore,:metareview) if pscore[:metareview]
     rscore_feedback = Rscore.new(pscore,:feedback) if pscore[:feedback]
@@ -147,7 +147,7 @@
     <% end %>
     <% if !@new_derived_scores.nil? %>
       <TD align="center">
-        <%= ndscore_review.my_avg.is_a?(Float)?sprintf("%.2f",ndscore_review.my_avg):ndscore_review.my_avg %><%= score_postfix %>
+        <%= ndscore_review %><%= score_postfix %>
       </TD>
     <%end %>
 </TR>

--- a/app/views/grades/_participant_charts.html.erb
+++ b/app/views/grades/_participant_charts.html.erb
@@ -61,7 +61,10 @@
           
   </div>
 </th>
-  
+  <th style="text-align:center;" WIDTH="<%= colwidth %>%">&nbsp;
+    <div class="circle" id="self-review-circle">
+    </div>
+  </th>
 </TR>
 
 <script type="text/javascript">
@@ -71,7 +74,7 @@
   var myCircle = Circles.create({
     id:           '<%= "#{type}-circle" %>',
     radius:       25,
-    value:        <%= @pscore[type.to_sym][:scores][:avg].to_i %>,
+    value: <%= @pscore[type.to_sym][:scores][:avg].to_i %>,
     maxValue:     100,
     width:        7,
     text:         '<%=@pscore[type.to_sym][:scores][:avg].to_i%>',
@@ -85,13 +88,25 @@
   var myCircle = Circles.create({
     id:           'final-circle',
     radius:       35,
-    value:        <%= @pscore[:total_score].to_i %>,
+    value: <%= @pscore[:total_score].to_i %>,
     maxValue:     100,
     width:        15,
     text:         '<%=@pscore[:total_score].to_i==-1? "N/A":@pscore[:total_score].to_i%>',
     colors:       ['#FFEB99', '#FFCC00'],
     duration:       700,
     textClass:      'circles-final'  
+  });
+
+  var myCircle = Circles.create({
+      id:           'self-review-circle',
+      radius:       35,
+      value: <%= @new_derived_scores[:total_score].to_i %>,
+      maxValue:     100,
+      width:        15,
+      text:         '<%=@new_derived_scores[:total_score].to_i==-1? "N/A":@new_derived_scores[:total_score].to_i%>',
+      colors:       ['#99ffa4', '#077512'],
+      duration:       700,
+      textClass:      'circles-final'
   });
 
 </script> 

--- a/app/views/grades/_participant_charts.html.erb
+++ b/app/views/grades/_participant_charts.html.erb
@@ -67,6 +67,8 @@
   </th>
 </TR>
 
+
+
 <script type="text/javascript">
   <% ['review', 'metareview', 'feedback', 'teammate'].each do |type| %>
   <% if @pscore[type.to_sym] && @pscore[type.to_sym][:scores][:avg]%>
@@ -97,18 +99,19 @@
     textClass:      'circles-final'  
   });
 
-  var myCircle = Circles.create({
-      id:           'self-review-circle',
-      radius:       35,
-      value: <%= @new_derived_scores[:total_score].to_i %>,
-      maxValue:     100,
-      width:        15,
-      text:         '<%=@new_derived_scores[:total_score].to_i==-1? "N/A":@new_derived_scores[:total_score].to_i%>',
-      colors:       ['#99ffa4', '#077512'],
-      duration:       700,
-      textClass:      'circles-final'
-  });
-
+  <%if !@new_derived_scores.nil? %>
+    var myCircle = Circles.create({
+        id:           'self-review-circle',
+        radius:       35,
+        value: <%= @new_derived_scores[:total_score].to_i %>,
+        maxValue:     100,
+        width:        15,
+        text:         '<%=@new_derived_scores[:total_score].to_i==-1? "N/A":@new_derived_scores[:total_score].to_i%>',
+        colors:       ['#99ffa4', '#077512'],
+        duration:       700,
+        textClass:      'circles-final'
+    });
+  <%end %>
 </script> 
 
 <style>

--- a/app/views/grades/_participant_charts.html.erb
+++ b/app/views/grades/_participant_charts.html.erb
@@ -103,10 +103,10 @@
     var myCircle = Circles.create({
         id:           'self-review-circle',
         radius:       35,
-        value: <%= @new_derived_scores[:total_score].to_i %>,
+        value: <%= @new_derived_scores.to_i %>,
         maxValue:     100,
         width:        15,
-        text:         '<%=@new_derived_scores[:total_score].to_i==-1? "N/A":@new_derived_scores[:total_score].to_i%>',
+        text:         '<%=@new_derived_scores.to_i%>',
         colors:       ['#99ffa4', '#077512'],
         duration:       700,
         textClass:      'circles-final'

--- a/app/views/grades/_participant_title.html.erb
+++ b/app/views/grades/_participant_title.html.erb
@@ -12,7 +12,7 @@
 	<% colwidth = 15 %>
 <% end %>
 
-<%if @cscore %>
+<%if @new_derived_scores %>
   <% colwidth = 10 %>
 <%end%>
 
@@ -46,7 +46,7 @@
 <% end %>
 <th style="text-align:center;" WIDTH="<%= colwidth %>%">Final Score</th>
 
-<%if @cscore%>
-  <th style="text-align:center;"  WIDTH="<%= colwidth %>%">Final Self Review Score</th>
+<%if @new_derived_scores %>
+  <th style="text-align:center;"  WIDTH="<%= colwidth %>%">Final Derived Peer Review Score</th>
 <%end%>
 </tr>

--- a/app/views/grades/_participant_title.html.erb
+++ b/app/views/grades/_participant_title.html.erb
@@ -12,6 +12,10 @@
 	<% colwidth = 15 %>
 <% end %>
 
+<%if @cscore %>
+  <% colwidth = 10 %>
+<%end%>
+
 <tr <% if prefix %>id='<%= prefix %>_1' style="background-color: #f9f9f9;"<% end %>>
 <th style="text-align:center;" WIDTH="<%= namecolwidth %>%">&nbsp;</th>
 <th style="text-align:center;" COLSPAN="2" WIDTH="<%= colwidth*2 %>%">Submitted work</th>
@@ -22,7 +26,8 @@
 <% if has_team_and_metareview?[:has_team] %>
   <th style="text-align:center;" COLSPAN="2" WIDTH="<%= colwidth*2 %>%">Teammate Review</th>
 <% end %>
-<th style="text-align:center;" WIDTH="<%= colwidth %>%">&nbsp;</th></tr>           
+<th style="text-align:center;" WIDTH="<%= colwidth %>%">&nbsp;</th></tr>
+<th style="text-align:center;" WIDTH="<%= colwidth %>%">&nbsp;</th></tr>
 
 <tr <% if prefix %>id='<%= prefix %>_2' style="display:none; background-color: #f9f9f9;"<% end %>>
 <th style="text-align:left;" WIDTH="<%= namecolwidth %>%" ALIGN="LEFT">Contributor</th>
@@ -38,6 +43,10 @@
 <% if has_team_and_metareview?[:has_team] %>
 	<th style="text-align:center;" WIDTH="<%= colwidth %>%">Average</th>
 	<th style="text-align:center;" WIDTH="<%= colwidth %>%">Range </th>
-<% end %>   
-<th style="text-align:center;" WIDTH="<%= colwidth %>%">Final Score</th></tr>    
-    
+<% end %>
+<th style="text-align:center;" WIDTH="<%= colwidth %>%">Final Score</th>
+
+<%if @cscore%>
+  <th style="text-align:center;"  WIDTH="<%= colwidth %>%">Final Self Review Score</th>
+<%end%>
+</tr>

--- a/app/views/grades/view_team.html.erb
+++ b/app/views/grades/view_team.html.erb
@@ -28,7 +28,13 @@
 <% end %>
 <!--Obtain only review scores-->
 <% rscore_review = Rscore.new(@pscore,:review) if @pscore[:review] %>
+<%= %>
 <h4>Average peer review score: <span class = "c5"><%= rscore_review.my_avg.is_a?(Float)? sprintf("%.2f",rscore_review.my_avg): rscore_review.my_avg %></span></h4>
+<%if @current_role_name.eql? "Student"%>
+  <% rscore_review = Rscore.new(@cscore,:review) if @pscore[:review] %>
+  <%= %>
+  <h4>Average Self review score: <span class = "c5"><%= rscore_review.my_avg.is_a?(Float)? sprintf("%.2f",rscore_review.my_avg): rscore_review.my_avg %></span></h4>
+<%end %>
 <!--Toggle submission-->
 <button onclick="toggleFunction('<%= @participant.id.to_s%>')" class="btn btn-default">Show Submission</button>
 <div id="<%= @participant.id.to_s%>" style="display:none;">
@@ -101,14 +107,34 @@
             
               <% i = 1 %>
               <% vm.list_of_reviews.each do |review| %>
-                  <!-- instructors (or higher level users) see reviewer name, students see anonymized string -->
-                  <% if (['Student'].include? @current_role_name) && @assignment.is_anonymous%>
-                      <th class="sorter-false"> <a target="_blank" href="../response/view?id=<%= review.id.to_s %>"  data-toggle="tooltip" data-placement="right" title="Click to see details"><%= "Review " + i.to_s %></a>  </th>
-                  <% else %>
-                      <% user_name = User.find(Participant.find(ResponseMap.find(Response.find(review.id).map_id).reviewer_id).user_id).fullname(session[:ip]).to_s %>
-                      <th class="sorter-false"> <a target="_blank" href="../response/view?id=<%= review.id.to_s %>"  data-toggle="tooltip" data-placement="right" title="Click to see details"><%= user_name.to_s %></a>  </th>
-                  <% end %>
-                  <% i += 1 %>
+                <%
+                  review_map = ResponseMap.find(review.map_id)
+                  review_type = nil
+                  if review_map
+                    review_type =  review_map.type
+                  end
+                %>
+                <!-- instructors (or higher level users) see reviewer name, students see anonymized string -->
+                <% if (['Student'].include? @current_role_name) && @assignment.is_anonymous%>
+                  <% if review_type == 'ReviewResponseMap' %>
+                    <th class="sorter-false"> <a target="_blank" href="../response/view?id=<%= review.id.to_s %>"  data-toggle="tooltip" data-placement="right" title="Click to see details">
+                      <%= "Review " +   i.to_s %>
+                    </a></th>
+                  <%end%>
+                  <% if review_type == 'SelfReviewResponseMap' %>
+                    <th class="sorter-false", bgcolor="aqua"> <a target="_blank" href="../response/view?id=<%= review.id.to_s %>"  data-toggle="tooltip" data-placement="right" title="Click to see details">
+                      <%= "Self-Review"%>
+                    </a></th>
+                  <%end%>
+                <% else %>
+                    <% user_name = User.find(Participant.find(ResponseMap.find(Response.find(review.id).map_id).reviewer_id).user_id).fullname(session[:ip]).to_s %>
+                  <% if review_type == 'SelfReviewResponseMap' %>
+                    <th class="sorter-false", bgcolor="aqua"> <a target="_blank" href="../response/view?id=<%= review.id.to_s %>"  data-toggle="tooltip" data-placement="right" title="Click to see details"><%= user_name.to_s %></a>  </th>
+                  <%else %>
+                    <th class="sorter-false"> <a target="_blank" href="../response/view?id=<%= review.id.to_s %>"  data-toggle="tooltip" data-placement="right" title="Click to see details"><%= user_name.to_s %></a>  </th>
+                  <%end%>
+                <% end %>
+                <% i += 1 %>
               <% end %>
 
               <th class="sorter-true" align="right" >
@@ -117,7 +143,9 @@
               <th class="sorter-false">
                 <span  data-toggle="tooltip" data-placement="right" title="A count of comments, for the respective question, which have word count > 10. The purpose of this metric is to represent how many comments for the question are of a substantial length to provide quality feedback.">metric-1</span>
               </th>
-
+              <th class="sorter-true" align="right" >
+                Composite Score<span></span>
+              </th>
             </tr>
             </thead>
 
@@ -153,6 +181,13 @@
                   </td>
                   <td  class = 'cf' align="center">
                     <%= row.countofcomments.to_s %>
+                  </td>
+                  <td  class = 'cf' align="center">
+                    <%if @assignment.is_selfreview_enabled and @current_role_name.eql? "Student"%>
+                      <%= row.composite_score_for_row.to_s %>
+                    <%else %>
+                      <%= "Not applicable" %>
+                    <%end %>
                   </td>
                 </tr>
                 <!--loop that creates the collapsed-by-default row, which lists all comments. -->

--- a/app/views/grades/view_team.html.erb
+++ b/app/views/grades/view_team.html.erb
@@ -30,10 +30,10 @@
 <% rscore_review = Rscore.new(@pscore,:review) if @pscore[:review] %>
 <%= %>
 <h4>Average peer review score: <span class = "c5"><%= rscore_review.my_avg.is_a?(Float)? sprintf("%.2f",rscore_review.my_avg): rscore_review.my_avg %></span></h4>
-<%if @current_role_name.eql? "Student"%>
-  <% rscore_review = Rscore.new(@cscore,:review) if @pscore[:review] %>
+<%if !@new_derived_scores.nil? and @current_role_name.eql? "Student"%>
+  <% rscore_review = Rscore.new(@new_derived_scores,:review) if @new_derived_scores[:review] %>
   <%= %>
-  <h4>Average Self review score: <span class = "c5"><%= rscore_review.my_avg.is_a?(Float)? sprintf("%.2f",rscore_review.my_avg): rscore_review.my_avg %></span></h4>
+  <h4>Final Average Peer Review Score: <span class = "c5"><%= rscore_review.my_avg.is_a?(Float)? sprintf("%.2f",rscore_review.my_avg): rscore_review.my_avg %></span></h4>
 <%end %>
 <!--Toggle submission-->
 <button onclick="toggleFunction('<%= @participant.id.to_s%>')" class="btn btn-default">Show Submission</button>
@@ -184,7 +184,7 @@
                   </td>
                   <td  class = 'cf' align="center">
                     <%if @assignment.is_selfreview_enabled and @current_role_name.eql? "Student"%>
-                      <%= row.composite_score_for_row.to_s %>
+                      <%= row.new_derived_score.to_s %>
                     <%else %>
                       <%= "Not applicable" %>
                     <%end %>

--- a/app/views/grades/view_team.html.erb
+++ b/app/views/grades/view_team.html.erb
@@ -31,9 +31,7 @@
 <%= %>
 <h4>Average peer review score: <span class = "c5"><%= rscore_review.my_avg.is_a?(Float)? sprintf("%.2f",rscore_review.my_avg): rscore_review.my_avg %></span></h4>
 <%if !@new_derived_scores.nil? and @current_role_name.eql? "Student"%>
-  <% rscore_review = Rscore.new(@new_derived_scores,:review) if @new_derived_scores[:review] %>
-  <%= %>
-  <h4>Final Average Peer Review Score: <span class = "c5"><%= rscore_review.my_avg.is_a?(Float)? sprintf("%.2f",rscore_review.my_avg): rscore_review.my_avg %></span></h4>
+  <h4>Final Average Peer Review Score: <span class = "c5"><%=@new_derived_scores%></span></h4>
 <%end %>
 <!--Toggle submission-->
 <button onclick="toggleFunction('<%= @participant.id.to_s%>')" class="btn btn-default">Show Submission</button>
@@ -143,9 +141,6 @@
               <th class="sorter-false">
                 <span  data-toggle="tooltip" data-placement="right" title="A count of comments, for the respective question, which have word count > 10. The purpose of this metric is to represent how many comments for the question are of a substantial length to provide quality feedback.">metric-1</span>
               </th>
-              <th class="sorter-true" align="right" >
-                Composite Score<span></span>
-              </th>
             </tr>
             </thead>
 
@@ -182,13 +177,7 @@
                   <td  class = 'cf' align="center">
                     <%= row.countofcomments.to_s %>
                   </td>
-                  <td  class = 'cf' align="center">
-                    <%if @assignment.is_selfreview_enabled and @current_role_name.eql? "Student"%>
-                      <%= row.new_derived_score.to_s %>
-                    <%else %>
-                      <%= "Not applicable" %>
-                    <%end %>
-                  </td>
+
                 </tr>
                 <!--loop that creates the collapsed-by-default row, which lists all comments. -->
                 <tr class="tablesorter-childRow">

--- a/app/views/reports/_self_review_report.html.erb
+++ b/app/views/reports/_self_review_report.html.erb
@@ -20,7 +20,7 @@
       <!--Last reviewed at-->
       <td bgcolor=<%= @bgcolor %> align='left'>
         <%= sr.updated_at.to_time.strftime("%m/%d/%Y - %I:%M%p") %>
-      </td></tr><tr>
+      </td><tr></tr>
     <% end %>
   </table>
 </div>

--- a/app/views/student_review/list.html.erb
+++ b/app/views/student_review/list.html.erb
@@ -15,9 +15,7 @@
 
 <% if check_reviewable_topics(@assignment) or @assignment.get_current_stage(@topic_id) == "Finished" %>
     <%= render :partial => 'responses', :locals => {:mappings => @review_mappings, :title => 'Review'} %>
-    <!-- Temporary fix for Staggered Deadline assignment issue preventing students from reviewing 04-23-19 -->
-    <!-- We need to perform the same check, but on the topic that is being reviewed and not the topic that the reviewer wrote on -->
-    <% if @assignment.staggered_deadline? or @assignment.number_of_current_round(@topic_id) == 1 or (@assignment.number_of_current_round(@topic_id) > 1 and @assignment.allow_selecting_additional_reviews_after_1st_round) %>   
+    <% if @assignment.number_of_current_round(@topic_id) == 1 or (@assignment.number_of_current_round(@topic_id) > 1 and @assignment.allow_selecting_additional_reviews_after_1st_round) %>   
       <% if @assignment.dynamic_reviewer_assignment? %>
           <% if @num_reviews_in_progress >= Assignment.max_outstanding_reviews %>
               <br><br>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -336,7 +336,6 @@ resources :institution, except: [:destroy] do
       get :intelligent_sign_up
       get :intelligent_save
       get :signup_as_instructor
-      post :delete_all_topics_for_assignment
       post :signup_as_instructor_action
       post :set_priority
       post :save_topic_deadlines

--- a/spec/controllers/grades_controller_spec.rb
+++ b/spec/controllers/grades_controller_spec.rb
@@ -105,7 +105,7 @@ describe GradesController do
       allow(AssignmentQuestionnaire).to receive(:where).with(assignment_id: 1, used_in_round: 2).and_return([])
       assignment_questionnaire.used_in_round = nil
       allow(AssignmentQuestionnaire).to receive(:find_by).with(assignment_id: 1, questionnaire_id: 1).and_return(assignment_questionnaire)
-      allow(review_questionnaire).to receive(:get_assessments_for).with(participant).and_return([review_response])
+      allow(review_questionnaire).to receive(:get_assessments_for).with(participant, false).and_return([review_response])
       allow(Answer).to receive(:compute_scores).with([review_response], [question]).and_return(max: 95, min: 88, avg: 90)
       allow(assignment).to receive(:compute_total_score).with(any_args).and_return(100)
       params = {id: 1}

--- a/spec/controllers/sign_up_sheet_controller_spec.rb
+++ b/spec/controllers/sign_up_sheet_controller_spec.rb
@@ -50,7 +50,7 @@ describe SignUpSheetController do
             }
           }
           post :create, params
-          expect(response).to redirect_to('/assignments/1/edit#tabs-2')
+          expect(response).to redirect_to('/assignments/1/edit#tabs-5')
         end
       end
 
@@ -105,7 +105,7 @@ describe SignUpSheetController do
           .with("The topic: \"Hello world!\" has been successfully deleted. ").and_return('OK')
         params = {id: 1, assignment_id: 1}
         post :destroy, params
-        expect(response).to redirect_to('/assignments/1/edit')
+        expect(response).to redirect_to('/assignments/1/edit#tabs-5')
       end
     end
 
@@ -117,18 +117,8 @@ describe SignUpSheetController do
         params = {id: 1, assignment_id: 1}
         post :destroy, params
         expect(flash[:error]).to eq('The topic could not be deleted.')
-        expect(response).to redirect_to('/assignments/1/edit')
+        expect(response).to redirect_to('/assignments/1/edit#tabs-5')
       end
-    end
-  end
-
-  describe '#delete_all_topics_for_assignment' do
-    it 'deletes all topics for the assignment and redirects to edit assignment page' do
-      allow(SignUpTopic).to receive(:find).with(assignment_id: '1').and_return(topic)
-      params = {assignment_id: 1}
-      post :delete_all_topics_for_assignment, params
-      expect(flash[:success]).to eq('All topics have been deleted successfully.')
-      expect(response).to redirect_to('/assignments/1/edit')
     end
   end
 
@@ -147,7 +137,7 @@ describe SignUpSheetController do
         params = {id: 1, assignment_id: 1}
         post :update, params
         expect(flash[:error]).to eq('The topic could not be updated.')
-        expect(response).to redirect_to('/assignments/1/edit#tabs-2')
+        expect(response).to redirect_to('/assignments/1/edit#tabs-5')
       end
     end
 
@@ -172,7 +162,7 @@ describe SignUpSheetController do
           }
         }
         post :update, params
-        expect(response).to redirect_to('/assignments/1/edit#tabs-2')
+        expect(response).to redirect_to('/assignments/1/edit#tabs-5')
       end
     end
   end

--- a/spec/features/assignment_creation_spec.rb
+++ b/spec/features/assignment_creation_spec.rb
@@ -442,7 +442,6 @@ describe "assignment function" do
       assignment = create(:assignment, name: 'public assignment for test')
       login_as("instructor6")
       visit "/assignments/#{assignment.id}/edit"
-      check("assignment_has_topics")
       click_link 'Topics'
     end
 
@@ -515,16 +514,6 @@ describe "assignment function" do
 
       topics_exist = SignUpTopic.where(assignment_id: assignment.id).count
       expect(topics_exist).to be_eql 0
-    end
-
-    it "hides topics tab when has topics is un-checked", js: true do
-      click_link 'General'
-      uncheck("assignment_has_topics")
-      # The below line is used to accept the js confirmation popup
-      page.driver.browser.switch_to.alert.accept
-      # Wait for topics to be removed and page to re-load
-      sleep 3
-      expect(page).not_to have_link('Topics')
     end
   end
 

--- a/spec/models/assignment_particpant_spec.rb
+++ b/spec/models/assignment_particpant_spec.rb
@@ -108,7 +108,7 @@ describe AssignmentParticipant do
         score_map = {max: 100, min: 100, avg: 100}
         allow(AssignmentQuestionnaire).to receive(:find_by).with(assignment_id: 1, questionnaire_id: 1)
                                                            .and_return(double('AssignmentQuestionnaire', used_in_round: nil))
-        allow(review_questionnaire).to receive(:get_assessments_for).with(participant).and_return([response])
+        allow(review_questionnaire).to receive(:get_assessments_for).with(participant, false).and_return([response])
         allow(Answer).to receive(:compute_scores).with(any_args).and_return(score_map)
         participant.compute_assignment_score(question_hash, scores)
         expect(scores[:review][:assessments]).to eq([response])


### PR DESCRIPTION
Currently, it is possible to check the “Allow self-review” box on the Review Strategy tab of assignment creation, and then an author will be asked to review his/her own submission in addition to the submissions of others.  But as currently implemented, nothing is done with the scores on these self-

The objective of these changes is to make it be possible to see self-review scores juxtaposed with peer-review scores.  They are shown amidst the other reviews, but in a way that highlights them as being a different kind of review.

Wiki Link: http://wiki.expertiza.ncsu.edu/index.php/CSC/ECE_517_Spring_2019_E1926_Improve_self-review
Screencast Video: https://drive.google.com/file/d/1wnYxQxETkZM0yU83M80QYGNZkJ7lsIEq/view
