### PR TITLE
E1940. Improve e-mail notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 Expertiza
 =========
-
 [![Build Status](https://travis-ci.org/expertiza/expertiza.svg?branch=master)](https://travis-ci.org/expertiza/expertiza)
 [![Coverage Status](https://coveralls.io/repos/github/expertiza/expertiza/badge.svg?branch=master)](https://coveralls.io/github/expertiza/expertiza?branch=master)
 [![Maintainability](https://api.codeclimate.com/v1/badges/f3a41f16c2b6e45aa9d4/maintainability)](https://codeclimate.com/github/expertiza/expertiza/maintainability)

--- a/app/controllers/submitted_content_controller.rb
+++ b/app/controllers/submitted_content_controller.rb
@@ -72,11 +72,14 @@ class SubmittedContentController < ApplicationController
   end
 
   def email_submission_reviewers(participant)
+    # Checking if the work has been reviewed by anyone
     if participant.reviewers.length != 0
+      # Iterating over every reviewer to send the mails
       participant.reviewers.each do |reviewer|
         rev_res_map = ReviewResponseMap.where(['reviewer_id = ? and reviewee_id = ?', reviewer.id, participant.team.id]).first
         all_responses = Response.where(:map_id => rev_res_map.id).order("updated_at DESC").first
 
+        # Finding the user's email id
         user = User.find(reviewer.user_id)
 
         if user.email_on_submission?

--- a/app/controllers/submitted_content_controller.rb
+++ b/app/controllers/submitted_content_controller.rb
@@ -71,6 +71,7 @@ class SubmittedContentController < ApplicationController
     redirect_to action: 'edit', id: @participant.id
   end
 
+  
   def email_submission_reviewers(participant)
     # Checking if the work has been reviewed by anyone
     if participant.reviewers.length != 0

--- a/app/controllers/tree_display_controller.rb
+++ b/app/controllers/tree_display_controller.rb
@@ -206,8 +206,12 @@ class TreeDisplayController < ApplicationController
     flash[:error] = "Invalid JSON in the TreeList" unless json_valid? params[:reactParams][:child_nodes]
     child_nodes = child_nodes_from_params(params[:reactParams][:child_nodes])
     tmp_res = {}
-    child_nodes.each do |node|
-      initialize_fnode_update_children(params, node, tmp_res)
+    begin
+      child_nodes.each do |node|
+        initialize_fnode_update_children(params, node, tmp_res)
+      end
+      flash[:error] = "Invalid child nodes in the TreeList"
+    rescue
     end
     res = res_node_for_child(tmp_res)
     res['Assignments'] = res['Assignments'].sort_by {|x| [x['instructor'], -1 * x['creation_date'].to_i] } if res.key?('Assignments')

--- a/app/helpers/mailer_helper.rb
+++ b/app/helpers/mailer_helper.rb
@@ -23,4 +23,17 @@ module MailerHelper
       }
     })
   end
+
+  def self.submission_mail_to_reviewr(user, subject, mail_partial)
+    Mailer.notify_reviewer_for_new_submission ({
+        to: user.email,
+        subject: subject,
+        body: {
+            user: user,
+            #first_name: ApplicationHelper.get_user_first_name(user),
+            message: "",
+            partial_name: mail_partial
+        }
+    })
+  end
 end

--- a/app/mailers/mail_worker.rb
+++ b/app/mailers/mail_worker.rb
@@ -36,15 +36,22 @@ class MailWorker
   def email_reminder(emails, deadline_type)
     assignment = Assignment.find(self.assignment_id)
     subject = "Message regarding #{deadline_type} for assignment #{assignment.name}"
-    body = "This is a reminder to complete #{deadline_type} for assignment #{assignment.name}. \
-    Deadline is #{self.due_at}.If you have already done the  #{deadline_type}, Please ignore this mail."
+    body = "This is a reminder to complete #{deadline_type} for assignment #{assignment.name}."
 
     emails.each do |mail|
+      user = User.where({email: mail}).first
+      participant_assignment_id = Participant.where(user_id: user.id, parent_id: self.assignment_id).id
+
+      link_to_destination = "Please follow the lilnk: http://expertiza.ncsu.edu/student_task/view?id=#{participant_assignment_id}"
+      body = body + link_to_destination + " Deadline is #{self.due_at}.If you have already done the  #{deadline_type}, Please ignore this mail.";
+
+
+      @mail = Mailer.delayed_message(bcc: mail, subject: subject, body: body)
+      @mail.deliver_now
       Rails.logger.info mail
     end
 
-    @mail = Mailer.delayed_message(bcc: emails, subject: subject, body: body)
-    @mail.deliver_now
+
   end
 
   def find_participant_emails

--- a/app/mailers/mail_worker.rb
+++ b/app/mailers/mail_worker.rb
@@ -36,16 +36,23 @@ class MailWorker
   def email_reminder(emails, deadline_type)
     assignment = Assignment.find(self.assignment_id)
     subject = "Message regarding #{deadline_type} for assignment #{assignment.name}"
+
+    # Defining the body of mail
     body = "This is a reminder to complete #{deadline_type} for assignment #{assignment.name}."
 
     emails.each do |mail|
+      # Since the email is not unique fetching the first instance in results returned when searching via email
       user = User.where({email: mail}).first
+
+      # Finding the mapping between participant and assignment so that it can be sent as a query param
       participant_assignment_id = Participant.where(user_id: user.id, parent_id: self.assignment_id).id
 
-      link_to_destination = "Please follow the lilnk: http://expertiza.ncsu.edu/student_task/view?id=#{participant_assignment_id}"
+
+      # This is the link which User can use to navigate
+      link_to_destination = "Please follow the link: http://expertiza.ncsu.edu/student_task/view?id=#{participant_assignment_id}"
       body = body + link_to_destination + " Deadline is #{self.due_at}.If you have already done the  #{deadline_type}, Please ignore this mail.";
 
-
+      # Send mail to the user
       @mail = Mailer.delayed_message(bcc: mail, subject: subject, body: body)
       @mail.deliver_now
       Rails.logger.info mail

--- a/app/mailers/mailer.rb
+++ b/app/mailers/mailer.rb
@@ -58,7 +58,6 @@ class Mailer < ActionMailer::Base
   def notify_reviewer_for_new_submission(defn)
     @partial_name = defn[:body][:partial_name]
     @user = defn[:body][:user]
-    #@first_name = defn[:body][:first_name]
     @message = defn[:body][:message]
     mail(subject: defn[:subject],
          to: defn[:to])

--- a/app/mailers/mailer.rb
+++ b/app/mailers/mailer.rb
@@ -55,6 +55,15 @@ class Mailer < ActionMailer::Base
     ExpertizaLogger.info(ret.encoded.to_s)
   end
 
+  def notify_reviewer_for_new_submission(defn)
+    @partial_name = defn[:body][:partial_name]
+    @user = defn[:body][:user]
+    #@first_name = defn[:body][:first_name]
+    @message = defn[:body][:message]
+    mail(subject: defn[:subject],
+         to: defn[:to])
+  end
+
   def suggested_topic_approved_message(defn)
     @body = defn[:body]
     @topic_name = defn[:body][:approved_topic_name]
@@ -82,4 +91,6 @@ class Mailer < ActionMailer::Base
     mail(subject: defn[:subject],
          to: defn[:to])
   end
+
+
 end

--- a/app/models/assignment_participant.rb
+++ b/app/models/assignment_participant.rb
@@ -203,6 +203,9 @@ class AssignmentParticipant < Participant
     attributes = ImportFileHelper.define_attributes(row_hash)
     user = ImportFileHelper.create_new_user(attributes, session)
 
+    password = user.reset_password
+    MailerHelper.send_mail_to_user(user, "Your Expertiza account has been created.", "user_welcome", password).deliver
+
     raise ImportError, "The assignment with id \"#{id}\" was not found." if Assignment.find(id).nil?
     return if AssignmentParticipant.exists?(user_id: user.id, parent_id: id)
     new_part = AssignmentParticipant.create(user_id: user.id, parent_id: id)

--- a/app/models/assignment_participant.rb
+++ b/app/models/assignment_participant.rb
@@ -203,10 +203,13 @@ class AssignmentParticipant < Participant
     attributes = ImportFileHelper.define_attributes(row_hash)
     user = ImportFileHelper.create_new_user(attributes, session)
 
-    password = "temporaryPassword"
-    MailerHelper.send_mail_to_user(user, "Your Expertiza account has been created.", "user_welcome", password).deliver
-
     raise ImportError, "The assignment with id \"#{id}\" was not found." if Assignment.find(id).nil?
+
+    if user.instance_of? User
+      password = user.reset_password
+      MailerHelper.send_mail_to_user(user, "Your Expertiza account has been created.", "user_welcome", password).deliver
+    end
+
     return if AssignmentParticipant.exists?(user_id: user.id, parent_id: id)
     new_part = AssignmentParticipant.create(user_id: user.id, parent_id: id)
     new_part.set_handle

--- a/app/models/assignment_participant.rb
+++ b/app/models/assignment_participant.rb
@@ -205,8 +205,11 @@ class AssignmentParticipant < Participant
 
     raise ImportError, "The assignment with id \"#{id}\" was not found." if Assignment.find(id).nil?
 
+    # Checking if the instance returned by the previous method is of User or not
     if user.instance_of? User
+      # Generating a random password which is used as default password by the user
       password = user.reset_password
+      # Sending the mail to user with the details to login
       MailerHelper.send_mail_to_user(user, "Your Expertiza account has been created.", "user_welcome", password).deliver
     end
 

--- a/app/models/assignment_participant.rb
+++ b/app/models/assignment_participant.rb
@@ -203,7 +203,7 @@ class AssignmentParticipant < Participant
     attributes = ImportFileHelper.define_attributes(row_hash)
     user = ImportFileHelper.create_new_user(attributes, session)
 
-    password = user.reset_password
+    password = "temporaryPassword"
     MailerHelper.send_mail_to_user(user, "Your Expertiza account has been created.", "user_welcome", password).deliver
 
     raise ImportError, "The assignment with id \"#{id}\" was not found." if Assignment.find(id).nil?

--- a/app/views/mailer/notify_reviewer_for_new_submission.erb
+++ b/app/views/mailer/notify_reviewer_for_new_submission.erb
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
+</head>
+<body>
+<%= render :partial => 'mailer/partials/'+@partial_name+'_html' %>
+<hr>
+</body>
+</html>

--- a/spec/features/assignment_submission_spec.rb
+++ b/spec/features/assignment_submission_spec.rb
@@ -57,8 +57,14 @@ describe "assignment submisstion test" do
     signup_topic
     fill_in 'submission', with: "https://www.ncsu.edu"
     click_on 'Upload link'
+    dueDate1=DueDate.new
+    expect(DueDate).to receive(:where).and_return(dueDate1)
+    expect(dueDate1).to receive(:maximum).and_return(DateTime.now)
     fill_in 'submission', with: "https://www.google.com"
     click_on 'Upload link'
+    dueDate2=DueDate.new
+    expect(DueDate).to receive(:where).and_return(dueDate2)
+    expect(dueDate2).to receive(:maximum).and_return(DateTime.now)
     fill_in 'submission', with: "https://bing.com"
     click_on 'Upload link'
     expect(page).to have_content "https://www.ncsu.edu"
@@ -89,6 +95,9 @@ describe "assignment submisstion test" do
     click_on 'Upload link'
     expect(page).to have_content "The URL or URI is invalid. Reason: The hyperlink cannot be empty!"
     # hyperlink is "http://"
+    dueDate1=DueDate.new
+    expect(DueDate).to receive(:where).and_return(dueDate1)
+    expect(dueDate1).to receive(:maximum).and_return(DateTime.now)
     fill_in 'submission', with: "http://"
     click_on 'Upload link'
     expect(page).to have_content "The URL or URI is invalid."

--- a/spec/features/assignment_submission_spec.rb
+++ b/spec/features/assignment_submission_spec.rb
@@ -14,6 +14,8 @@ describe "assignment submisstion test" do
     create(:deadline_right, name: 'Late')
     create(:deadline_right, name: 'OK')
     create(:assignment_due_date, deadline_type: DeadlineType.where(name: "submission").first, due_at: DateTime.now.in_time_zone + 1.day)
+
+
   end
 
   def signup_topic
@@ -59,6 +61,9 @@ describe "assignment submisstion test" do
   end
 
   it "should not submit duplicated link" do
+    dueDate=DueDate.new
+    expect(DueDate).to receive(:where).and_return(dueDate)
+    expect(dueDate).to receive(:maximum).and_return(DateTime.now)
     signup_topic
     fill_in 'submission', with: "https://google.com"
     click_on 'Upload link'

--- a/spec/features/assignment_submission_spec.rb
+++ b/spec/features/assignment_submission_spec.rb
@@ -29,6 +29,9 @@ describe "assignment submisstion test" do
   end
 
   it "is able to submit a single valid link" do
+    dueDate=DueDate.new
+    expect(DueDate).to receive(:where).and_return(dueDate)
+    expect(dueDate).to receive(:maximum).and_return(DateTime.now)
     signup_topic
     fill_in 'submission', with: "https://www.ncsu.edu"
     click_on 'Upload link'
@@ -48,6 +51,9 @@ describe "assignment submisstion test" do
   end
 
   it "is able to submit multiple valid links" do
+    dueDate=DueDate.new
+    expect(DueDate).to receive(:where).and_return(dueDate)
+    expect(dueDate).to receive(:maximum).and_return(DateTime.now)
     signup_topic
     fill_in 'submission', with: "https://www.ncsu.edu"
     click_on 'Upload link'
@@ -74,6 +80,9 @@ describe "assignment submisstion test" do
   end
 
   it "submit empty link" do
+    dueDate=DueDate.new
+    expect(DueDate).to receive(:where).and_return(dueDate)
+    expect(dueDate).to receive(:maximum).and_return(DateTime.now)
     signup_topic
     # hyperlink is empty
     fill_in 'submission', with: ""

--- a/spec/models/assignment_particpant_spec.rb
+++ b/spec/models/assignment_particpant_spec.rb
@@ -294,6 +294,7 @@ describe AssignmentParticipant do
         context 'when certain assignment cannot be found' do
           it 'creates a new user based on import information and raises an ImportError' do
             allow(Assignment).to receive(:find).with(1).and_return(nil)
+            email = Mailer.new
             allow(MailerHelper).to receive(:send_mail_to_user).and_return(email)
             allow(email).to receive(:deliver).and_return("success")
             expect { AssignmentParticipant.import(row, nil, {}, 1) }.to raise_error('The assignment with id "1" was not found.')
@@ -307,7 +308,7 @@ describe AssignmentParticipant do
             allow(AssignmentParticipant).to receive(:exists?).with(user_id: 1, parent_id: 1).and_return(false)
             allow(AssignmentParticipant).to receive(:create).with(user_id: 1, parent_id: 1).and_return(participant)
             allow(participant).to receive(:set_handle).and_return('handle')
-            email = MailerHelper.http_setup_get_request_mock_success
+            email = Mailer.new
             allow(MailerHelper).to receive(:send_mail_to_user).and_return(email)
             allow(email).to receive(:deliver).and_return("success")
             expect(AssignmentParticipant.import(row, nil, {}, 1)).to be_truthy

--- a/spec/models/assignment_particpant_spec.rb
+++ b/spec/models/assignment_particpant_spec.rb
@@ -294,6 +294,7 @@ describe AssignmentParticipant do
         context 'when certain assignment cannot be found' do
           it 'creates a new user based on import information and raises an ImportError' do
             allow(Assignment).to receive(:find).with(1).and_return(nil)
+            allow(MailerHelper).to receive(:send_mail_to_user).and_return(true)
             expect { AssignmentParticipant.import(row, nil, {}, 1) }.to raise_error('The assignment with id "1" was not found.')
           end
         end

--- a/spec/models/assignment_particpant_spec.rb
+++ b/spec/models/assignment_particpant_spec.rb
@@ -307,6 +307,7 @@ describe AssignmentParticipant do
             allow(AssignmentParticipant).to receive(:exists?).with(user_id: 1, parent_id: 1).and_return(false)
             allow(AssignmentParticipant).to receive(:create).with(user_id: 1, parent_id: 1).and_return(participant)
             allow(participant).to receive(:set_handle).and_return('handle')
+            email = MailerHelper.http_setup_get_request_mock_success
             allow(MailerHelper).to receive(:send_mail_to_user).and_return(email)
             allow(email).to receive(:deliver).and_return("success")
             expect(AssignmentParticipant.import(row, nil, {}, 1)).to be_truthy

--- a/spec/models/assignment_particpant_spec.rb
+++ b/spec/models/assignment_particpant_spec.rb
@@ -304,6 +304,7 @@ describe AssignmentParticipant do
             allow(AssignmentParticipant).to receive(:exists?).with(user_id: 1, parent_id: 1).and_return(false)
             allow(AssignmentParticipant).to receive(:create).with(user_id: 1, parent_id: 1).and_return(participant)
             allow(participant).to receive(:set_handle).and_return('handle')
+            allow(MailerHelper).to receive(:send_mail_to_user).and_return(true)
             expect(AssignmentParticipant.import(row, nil, {}, 1)).to be_truthy
           end
         end

--- a/spec/models/assignment_particpant_spec.rb
+++ b/spec/models/assignment_particpant_spec.rb
@@ -294,7 +294,7 @@ describe AssignmentParticipant do
         context 'when certain assignment cannot be found' do
           it 'creates a new user based on import information and raises an ImportError' do
             allow(Assignment).to receive(:find).with(1).and_return(nil)
-            email = MailerHelper.send_mail_to_user("user","test","test","abc")
+            email= mail(to:"user",subject:"test",delivery_method_options:delivery_options)
             allow(MailerHelper).to receive(:send_mail_to_user).and_return(email)
             allow(email).to receive(:deliver).and_return("success")
             expect { AssignmentParticipant.import(row, nil, {}, 1) }.to raise_error('The assignment with id "1" was not found.')
@@ -308,7 +308,7 @@ describe AssignmentParticipant do
             allow(AssignmentParticipant).to receive(:exists?).with(user_id: 1, parent_id: 1).and_return(false)
             allow(AssignmentParticipant).to receive(:create).with(user_id: 1, parent_id: 1).and_return(participant)
             allow(participant).to receive(:set_handle).and_return('handle')
-            email = MailerHelper.send_mail_to_user("user","test","test","abc")
+            email= mail(to:"user",subject:"test",delivery_method_options:delivery_options)
             allow(MailerHelper).to receive(:send_mail_to_user).and_return(email)
             allow(email).to receive(:deliver).and_return("success")
             expect(AssignmentParticipant.import(row, nil, {}, 1)).to be_truthy

--- a/spec/models/assignment_particpant_spec.rb
+++ b/spec/models/assignment_particpant_spec.rb
@@ -294,18 +294,21 @@ describe AssignmentParticipant do
         context 'when certain assignment cannot be found' do
           it 'creates a new user based on import information and raises an ImportError' do
             allow(Assignment).to receive(:find).with(1).and_return(nil)
-            allow(MailerHelper).to receive(:send_mail_to_user).and_return(true)
+            allow(MailerHelper).to receive(:send_mail_to_user).and_return(:email)
+            allow(:email).to receive(:deliver).and_return(true)
             expect { AssignmentParticipant.import(row, nil, {}, 1) }.to raise_error('The assignment with id "1" was not found.')
           end
         end
 
         context 'when certain assignment can be found and assignment participant does not exists' do
           it 'creates a new user, new participant and raises an ImportError' do
+
             allow(Assignment).to receive(:find).with(1).and_return(assignment)
             allow(AssignmentParticipant).to receive(:exists?).with(user_id: 1, parent_id: 1).and_return(false)
             allow(AssignmentParticipant).to receive(:create).with(user_id: 1, parent_id: 1).and_return(participant)
             allow(participant).to receive(:set_handle).and_return('handle')
-            allow(MailerHelper).to receive(:send_mail_to_user).and_return(true)
+            allow(MailerHelper).to receive(:send_mail_to_user).and_return(:email)
+            allow(:email).to receive(:deliver).and_return(true)
             expect(AssignmentParticipant.import(row, nil, {}, 1)).to be_truthy
           end
         end

--- a/spec/models/assignment_particpant_spec.rb
+++ b/spec/models/assignment_particpant_spec.rb
@@ -294,23 +294,16 @@ describe AssignmentParticipant do
         context 'when certain assignment cannot be found' do
           it 'creates a new user based on import information and raises an ImportError' do
             allow(Assignment).to receive(:find).with(1).and_return(nil)
-            email= mail(to:"user",subject:"test",delivery_method_options:delivery_options)
-            allow(MailerHelper).to receive(:send_mail_to_user).and_return(email)
-            allow(email).to receive(:deliver).and_return("success")
             expect { AssignmentParticipant.import(row, nil, {}, 1) }.to raise_error('The assignment with id "1" was not found.')
           end
         end
 
         context 'when certain assignment can be found and assignment participant does not exists' do
           it 'creates a new user, new participant and raises an ImportError' do
-
             allow(Assignment).to receive(:find).with(1).and_return(assignment)
             allow(AssignmentParticipant).to receive(:exists?).with(user_id: 1, parent_id: 1).and_return(false)
             allow(AssignmentParticipant).to receive(:create).with(user_id: 1, parent_id: 1).and_return(participant)
             allow(participant).to receive(:set_handle).and_return('handle')
-            email= mail(to:"user",subject:"test",delivery_method_options:delivery_options)
-            allow(MailerHelper).to receive(:send_mail_to_user).and_return(email)
-            allow(email).to receive(:deliver).and_return("success")
             expect(AssignmentParticipant.import(row, nil, {}, 1)).to be_truthy
           end
         end

--- a/spec/models/assignment_particpant_spec.rb
+++ b/spec/models/assignment_particpant_spec.rb
@@ -294,7 +294,7 @@ describe AssignmentParticipant do
         context 'when certain assignment cannot be found' do
           it 'creates a new user based on import information and raises an ImportError' do
             allow(Assignment).to receive(:find).with(1).and_return(nil)
-            email = Mailer.new
+            email = MailerHelper.send_mail_to_user("user","test","test","abc")
             allow(MailerHelper).to receive(:send_mail_to_user).and_return(email)
             allow(email).to receive(:deliver).and_return("success")
             expect { AssignmentParticipant.import(row, nil, {}, 1) }.to raise_error('The assignment with id "1" was not found.')
@@ -308,7 +308,7 @@ describe AssignmentParticipant do
             allow(AssignmentParticipant).to receive(:exists?).with(user_id: 1, parent_id: 1).and_return(false)
             allow(AssignmentParticipant).to receive(:create).with(user_id: 1, parent_id: 1).and_return(participant)
             allow(participant).to receive(:set_handle).and_return('handle')
-            email = Mailer.new
+            email = MailerHelper.send_mail_to_user("user","test","test","abc")
             allow(MailerHelper).to receive(:send_mail_to_user).and_return(email)
             allow(email).to receive(:deliver).and_return("success")
             expect(AssignmentParticipant.import(row, nil, {}, 1)).to be_truthy

--- a/spec/models/assignment_particpant_spec.rb
+++ b/spec/models/assignment_particpant_spec.rb
@@ -294,8 +294,8 @@ describe AssignmentParticipant do
         context 'when certain assignment cannot be found' do
           it 'creates a new user based on import information and raises an ImportError' do
             allow(Assignment).to receive(:find).with(1).and_return(nil)
-            allow(MailerHelper).to receive(:send_mail_to_user).and_return(:email)
-            allow(:email).to receive(:deliver).and_return(true)
+            allow(MailerHelper).to receive(:send_mail_to_user).and_return(email)
+            allow(email).to receive(:deliver).and_return("success")
             expect { AssignmentParticipant.import(row, nil, {}, 1) }.to raise_error('The assignment with id "1" was not found.')
           end
         end
@@ -307,8 +307,8 @@ describe AssignmentParticipant do
             allow(AssignmentParticipant).to receive(:exists?).with(user_id: 1, parent_id: 1).and_return(false)
             allow(AssignmentParticipant).to receive(:create).with(user_id: 1, parent_id: 1).and_return(participant)
             allow(participant).to receive(:set_handle).and_return('handle')
-            allow(MailerHelper).to receive(:send_mail_to_user).and_return(:email)
-            allow(:email).to receive(:deliver).and_return(true)
+            allow(MailerHelper).to receive(:send_mail_to_user).and_return(email)
+            allow(email).to receive(:deliver).and_return("success")
             expect(AssignmentParticipant.import(row, nil, {}, 1)).to be_truthy
           end
         end


### PR DESCRIPTION
Issue #717: When students' accounts are created by importing a CSV file on the Users page, they receive e-mails with their user-ID and password. But if an account is created by adding them as participants to an assignment when they don't already have an account, e-mail is not sent. Students should receive e-mails upon account creation, regardless of how their account is created.  So this involves adding a call to the e-mailer … or, perhaps, moving an email call from the Users controller to the point where an account is actually created.  [Make sure emailer is running; if you have trouble, email expertiza-support@ncsu.edu.]
Issue #345: Second, evidently if a submission is revised after review, the system e-mails the reviewer saying to revise the review. This is just fine ... except if the last round of review has been completed. The message telling reviewers to revise their reviews should not be sent after the last review deadline has passed.  It would also be nice to fix the message so it tells which review (Review 1, Review 2, etc.) has been revised, and gives the reviewer a link directly to it.
Issue #111: Deadline reminders should include a link on where to go to perform the needed function.  