### PR TITLE
Pointing to Errbit for error monitoring

### DIFF
--- a/config/initializers/airbrake.rb
+++ b/config/initializers/airbrake.rb
@@ -1,56 +1,24 @@
-# Airbrake is an online tool that provides robust exception tracking in your Rails
-# applications. In doing so, it allows you to easily review errors, tie an error
-# to an individual piece of code, and trace the cause back to recent
-# changes. Airbrake enables for easy categorization, searching, and prioritization
+# Errbit is an online tool that provides robust exception tracking in your Rails
+# applications. Errbit enables for easy categorization, storing and searching
 # of exceptions so that when errors occur, your team can quickly determine the
 # root cause.
-#
-# Configuration details:
-# https://github.com/airbrake/airbrake-ruby#configuration
-Airbrake.configure do |c|
+Airbrake.configure do |config|
+
   # You must set both project_id & project_key. To find your project_id and
   # project_key navigate to your project's General Settings and copy the values
   # from the right sidebar.
-  # https://github.com/airbrake/airbrake-ruby#project_id--project_key
-  c.project_id = '19072'
-  c.project_key = '70f2332b3e675ea123d81bc81b499907'
-
-  # Configures the root directory of your project. Expects a String or a
-  # Pathname, which represents the path to your project. Providing this option
-  # helps us to filter out repetitive data from backtrace frames and link to
-  # GitHub files from our dashboard.
-  # https://github.com/airbrake/airbrake-ruby#root_directory
-  c.root_directory = Rails.root
-
-  # By default, Airbrake Ruby outputs to STDOUT. In Rails apps it makes sense to
-  # use the Rails' logger.
-  # https://github.com/airbrake/airbrake-ruby#logger
-  c.logger = Rails.logger
-
-  # Configures the environment the application is running in. Helps the Airbrake
-  # dashboard to distinguish between exceptions occurring in different
-  # environments. By default, it's not set.
-  # NOTE: This option must be set in order to make the 'ignore_environments'
-  # option work.
-  # https://github.com/airbrake/airbrake-ruby#environment
-  c.environment = Rails.env
+  config.host = 'https://errbit-expertiza2019.herokuapp.com'
+  config.project_id = 1 # required, but any positive integer works
+  config.project_key = '64ed97f0c8e628acefb3a7f63308a11c'
+  config.environment = Rails.env
 
   # Setting this option allows Airbrake to filter exceptions occurring in
   # unwanted environments such as :test. By default, it is equal to an empty
   # Array, which means Airbrake Ruby sends exceptions occurring in all
   # environments.
   # NOTE: This option *does not* work if you don't set the 'environment' option.
-  # https://github.com/airbrake/airbrake-ruby#ignore_environments
-  c.ignore_environments = %w(development test)
-
-  # A list of parameters that should be filtered out of what is sent to
-  # Airbrake. By default, all "password" attributes will have their contents
-  # replaced.
-  # https://github.com/airbrake/airbrake-ruby#blacklist_keys
-  c.blacklist_keys = [/password/i]
+   config.ignore_environments = %w(test)
 end
 
-# If Airbrake doesn't send any expected exceptions, we suggest to uncomment the
-# line below. It might simplify debugging of background Airbrake workers, which
-# can silently die.
-# Thread.abort_on_exception = ['test', 'development'].include?(Rails.env)
+
+


### PR DESCRIPTION
`Set up an open-source error monitoring tool instead of Airbrake`

Details about the changes:
- Making Errbit catch errors occurred in Expertiza by changing the configuration in airbrake.rb file.
- @Winbobob please review the changes and suggest changes if necessary.
