### PR TITLE
E2073. Refactor course_controller.rb redux

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -5,7 +5,7 @@
 # By: ajbudlon
 
 # change access permission from public to private or vice versa
-class CourseController < ApplicationController
+class CoursesController < ApplicationController
   include AuthorizationHelper
 
   autocomplete :user, :name

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -88,7 +88,7 @@ Expertiza::Application.routes.draw do
     end
   end
 
-  resources :course, only: %i[new create edit update] do
+  resources :course, controller: 'courses', only: %i[new create edit update] do
     collection do
       get :toggle_access
       get :copy


### PR DESCRIPTION
Background: The CourseController handles creating, modifying, and deleting courses.
Issues to be fixed:
The class should be named courses_controller.rb, to follow the current Rails convention that controllers should be named in the plural.
Line 77: “The copy is currently associated with an existing location from the original course.” Does this mean that the copy is using the same submission directory as the original course? Then it should say that! The existing phrasing is confusing.
To explain, when students submit files (rather than links) to Expertiza, the files must be stored somewhere. The instructor is supposed to specify the path, and then Expertiza stores the files there. But suppose the instructor specifies a path that has been used for another assignment, or forgets to specify a path, causing a null path to be used. In either case, the new course will use the same directory as an existing course, which can cause files submitted for one assignment to show up in another assignment. So we absolutely have to enforce that the submission directory for this course is different.from the submission directory for all other courses.
I think we’ve already adopted that rule for assignments; check assignment_controller.rb and make sure that courses_controller.rb is consistent with it.
create and update duplicate code. Duplicate parts should be moved to a partial or a private method.
create_course_node should be a method of course_node.rb. It does not belong in a controller.

Collaborators: Nick Garner (nickrgarner), Jonathan Nguyen (jhnguye4), Surbhi Jha (surbhijha)