### PR TITLE
E2074. Extensions to teammate review

### DIFF
--- a/app/assets/javascripts/tree_display.jsx
+++ b/app/assets/javascripts/tree_display.jsx
@@ -1034,6 +1034,7 @@ jQuery(document).ready(function() {
     }
   })
 
+<<<<<<< HEAD
   var FilterableTable = React.createClass({
     getInitialState: function() {
       return {
@@ -1130,6 +1131,374 @@ jQuery(document).ready(function() {
       )
     }
   })
+=======
+	var ContentTable = React.createClass({
+		getInitialState: function() {
+			return {
+				expandedRow: []
+			}
+		},
+		handleExpandClick: function(id, expanded, newParams) {
+			this.state.expandedRow.concat([ id ])
+			if (expanded) {
+				this.setState({
+					expandedRow: this.state.expandedRow.concat([ id ])
+				})
+				// if(this.props.dataType!='assignment') {
+				_this = this
+				jQuery.post(
+					'/tree_display/get_sub_folder_contents',
+					{
+						reactParams2: newParams
+					},
+					function(data) {
+						_this.props.data[id.split('_')[2]]['children'] = data
+						_this.forceUpdate()
+					},
+					'json'
+				)
+				// }
+			} else {
+				var index = this.state.expandedRow.indexOf(id)
+				if (index > -1) {
+					var list = this.state.expandedRow
+					list.splice(index, 1)
+					this.setState({
+						expandedRow: list
+					})
+				}
+			}
+		},
+		handleSortingClick: function(colName, order) {
+			this.props.onUserClick(colName, order)
+		},
+		render: function() {
+			var _rows = []
+			var _this = this
+			var colWidthArray = [ '30%', '0%', '0%', '0%', '25%', '25%', '20%' ]
+			var colDisplayStyle = {
+				display: ''
+			}
+			if (this.props) {
+				if (this.props.dataType === 'questionnaire') {
+					colWidthArray = [ '70%', '0%', '0%', '0%', '0%', '0%', '30%' ]
+					colDisplayStyle = {
+						display: 'none'
+					}
+				}
+				if (this.props.dataType == 'course') {
+					colWidthArray = [ '20%', '0%', '0%', '20%', '20%', '20%', '20%' ]
+					_rows.push(<TitleRow title="My Courses" />)
+				} else if (this.props.dataType == 'assignment') {
+					_rows.push(<TitleRow title="My Assignments" />)
+				}
+				jQuery.each(this.props.data, function(i, entry) {
+					if (
+						((entry.name && entry.name.indexOf(_this.props.filterText) !== -1) ||
+							(entry.creation_date && entry.creation_date.indexOf(_this.props.filterText) !== -1) ||
+							(entry.institution && entry.institution.indexOf(_this.props.filterText) !== -1) ||
+							(entry.updated_date && entry.updated_date.indexOf(_this.props.filterText) !== -1)) &&
+						(entry.private == true || entry.type == 'FolderNode')
+					) {
+						_rows.push(
+							<ContentTableRow
+								key={entry.type + '_' + (parseInt(entry.nodeinfo.id) * 2).toString() + '_' + i}
+								id={
+									entry.type +
+									'_' +
+									(parseInt(entry.nodeinfo.node_object_id) * 2).toString() +
+									'_' +
+									i
+								}
+								name={entry.name}
+								institution={entry.institution}
+								creation_date={entry.creation_date}
+								updated_date={entry.updated_date}
+								actions={entry.actions}
+								is_available={entry.is_available}
+								course_id={entry.course_id}
+								max_team_size={entry.max_team_size}
+								is_intelligent={entry.is_intelligent}
+								require_quiz={entry.require_quiz}
+								dataType={_this.props.dataType}
+								//this is just a hack. All current users courses are marked as private during fetch for display purpose.
+								private={entry.private}
+								allow_suggestions={entry.allow_suggestions}
+								has_topic={entry.has_topic}
+								rowClicked={_this.handleExpandClick}
+								newParams={entry.newParams}
+							/>
+						)
+						_rows.push(
+							<ContentTableDetailsRow
+								key={entry.type + '_' + (parseInt(entry.nodeinfo.id) * 2 + 1).toString() + '_' + i}
+								id={
+									entry.type +
+									'_' +
+									(parseInt(entry.nodeinfo.node_object_id) * 2 + 1).toString() +
+									'_' +
+									i
+								}
+								// showElement={true}
+								showElement={
+									_this.state.expandedRow.indexOf(
+										entry.type +
+											'_' +
+											(parseInt(entry.nodeinfo.node_object_id) * 2).toString() +
+											'_' +
+											i
+									) > -1 ? (
+										''
+									) : (
+										'none'
+									)
+								}
+								dataType={_this.props.dataType}
+								children={entry.children}
+							/>
+						)
+					} else {
+						return
+					}
+				})
+				if (this.props.showPublic) {
+					if (this.props.dataType == 'course') {
+						_rows.push(<TitleRow title="Others' Public Courses" />)
+						jQuery.each(this.props.data, function(i, entry) {
+							if (
+								((entry.name && entry.name.indexOf(_this.props.filterText) !== -1) ||
+									(entry.creation_date &&
+										entry.creation_date.indexOf(_this.props.filterText) !== -1) ||
+									(entry.institution && entry.institution.indexOf(_this.props.filterText) !== -1) ||
+									(entry.updated_date &&
+										entry.updated_date.indexOf(_this.props.filterText) !== -1)) &&
+								entry.private == false
+							) {
+								_rows.push(
+									<ContentTableRow
+										key={entry.type + '_' + (parseInt(entry.nodeinfo.id) * 2).toString() + '_' + i}
+										id={
+											entry.type +
+											'_' +
+											(parseInt(entry.nodeinfo.node_object_id) * 2).toString() +
+											'_' +
+											i
+										}
+										name={entry.name}
+										institution={entry.institution}
+										creation_date={entry.creation_date}
+										updated_date={entry.updated_date}
+										actions={entry.actions}
+										is_available={entry.is_available}
+										course_id={entry.course_id}
+										max_team_size={entry.max_team_size}
+										is_intelligent={entry.is_intelligent}
+										require_quiz={entry.require_quiz}
+										dataType={_this.props.dataType}
+										private={entry.private}
+										allow_suggestions={entry.allow_suggestions}
+										has_topic={entry.has_topic}
+										rowClicked={_this.handleExpandClick}
+										newParams={entry.newParams}
+									/>
+								)
+								_rows.push(
+									<ContentTableDetailsRow
+										key={
+											entry.type +
+											'_' +
+											(parseInt(entry.nodeinfo.id) * 2 + 1).toString() +
+											'_' +
+											i
+										}
+										id={
+											entry.type +
+											'_' +
+											(parseInt(entry.nodeinfo.node_object_id) * 2 + 1).toString() +
+											'_' +
+											i
+										}
+										showElement={
+											_this.state.expandedRow.indexOf(
+												entry.type +
+													'_' +
+													(parseInt(entry.nodeinfo.node_object_id) * 2).toString() +
+													'_' +
+													i
+											) > -1 ? (
+												''
+											) : (
+												'none'
+											)
+										}
+										dataType={_this.props.dataType}
+										children={entry.children}
+									/>
+								)
+							} else {
+								return
+							}
+						})
+					} else if (this.props.dataType == 'assignment') {
+						_rows.push(<TitleRow title="Others' Public Assignments" />)
+						jQuery.each(this.props.data, function(i, entry) {
+							if (
+								((entry.name && entry.name.indexOf(_this.props.filterText) !== -1) ||
+									(entry.creation_date &&
+										entry.creation_date.indexOf(_this.props.filterText) !== -1) ||
+									(entry.updated_date &&
+										entry.updated_date.indexOf(_this.props.filterText) !== -1)) &&
+								entry.private == false
+							) {
+								_rows.push(
+									<ContentTableRow
+										key={entry.type + '_' + (parseInt(entry.nodeinfo.id) * 2).toString() + '_' + i}
+										id={
+											entry.type +
+											'_' +
+											(parseInt(entry.nodeinfo.node_object_id) * 2).toString() +
+											'_' +
+											i
+										}
+										name={entry.name}
+										creation_date={entry.creation_date}
+										updated_date={entry.updated_date}
+										actions={entry.actions}
+										is_available={entry.is_available}
+										course_id={entry.course_id}
+										max_team_size={entry.max_team_size}
+										is_intelligent={entry.is_intelligent}
+										require_quiz={entry.require_quiz}
+										dataType={_this.props.dataType}
+										private={entry.private}
+										allow_suggestions={entry.allow_suggestions}
+										has_topic={entry.has_topic}
+										rowClicked={_this.handleExpandClick}
+										newParams={entry.newParams}
+									/>
+								)
+								_rows.push(
+									<ContentTableDetailsRow
+										key={
+											entry.type +
+											'_' +
+											(parseInt(entry.nodeinfo.id) * 2 + 1).toString() +
+											'_' +
+											i
+										}
+										id={
+											entry.type +
+											'_' +
+											(parseInt(entry.nodeinfo.node_object_id) * 2 + 1).toString() +
+											'_' +
+											i
+										}
+										showElement={
+											_this.state.expandedRow.indexOf(
+												entry.type +
+													'_' +
+													(parseInt(entry.nodeinfo.node_object_id) * 2).toString() +
+													'_' +
+													i
+											) > -1 ? (
+												''
+											) : (
+												'none'
+											)
+										}
+										dataType={_this.props.dataType}
+										children={entry.children}
+									/>
+								)
+							} else {
+								return
+							}
+						})
+					}
+				}
+			}
+			if (this.props.dataType == 'course') {
+				return (
+					<table className="table table-hover" style={{ 'table-layout': 'fixed' }}>
+						<thead>
+							<tr>
+								<th width={colWidthArray[0]}>
+									Name
+									<SortToggle
+										colName="name"
+										order="normal"
+										handleUserClick={this.handleSortingClick}
+									/>
+								</th>
+								<th style={colDisplayStyle} width={colWidthArray[3]}>
+									Institution
+									<SortToggle
+										colName="institution"
+										order="normal"
+										handleUserClick={this.handleSortingClick}
+									/>
+								</th>
+								<th style={colDisplayStyle} width={colWidthArray[4]}>
+									Creation Date
+									<SortToggle
+										colName="creation_date"
+										order="normal"
+										handleUserClick={this.handleSortingClick}
+									/>
+								</th>
+								<th style={colDisplayStyle} width={colWidthArray[5]}>
+									Updated Date
+									<SortToggle
+										colName="updated_date"
+										order="normal"
+										handleUserClick={this.handleSortingClick}
+									/>
+								</th>
+								<th width={colWidthArray[6]}>Actions</th>
+							</tr>
+						</thead>
+						<tbody>{_rows}</tbody>
+					</table>
+				)
+			} else {
+				return (
+					<table className="table table-hover" style={{ 'table-layout': 'fixed' }}>
+						<thead>
+							<tr>
+								<th width={colWidthArray[0]}>
+									Name
+									<SortToggle
+										colName="name"
+										order="normal"
+										handleUserClick={this.handleSortingClick}
+									/>
+								</th>
+								<th style={colDisplayStyle} width={colWidthArray[4]}>
+									Creation Date
+									<SortToggle
+										colName="creation_date"
+										order="normal"
+										handleUserClick={this.handleSortingClick}
+									/>
+								</th>
+								<th style={colDisplayStyle} width={colWidthArray[5]}>
+									Updated Date
+									<SortToggle
+										colName="updated_date"
+										order="normal"
+										handleUserClick={this.handleSortingClick}
+									/>
+								</th>
+								<th width={colWidthArray[6]}>Actions</th>
+							</tr>
+						</thead>
+						<tbody>{_rows}</tbody>
+					</table>
+				)
+			}
+		}
+	})
+>>>>>>> 6ccd15879... Minor updates
 
   var TabSystem = React.createClass({
     getInitialState: function() {

--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -279,6 +279,11 @@ class AssignmentsController < ApplicationController
     dd.deadline_type_id == DeadlineHelper::DEADLINE_TYPE_TEAM_FORMATION
   end
   
+  # checks if an assignment has a teammate review deadline associated
+  def teammate_review_deadline_allowed?(dd)
+    dd.deadline_type_id == DeadlineHelper::DEADLINE_TYPE_TEAMMATE_REVIEW
+  end
+  
   # sets an assignment's deadline name
   def update_nil_dd_deadline_name(due_date_all)
     due_date_all.each do |dd|
@@ -388,7 +393,7 @@ class AssignmentsController < ApplicationController
     @drop_topic_allowed = drop_topic_allowed?(dd)
     @signup_allowed = signup_allowed?(dd)
     @team_formation_allowed = team_formation_allowed?(dd)
-    @teammate_review_deadline_allowed = team_formation_allowed?(dd)
+    @teammate_review_deadline_allowed = teammate_review_deadline_allowed?(dd)
     # E2074 - Add teammate review deadline/assignment
     # Teammate review deadlines should only be allowed on assignments that allow
     # teams to be formed

--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -278,7 +278,7 @@ class AssignmentsController < ApplicationController
   def team_formation_allowed?(dd)
     dd.deadline_type_id == DeadlineHelper::DEADLINE_TYPE_TEAM_FORMATION
   end
-
+  
   # sets an assignment's deadline name
   def update_nil_dd_deadline_name(due_date_all)
     due_date_all.each do |dd|
@@ -363,6 +363,8 @@ class AssignmentsController < ApplicationController
     @drop_topic_allowed_checkbox = false
     @team_formation_allowed = false
     @team_formation_allowed_checkbox = false
+    @teammate_review_deadline_allowed = false
+    @teammate_review_deadline_allowed_checkbox = false # E2074
     @participants_count = @assignment_form.assignment.participants.size
     @teams_count = @assignment_form.assignment.teams.size
   end
@@ -386,6 +388,10 @@ class AssignmentsController < ApplicationController
     @drop_topic_allowed = drop_topic_allowed?(dd)
     @signup_allowed = signup_allowed?(dd)
     @team_formation_allowed = team_formation_allowed?(dd)
+    @teammate_review_deadline_allowed = team_formation_allowed?(dd)
+    # E2074 - Add teammate review deadline/assignment
+    # Teammate review deadlines should only be allowed on assignments that allow
+    # teams to be formed
   end
 
   # adjusts the time zone for a due date

--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -386,14 +386,14 @@ class AssignmentsController < ApplicationController
   end
 
   # gets the current settings of the current assignment
-  def update_due_date_nameurl(dd)
-    @due_date_nameurl_not_empty = due_date_nameurl_not_empty?(dd)
+  def update_due_date_nameurl
+    @due_date_nameurl_not_empty =  @due_date_all.any? { |d| due_date_nameurl_not_empty?(d) }
     @due_date_nameurl_not_empty_checkbox = @due_date_nameurl_not_empty
-    @metareview_allowed = meta_review_allowed?(dd)
-    @drop_topic_allowed = drop_topic_allowed?(dd)
-    @signup_allowed = signup_allowed?(dd)
-    @team_formation_allowed = team_formation_allowed?(dd)
-    @teammate_review_deadline_allowed = teammate_review_deadline_allowed?(dd)
+    @metareview_allowed = @due_date_all.any? { |d| meta_review_allowed?(d) }
+    @drop_topic_allowed = @due_date_all.any? { |d| drop_topic_allowed?(d) }
+    @signup_allowed = @due_date_all.any? { |d| signup_allowed?(d) }
+    @team_formation_allowed = @due_date_all.any? { |d| team_formation_allowed?(d) }
+    @teammate_review_deadline_allowed = @due_date_all.any? { |d| teammate_review_deadline_allowed?(d) } 
     # E2074 - Add teammate review deadline/assignment
     # Teammate review deadlines should only be allowed on assignments that allow
     # teams to be formed
@@ -407,7 +407,7 @@ class AssignmentsController < ApplicationController
   # ensures due dates ahave a name, description and at least either meta reviews, topic drops, signups, or team formations
   def validate_due_date
     @due_date_nameurl_not_empty && @due_date_nameurl_not_empty_checkbox &&
-      (@metareview_allowed || @drop_topic_allowed || @signup_allowed || @team_formation_allowed)
+      (@metareview_allowed || @drop_topic_allowed || @signup_allowed || @team_formation_allowed || @teammate_review_deadline_allowed)
   end
 
   # checks if each questionnaire in an assignment is used
@@ -443,12 +443,19 @@ class AssignmentsController < ApplicationController
   end
 
   # update values for an assignment's due date when editing
+  # this method doesn't work, it overwrites all the state values on each iteration
+  # the method update_due_date_nameurl has been fixed to account for this
   def update_due_date
+    # @due_date_all.each do |dd|
+    #   update_due_date_nameurl(dd)
+    #   adjust_due_date_for_timezone(dd)
+    #   break if validate_due_date
+    # end
     @due_date_all.each do |dd|
-      update_due_date_nameurl(dd)
       adjust_due_date_for_timezone(dd)
       break if validate_due_date
     end
+    update_due_date_nameurl # only calling this method once now
   end
 
   # update the current assignment's badges when editing

--- a/app/controllers/sign_up_sheet_controller.rb
+++ b/app/controllers/sign_up_sheet_controller.rb
@@ -39,9 +39,9 @@ class SignUpSheetController < ApplicationController
   # Prepares the form for adding a new topic. Used in conjunction with create
   def new
     @id = params[:id]
-    @signup_topic = SignUpTopic.new
-    @signup_topic.assignment = Assignment.find(params[:id])
-    @topic = @signup_topic
+    @sign_up_topic = SignUpTopic.new
+    @sign_up_topic.assignment = Assignment.find(params[:id])
+    @topic = @sign_up_topic
   end
 
   # This method is used to create signup topics
@@ -129,8 +129,8 @@ class SignUpSheetController < ApplicationController
   def load_add_signup_topics(assignment_id)
     @id = assignment_id
     @sign_up_topics = SignUpTopic.where('assignment_id = ?', assignment_id)
-    @slots_filled = SignUpTopic.filled_slots(assignment_id)
-    @slots_waitlisted = SignUpTopic.find_waitlisted_slots(assignment_id)
+    @slots_filled = SignUpTopic.find_slots_filled(assignment_id)
+    @slots_waitlisted = SignUpTopic.find_slots_waitlisted(assignment_id)
 
     @assignment = Assignment.find(assignment_id)
     # ACS Removed the if condition (and corresponding else) which differentiate assignments as team and individual assignments
@@ -141,12 +141,12 @@ class SignUpSheetController < ApplicationController
   end
 
   def set_values_for_new_topic
-    @signup_topic = SignUpTopic.new
-    @signup_topic.topic_identifier = params[:topic][:topic_identifier]
-    @signup_topic.topic_name = params[:topic][:topic_name]
-    @signup_topic.max_choosers = params[:topic][:max_choosers]
-    @signup_topic.category = params[:topic][:category]
-    @signup_topic.assignment_id = params[:id]
+    @sign_up_topic = SignUpTopic.new
+    @sign_up_topic.topic_identifier = params[:topic][:topic_identifier]
+    @sign_up_topic.topic_name = params[:topic][:topic_name]
+    @sign_up_topic.max_choosers = params[:topic][:max_choosers]
+    @sign_up_topic.category = params[:topic][:category]
+    @sign_up_topic.assignment_id = params[:id]
     @assignment = Assignment.find(params[:id])
   end
 
@@ -167,8 +167,8 @@ class SignUpSheetController < ApplicationController
   def list
     @participant = AssignmentParticipant.find(params[:id].to_i)
     @assignment = @participant.assignment
-    @slots_filled = SignUpTopic.filled_slots(@assignment.id)
-    @slots_waitlisted = SignUpTopic.find_waitlisted_slots(@assignment.id)
+    @slots_filled = SignUpTopic.find_slots_filled(@assignment.id)
+    @slots_waitlisted = SignUpTopic.find_slots_waitlisted(@assignment.id)
     @show_actions = true
     @priority = 0
     @sign_up_topics = SignUpTopic.where(assignment_id: @assignment.id, private_to: nil)
@@ -180,8 +180,8 @@ class SignUpSheetController < ApplicationController
       @bids = team_id.nil? ? [] : Bid.where(team_id: team_id).order(:priority)
       signed_up_topics = []
       @bids.each do |bid|
-        signup_topic = SignUpTopic.find_by(id: bid.topic_id)
-        signed_up_topics << signup_topic if signup_topic
+        sign_up_topic = SignUpTopic.find_by(id: bid.topic_id)
+        signed_up_topics << sign_up_topic if sign_up_topic
       end
       signed_up_topics &= @sign_up_topics
       @sign_up_topics -= signed_up_topics
@@ -420,15 +420,15 @@ class SignUpSheetController < ApplicationController
 
   def setup_new_topic
     set_values_for_new_topic
-    @signup_topic.micropayment = params[:topic][:micropayment] if @assignment.microtask?
+    @sign_up_topic.micropayment = params[:topic][:micropayment] if @assignment.microtask?
     if @assignment.staggered_deadline?
       topic_set = []
-      topic = @signup_topic.id
+      topic = @sign_up_topic.id
     end
-    if @signup_topic.save
-      undo_link "The topic: \"#{@signup_topic.topic_name}\" has been created successfully. "
+    if @sign_up_topic.save
+      undo_link "The topic: \"#{@sign_up_topic.topic_name}\" has been created successfully. "
       # Akshay - correctly changing the redirection url to topics tab in edit assignment view.
-      redirect_to edit_assignment_path(@signup_topic.assignment_id) + "#tabs-2"
+      redirect_to edit_assignment_path(@sign_up_topic.assignment_id) + "#tabs-2"
     else
       render action: 'new', id: params[:id]
     end

--- a/app/controllers/student_task_controller.rb
+++ b/app/controllers/student_task_controller.rb
@@ -56,6 +56,8 @@ class StudentTaskController < ApplicationController
     @topic_id = SignedUpTeam.topic_id(@assignment.id, @participant.user_id)
     @topics = SignUpTopic.where(assignment_id: @assignment.id)
     @use_bookmark = @assignment.use_bookmark
+    # E 2074 - Hide "Your Work" and "Others' Work" tab on assignments with zero rounds of reviews/submissions
+    @has_submissions = action_allowed? ? @assignment.rounds_of_reviews > 0 : true
     # Timeline feature
     @timeline_list = StudentTask.get_timeline_data(@assignment, @participant, @team)
   end

--- a/app/controllers/student_teams_controller.rb
+++ b/app/controllers/student_teams_controller.rb
@@ -40,19 +40,24 @@ class StudentTeamsController < ApplicationController
 
     @send_invs = Invitation.where from_id: student.user.id, assignment_id: student.assignment.id
     @received_invs = Invitation.where to_id: student.user.id, assignment_id: student.assignment.id, reply_status: 'W'
+    
     # Get the current due dates
-    @student.assignment.due_dates.each do |due_date|
-      if due_date.due_at > Time.now
-        @current_due_date = due_date
-        break
-      end
-    end
-
+    # @student.assignment.due_dates.each do |due_date|
+    #   if due_date.due_at > Time.now
+    #     @current_due_date = due_date
+    #     break
+    #   end
+    # end
+    # This above is no longer needed as there is a dedicated field for teammate deadline reviews
+    # It may be wise to keep it though, in the case that no due date is assigned, as this basically
+    # is preventing the student from submitting a peer review after all of the due dates for the current assignment have passed
     current_team = @student.team
 
     @users_on_waiting_list = (SignUpTopic.find(current_team.topic).users_on_waiting_list if @student.assignment.topics? && current_team && current_team.topic)
-
-    @teammate_review_allowed = true if @student.assignment.find_current_stage == 'Finished' || @current_due_date && (@current_due_date.teammate_review_allowed_id == 3 || @current_due_date.teammate_review_allowed_id == 2) # late(2) or yes(3)
+    
+    # E2074 - teammate review deadline
+    @teammate_review_deadline = @student.assignment.due_dates.find_by(deadline_type_id: DeadlineType.find_by(name: "teammate_review"))
+    @teammate_review_allowed = @teammate_review_deadline ? Time.now < @teammate_review_deadline.due_at : true
   end
 
   def create

--- a/app/controllers/tree_display_controller.rb
+++ b/app/controllers/tree_display_controller.rb
@@ -25,17 +25,17 @@ class TreeDisplayController < ApplicationController
     @node_type = params[:nodeType]
   end
 
-  def goto_questionnaires; goto_controller('Questionnaires') end
-  def goto_review_rubrics; goto_controller('Review') end
-  def goto_metareview_rubrics; goto_controller('Metareview') end
-  def goto_teammatereview_rubrics; goto_controller('Teammate Review') end
-  def goto_author_feedbacks; goto_controller('Author Feedback') end
-  def goto_global_survey; goto_controller('Global Survey') end
-  def goto_surveys; goto_controller('Assignment Survey') end
-  def goto_course_surveys; goto_controller('Course Survey') end
-  def goto_courses; goto_controller('Courses') end
-  def goto_bookmarkrating_rubrics; goto_controller('Bookmarkrating') end
-  def goto_assignments; goto_controller('Assignments') end
+  def goto_questionnaires; goto_controller('Questionnaires','3') end
+  def goto_review_rubrics; goto_controller('Review','3') end
+  def goto_metareview_rubrics; goto_controller('Metareview','3') end
+  def goto_teammatereview_rubrics; goto_controller('Teammate Review','3') end
+  def goto_author_feedbacks; goto_controller('Author Feedback','3') end
+  def goto_global_survey; goto_controller('Global Survey','3') end
+  def goto_surveys; goto_controller('Assignment Survey','3') end
+  def goto_course_surveys; goto_controller('Course Survey','3') end
+  def goto_courses; goto_controller('Courses','1') end
+  def goto_bookmarkrating_rubrics; goto_controller('Bookmarkrating','3') end
+  def goto_assignments; goto_controller('Assignments','2') end
 
   # Redirects to proper page if user is not an instructor or TA.
   def list

--- a/app/helpers/assignment_helper.rb
+++ b/app/helpers/assignment_helper.rb
@@ -109,7 +109,7 @@ module AssignmentHelper
     else
       @reviewer = AssignmentParticipant.find_by(user_id: user_id, parent_id: assignment_id)
       if @reviewer
-        @teammates.all? { |t| TeammateReviewResponseMap.where(reviewer_id: @reviewer.id, reviewee_id: t.id).exists? }
+        @teammates.all? { |t| TeammateReviewResponseMap.where(reviewer_id: @reviewer.id, reviewee_id: t.id).exists? and TeammateReviewResponseMap.where(reviewer_id: @reviewer.id, reviewee_id: t.id).first.response.exists? }
       end
     end
   end

--- a/app/helpers/assignment_helper.rb
+++ b/app/helpers/assignment_helper.rb
@@ -101,17 +101,9 @@ module AssignmentHelper
     assignment.find_due_dates("teammate_review").count > 0
   end
   
-  def remove_teammate_review_deadline
-    @dd = AssignmentDueDate.find_by(deadline_type_id: DeadlineHelper::DEADLINE_TYPE_TEAMMATE_REVIEW)
-    if @dd
-      @dd.destroy
-    end
-  end
-
   # determines if user completed all teammate reviews for a particular assignment
   def user_completed_teammate_reviews?(user_id, assignment_id)
     @teammates = Team.find_team_for_assignment_and_user(assignment_id, user_id).first.participants.select { |p| p.user_id != user_id }
-    puts @teammates, "\n\n\n\n\n\n hhrehhee \n\n\n\n\n", @teammates.count
     if @teammates.count < 1
       true
     else
@@ -121,5 +113,4 @@ module AssignmentHelper
       end
     end
   end
-
 end

--- a/app/helpers/assignment_helper.rb
+++ b/app/helpers/assignment_helper.rb
@@ -94,5 +94,32 @@ module AssignmentHelper
       '#0984e3' # submission grade is not assigned yet.
     end
   end
+  
+  # determines if the user has teammate reviews to finish or not according to the 
+  # 
+  def user_has_teammate_reviews?(assignment)
+    assignment.find_due_dates("teammate_review").count > 0
+  end
+  
+  def remove_teammate_review_deadline
+    @dd = AssignmentDueDate.find_by(deadline_type_id: DeadlineHelper::DEADLINE_TYPE_TEAMMATE_REVIEW)
+    if @dd
+      @dd.destroy
+    end
+  end
+
+  # determines if user completed all teammate reviews for a particular assignment
+  def user_completed_teammate_reviews?(user_id, assignment_id)
+    @teammates = Team.find_team_for_assignment_and_user(assignment_id, user_id).first.participants.select { |p| p.user_id != user_id }
+    puts @teammates, "\n\n\n\n\n\n hhrehhee \n\n\n\n\n", @teammates.count
+    if @teammates.count < 1
+      true
+    else
+      @reviewer = AssignmentParticipant.find_by(user_id: user_id, parent_id: assignment_id)
+      if @reviewer
+        @teammates.all? { |t| TeammateReviewResponseMap.where(reviewer_id: @reviewer.id, reviewee_id: t.id).exists? }
+      end
+    end
+  end
 
 end

--- a/app/helpers/deadline_helper.rb
+++ b/app/helpers/deadline_helper.rb
@@ -7,6 +7,7 @@ module DeadlineHelper
   DEADLINE_TYPE_DROP_TOPIC = 6
   DEADLINE_TYPE_SIGN_UP = 7
   DEADLINE_TYPE_TEAM_FORMATION = 8
+  DEADLINE_TYPE_TEAMMATE_REVIEW = DeadlineType.find_by(name: 'teammate_review').id
 
   # Creates a new topic deadline for topic specified by topic_id.
   # The deadline itself is specified by due_date object which contains several values which specify

--- a/app/helpers/import_topics_helper.rb
+++ b/app/helpers/import_topics_helper.rb
@@ -36,9 +36,9 @@ module ImportTopicsHelper
   # end
 
   def self.create_new_sign_up_topic(attributes, session)
-    signup_topic = SignUpTopic.new(attributes)
-    signup_topic.assignment_id = session[:assignment_id]
-    signup_topic.save
+    sign_up_topic = SignUpTopic.new(attributes)
+    sign_up_topic.assignment_id = session[:assignment_id]
+    sign_up_topic.save
     # sign_up_topic
   end
 end

--- a/app/models/deadline_right.rb
+++ b/app/models/deadline_right.rb
@@ -28,6 +28,11 @@ class DeadlineRight < ActiveRecord::Base
       'can_review' => OK,
       'review_of_review_allowed' => NO
     },
+    'teammate_review' => {
+      'submission_allowed' => NO,
+      'can_review' => OK,
+      'review_of_review_allowed' => NO 
+    },
     'metareview' => {
       'submission_allowed' => NO,
       'can_review' => NO,

--- a/app/models/instructor.rb
+++ b/app/models/instructor.rb
@@ -47,7 +47,7 @@ class Instructor < User
     participants.each do |p_s|
       next if p_s.empty?
       p_s.each do |p|
-        user_list << p.user if user.role.all_privileges_of(p.user.role)
+        user_list << p.user if user.role.hasAllPrivilegesOf(p.user.role)
       end
     end
     user_list

--- a/app/models/sign_up_topic.rb
+++ b/app/models/sign_up_topic.rb
@@ -34,17 +34,37 @@ class SignUpTopic < ActiveRecord::Base
     end
   end
 
-  def self.filled_slots(assignment_id)
+  # The old method is commented out below.
+  #
+  # def self.import(columns, session, _id = nil)
+  #   if columns.length < 3
+  #     raise ArgumentError, "The CSV File expects the format: Topic identifier, Topic name, Max choosers, Topic Category (optional), Topic Description (Optional), Topic Link (optional)."
+  #   end
+  #
+  #   topic = SignUpTopic.where(topic_name: columns[1], assignment_id: session[:assignment_id]).first
+  #
+  #   if topic.nil?
+  #     attributes = ImportTopicsHelper.define_attributes(columns)
+  #     ImportTopicsHelper.create_new_sign_up_topic(attributes, session)
+  #   else
+  #     topic.max_choosers = columns[2]
+  #     topic.topic_identifier = columns[0]
+  #     # topic.assignment_id = session[:assignment_id]
+  #     topic.save
+  #   end
+  # end
+
+  def self.find_slots_filled(assignment_id)
     # SignUpTopic.find_by_sql("SELECT topic_id as topic_id, COUNT(t.max_choosers) as count FROM sign_up_topics t JOIN signed_up_teams u ON t.id = u.topic_id WHERE t.assignment_id =" + assignment_id+  " and u.is_waitlisted = false GROUP BY t.id")
     SignUpTopic.find_by_sql(["SELECT topic_id as topic_id, COUNT(t.max_choosers) as count FROM sign_up_topics t JOIN signed_up_teams u ON t.id = u.topic_id WHERE t.assignment_id = ? and u.is_waitlisted = false GROUP BY t.id", assignment_id])
   end
 
-  def self.find_waitlisted_slots(assignment_id)
+  def self.find_slots_waitlisted(assignment_id)
     # SignUpTopic.find_by_sql("SELECT topic_id as topic_id, COUNT(t.max_choosers) as count FROM sign_up_topics t JOIN signed_up_teams u ON t.id = u.topic_id WHERE t.assignment_id =" + assignment_id +  " and u.is_waitlisted = true GROUP BY t.id")
     SignUpTopic.find_by_sql(["SELECT topic_id as topic_id, COUNT(t.max_choosers) as count FROM sign_up_topics t JOIN signed_up_teams u ON t.id = u.topic_id WHERE t.assignment_id = ? and u.is_waitlisted = true GROUP BY t.id", assignment_id])
   end
 
-  def self.waitlisted_topics(assignment_id, team_id)
+  def self.find_waitlisted_topics(assignment_id, team_id)
     # SignedUpTeam.find_by_sql("SELECT u.id FROM sign_up_topics t, signed_up_teams u WHERE t.id = u.topic_id and u.is_waitlisted = true and t.assignment_id = " + assignment_id.to_s + " and u.team_id = " + team_id.to_s)
     SignedUpTeam.find_by_sql(["SELECT u.id FROM sign_up_topics t, signed_up_teams u WHERE t.id = u.topic_id and u.is_waitlisted = true and t.assignment_id = ? and u.team_id = ?", assignment_id.to_s, team_id.to_s])
   end
@@ -65,7 +85,7 @@ class SignUpTopic < ActiveRecord::Base
   end
 
   def self.reassign_topic(session_user_id, assignment_id, topic_id)
-    
+    # find whether assignment is team assignment
     assignment = Assignment.find(assignment_id)
 
     # making sure that the drop date deadline hasn't passed

--- a/app/models/ta.rb
+++ b/app/models/ta.rb
@@ -108,7 +108,7 @@ class Ta < User
     participants.each do |p_s|
       next if p_s.empty?
       p_s.each do |p|
-        user_list << p.user if user.role.all_privileges_of(p.user.role)
+        user_list << p.user if user.role.hasAllPrivilegesOf(p.user.role)
       end
     end
     user_list

--- a/app/models/waitlist.rb
+++ b/app/models/waitlist.rb
@@ -1,6 +1,6 @@
 class Waitlist < ActiveRecord::Base
   def self.cancel_all_waitlists(team_id, assignment_id)
-    waitlisted_topics = SignUpTopic.waitlisted_topics(assignment_id, team_id)
+    waitlisted_topics = SignUpTopic.find_waitlisted_topics(assignment_id, team_id)
     unless waitlisted_topics.nil?
       for waitlisted_topic in waitlisted_topics
         entry = SignedUpTeam.find(waitlisted_topic.id)

--- a/app/views/assignments/edit/_due_dates.html.erb
+++ b/app/views/assignments/edit/_due_dates.html.erb
@@ -515,18 +515,19 @@ function addDaysOrMonth(mul, type) {
     <%= label_tag('dropTopicAllowed', 'Use drop topic deadline') %><br/>
 <% end %>
 
+
+<span id='team_formation_due_date_checkbox' <%= 'hidden' if @assignment_form.assignment.max_team_size == 1%> 
+    <input name="teamFormationAllowed" type="hidden" value="false" />
+    <%= check_box_tag('teamFormationAllowed', 'true', @team_formation_allowed,:onclick=>"removeOrAddTeamFormation()" ) %>
+    <%= label_tag('teamFormationAllowed', 'Use team formation deadline') %><br/>
+</span>
+
 <%# E2074 - Add teammate review deadline %>
 <span id='teammate_review_deadline_checkbox' <%= 'hidden' if @assignment_form.assignment.max_team_size == 1 %> 
     <%# ** hide if this if no more than 1 person can be on a team %>
     <input name="teammateReviewDeadlineAllowed" type="hidden" value="false" />
     <%= check_box_tag('teammateReviewDeadlineAllowed', 'true', @teammate_review_deadline_allowed, :onclick=>"toggleTeammateReview()" ) %>
     <%= label_tag('teammateReviewDeadlineAllowed', 'Use teammate review deadline') %><br/>
-</span>
-
-<span id='team_formation_due_date_checkbox' <%= 'hidden' if @assignment_form.assignment.max_team_size == 1%> 
-    <input name="teamFormationAllowed" type="hidden" value="false" />
-    <%= check_box_tag('teamFormationAllowed', 'true', @team_formation_allowed,:onclick=>"removeOrAddTeamFormation()" ) %>
-    <%= label_tag('teamFormationAllowed', 'Use team formation deadline') %><br/>
 </span>
 
 <input name="metareviewAllowed" type="hidden" value="false" />

--- a/app/views/assignments/edit/_due_dates.html.erb
+++ b/app/views/assignments/edit/_due_dates.html.erb
@@ -509,7 +509,7 @@ function addDaysOrMonth(mul, type) {
 <% end %>
 
 <%# E2074 - Add teammate review deadline %>
-<span id='teammate_review_deadline_checkbox' <%= 'hidden' if @assignment_form.assignment.max_team_size < 2%> 
+<span id='teammate_review_deadline_checkbox' <%= 'hidden' unless @assignment_form.assignment.max_team_size == 1 %> 
     <%# ** hide if this if no more than 1 person can be on a team %>
     <input name="teammateReviewDeadlineAllowed" type="hidden" value="false" />
     <%= check_box_tag('teammateReviewDeadlineAllowed', 'true', @teammate_review_deadline_allowed, :onclick=>"toggleTeammateReview()" ) %>

--- a/app/views/assignments/edit/_due_dates.html.erb
+++ b/app/views/assignments/edit/_due_dates.html.erb
@@ -420,19 +420,19 @@
         }
         
         
-        /** E2074 Add teammate review deadline, toggle made more sense */
+        /** E2074 Add teammate review deadline, toggle made more sense  */
         // document.getElementById('#teammate_review_deadline_checkbox').onClick() {
+            // 
             
         // }
         function toggleTeammateReview(){
             if(document.getElementById("teammate_review")) {
                 removeDueDateTableElement('teammate_review', 0);
-                <% remove_teammate_review_deadline() %>
                 }
              else 
                  addDueDateTableElement(<%= @due_date_nameurl_not_empty==nil ? false:@due_date_nameurl_not_empty %>, 'teammate_review', 0, <%= due_date(@assignment_form.assignment, 'teammate_review').to_json.html_safe %>);
-            <%@teammate_review_deadline_allowed_checkbox=true%>
 
+            <%@teammate_review_deadline_allowed_checkbox=true%>
 
         }
 function removeOrAddMetareview() {

--- a/app/views/assignments/edit/_due_dates.html.erb
+++ b/app/views/assignments/edit/_due_dates.html.erb
@@ -260,8 +260,9 @@
 
         var submissions_count = <%= @num_submissions_round %>;
         var reviews_count = <%= @num_reviews_round %>;
-        if (new_round_count <= 0) {
-            alert('ERROR: number of rounds of review should be greater than 0');
+        // E2074 Add teammate review deadline
+        if (new_round_count < 0) {
+            alert('ERROR: number of rounds of review should be greater than or equal to 0');
             return
         }
 
@@ -367,9 +368,6 @@
             due_date_name_column.removeAttribute("style");
             due_date_url_column.removeAttribute("style");
         }
-        else{
-            return;
-        }
     }
 
         function removeOrAddMetareview(){
@@ -418,6 +416,16 @@
                 addDueDateTableElement(<%= @due_date_nameurl_not_empty==nil ? false:@due_date_nameurl_not_empty %>, 'team_formation', 0, <%= due_date(@assignment_form.assignment, 'team_formation').to_json.html_safe %>);
 
             <%@team_formation_allowed_checkbox=true%>
+
+        }
+        /** E2074 Add teammate review deadline, toggle made more sense */
+        function toggleTeammateReview(){
+            if(document.getElementById("teammate_review"))
+                removeDueDateTableElement('teammate_review', 0);
+             else
+                 addDueDateTableElement(<%= @due_date_nameurl_not_empty==nil ? false:@due_date_nameurl_not_empty %>, 'teammate_review', 0, <%= due_date(@assignment_form.assignment, 'teammate_review').to_json.html_safe %>);
+
+            <%@teammate_review_deadline_allowed_checkbox=true%>
 
         }
 function removeOrAddMetareview() {
@@ -500,6 +508,14 @@ function addDaysOrMonth(mul, type) {
     <%= label_tag('dropTopicAllowed', 'Use drop topic deadline') %><br/>
 <% end %>
 
+<%# E2074 - Add teammate review deadline %>
+<span id='teammate_review_deadline_checkbox' <%= 'hidden' if @assignment_form.assignment.max_team_size < 2%> 
+    <%# ** hide if this if no more than 1 person can be on a team %>
+    <input name="teammateReviewDeadlineAllowed" type="hidden" value="false" />
+    <%= check_box_tag('teammateReviewDeadlineAllowed', 'true', @teammate_review_deadline_allowed,:onclick=>"toggleTeammateReview()" ) %>
+    <%= label_tag('teammateReviewDeadlineAllowed', 'Use teammate review deadline') %><br/>
+</span>
+
 <span id='team_formation_due_date_checkbox' <%= 'hidden' if @assignment_form.assignment.max_team_size == 1%> 
     <input name="teamFormationAllowed" type="hidden" value="false" />
     <%= check_box_tag('teamFormationAllowed', 'true', @team_formation_allowed,:onclick=>"removeOrAddTeamFormation()" ) %>
@@ -544,6 +560,12 @@ function addDaysOrMonth(mul, type) {
         <% if @assignment_form.assignment.max_team_size > 1 && due_date(@assignment_form.assignment, 'team_formation').due_at %>
             addDueDateTableElement(<%= @due_date_nameurl_not_empty==nil ? false:@due_date_nameurl_not_empty %>,'team_formation', 0,<%= due_date(@assignment_form.assignment, 'team_formation').to_json.html_safe %>);
         <% end %>
+        
+        /** E2074 Add teamate review deadline if max_team_size > 1 if there is a deadline already set (technically only need the second check but the others are making the double check anyways) */
+        <% if @assignment_form.assignment.max_team_size > 1 && due_date(@assignment_form.assignment, 'teammate_review').due_at %>
+            addDueDateTableElement(<%= @due_date_nameurl_not_empty==nil ? false:@due_date_nameurl_not_empty %>,'teammate_review', 0,<%= due_date(@assignment_form.assignment, 'teammate_review').to_json.html_safe %>);
+        <% end %>
+        
         <% if @assignment_form.assignment.topics? %>
             <% if due_date(@assignment_form.assignment, 'signup').due_at %>
                 addDueDateTableElement(<%= @due_date_nameurl_not_empty==nil ? false:@due_date_nameurl_not_empty %>,'signup', 0,<%= due_date(@assignment_form.assignment, 'signup').to_json.html_safe %>);
@@ -556,6 +578,7 @@ function addDaysOrMonth(mul, type) {
         addDueDateTableElement(<%= @due_date_nameurl_not_empty==nil ? false:@due_date_nameurl_not_empty %>,'submission', <%=i%>, <%= due_date(@assignment_form.assignment, 'submission', i-1).to_json.html_safe %>); // or use questionnaire_options(@assignment, nil).to_json
         addDueDateTableElement(<%= @due_date_nameurl_not_empty==nil ? false:@due_date_nameurl_not_empty %>,'review', <%=i%>, <%= due_date(@assignment_form.assignment, 'review', i-1).to_json.html_safe %>) ;
         <% end %>
+        // Assignments with zero rounds of review will show no submission or review links/rows in the due dates table
         <% if @metareview_allowed %>
         addDueDateTableElement(<%= @due_date_nameurl_not_empty==nil ? false:@due_date_nameurl_not_empty %>,'metareview', 0, <%= due_date(@assignment_form.assignment, 'metareview').to_json.html_safe %>);
         <%end %>

--- a/app/views/assignments/edit/_due_dates.html.erb
+++ b/app/views/assignments/edit/_due_dates.html.erb
@@ -509,7 +509,7 @@ function addDaysOrMonth(mul, type) {
 <% end %>
 
 <%# E2074 - Add teammate review deadline %>
-<span id='teammate_review_deadline_checkbox' <%= 'hidden' unless @assignment_form.assignment.max_team_size == 1 %> 
+<span id='teammate_review_deadline_checkbox' <%= 'hidden' if @assignment_form.assignment.max_team_size == 1 %> 
     <%# ** hide if this if no more than 1 person can be on a team %>
     <input name="teammateReviewDeadlineAllowed" type="hidden" value="false" />
     <%= check_box_tag('teammateReviewDeadlineAllowed', 'true', @teammate_review_deadline_allowed, :onclick=>"toggleTeammateReview()" ) %>

--- a/app/views/assignments/edit/_due_dates.html.erb
+++ b/app/views/assignments/edit/_due_dates.html.erb
@@ -418,14 +418,21 @@
             <%@team_formation_allowed_checkbox=true%>
 
         }
+        
+        
         /** E2074 Add teammate review deadline, toggle made more sense */
+        // document.getElementById('#teammate_review_deadline_checkbox').onClick() {
+            
+        // }
         function toggleTeammateReview(){
-            if(document.getElementById("teammate_review"))
+            if(document.getElementById("teammate_review")) {
                 removeDueDateTableElement('teammate_review', 0);
-             else
+                <% remove_teammate_review_deadline() %>
+                }
+             else 
                  addDueDateTableElement(<%= @due_date_nameurl_not_empty==nil ? false:@due_date_nameurl_not_empty %>, 'teammate_review', 0, <%= due_date(@assignment_form.assignment, 'teammate_review').to_json.html_safe %>);
-
             <%@teammate_review_deadline_allowed_checkbox=true%>
+
 
         }
 function removeOrAddMetareview() {

--- a/app/views/assignments/edit/_due_dates.html.erb
+++ b/app/views/assignments/edit/_due_dates.html.erb
@@ -512,7 +512,7 @@ function addDaysOrMonth(mul, type) {
 <span id='teammate_review_deadline_checkbox' <%= 'hidden' if @assignment_form.assignment.max_team_size < 2%> 
     <%# ** hide if this if no more than 1 person can be on a team %>
     <input name="teammateReviewDeadlineAllowed" type="hidden" value="false" />
-    <%= check_box_tag('teammateReviewDeadlineAllowed', 'true', @teammate_review_deadline_allowed,:onclick=>"toggleTeammateReview()" ) %>
+    <%= check_box_tag('teammateReviewDeadlineAllowed', 'true', @teammate_review_deadline_allowed, :onclick=>"toggleTeammateReview()" ) %>
     <%= label_tag('teammateReviewDeadlineAllowed', 'Use teammate review deadline') %><br/>
 </span>
 

--- a/app/views/assignments/edit/_general.html.erb
+++ b/app/views/assignments/edit/_general.html.erb
@@ -269,7 +269,8 @@ function microtaskChanged() {
         var team_count_field = jQuery('#assignment_team_count_field');
         var teammate_reviews_field = jQuery('#assignment_show_teammate_reviews');
         var team_formation_due_date_checkbox = jQuery('#team_formation_due_date_checkbox')
-
+        var teammate_review_deadline_checkbox = jQuery('#teammate_review_deadline_checkbox')
+        
         jQuery("#questionnaire_table_TeammateReviewQuestionnaire").remove()
         if (checkbox.is(':checked')) {
             team_count_field.removeAttr('hidden');

--- a/app/views/assignments/edit/_general.html.erb
+++ b/app/views/assignments/edit/_general.html.erb
@@ -274,6 +274,8 @@ function microtaskChanged() {
         if (checkbox.is(':checked')) {
             team_count_field.removeAttr('hidden');
             team_formation_due_date_checkbox.removeAttr('hidden')
+            teammate_review_deadline_checkbox.removeAttr('hidden')
+            /** remove hidden attribute on update */
             jQuery('#assignment_form_assignment_max_team_size').val('2');
             teammate_reviews_field.removeAttr('hidden');
             addDueDateTableElement(<%= @due_date_nameurl_not_empty==nil ? false:@due_date_nameurl_not_empty %>,'team_formation', 0,<%= due_date(@assignment_form.assignment, 'team_formation').to_json.html_safe %>);
@@ -292,6 +294,7 @@ function microtaskChanged() {
               team_count_field.attr('hidden', true);
               team_formation_due_date_checkbox.attr('hidden', true)
               teammate_reviews_field.attr('hidden', true);
+              teammate_review_deadline_checkbox.attr('hidden', true)
               document.getElementById('assignment_form_assignment_max_team_size').value = '1';
               removeDueDateTableElement('team_formation', 0);
 

--- a/app/views/assignments/list_submissions.html.erb
+++ b/app/views/assignments/list_submissions.html.erb
@@ -57,6 +57,10 @@
         <!--Team member(s) / Participant name-->
           <td>
               <% users_for_curr_team.each do |user| %>
+                  <!-- E 2074 - Red dot placed before users who didnt complete teammate reviews (if applicable) -->
+                  <% if user_has_teammate_reviews?(@assignment) and not user_completed_teammate_reviews?(user.id, @assignment.id) %>
+                  <span style="height: 1.5rem; width: 1.5rem; background-color: red; border-radius: 50%; display: inline-block;"></span>
+                  <% end %>
                   <%= link_to user.name(session[:ip]), impersonate_impersonate_path(:user => {:name => user.name(session[:ip])}), :method => :post %>
                   (<%= user.fullname(session[:ip])%>)<br>
               <% end %>

--- a/app/views/assignments/list_submissions.html.erb
+++ b/app/views/assignments/list_submissions.html.erb
@@ -59,7 +59,8 @@
               <% users_for_curr_team.each do |user| %>
                   <!-- E 2074 - Red dot placed before users who didnt complete teammate reviews (if applicable) -->
                   <% if user_has_teammate_reviews?(@assignment) and not user_completed_teammate_reviews?(user.id, @assignment.id) %>
-                  <span style="height: 1.5rem; width: 1.5rem; background-color: red; border-radius: 50%; display: inline-block;"></span>
+                  <span id="red_cirle" style="height: 1.5rem; width: 1.5rem; background-color: red; border-radius: 50%; display: inline-block;"></span>
+                  <% @hide_circle=(user_has_teammate_reviews?(@assignment) and not user_completed_teammate_reviews?(user.id, @assignment.id)) %>
                   <% end %>
                   <%= link_to user.name(session[:ip]), impersonate_impersonate_path(:user => {:name => user.name(session[:ip])}), :method => :post %>
                   (<%= user.fullname(session[:ip])%>)<br>
@@ -92,4 +93,7 @@
     <% end %>
   </table>
   <p> **In "Team name" column, text in <i style = "color:#0984e3">blue</i> indicates that the submission grade is not assigned; text in <i style = "color: #cd6133">brown</i> indicates that the submission grade has been assigned.</p>
+  <% if @hide_circle%>
+    <p> **In "Team Members" column, the circle colored <i style = "color:red">red</i> indicates that the team member has not finished all of their required teammate reviews. </p>
+  <% end %>
 </div>

--- a/app/views/assignments/new.html.erb
+++ b/app/views/assignments/new.html.erb
@@ -71,6 +71,15 @@
                 method: frm.attr('method'),
                 data: frm.serialize(),
               })
+              /** add update on change of tabs on create assignment page */
+              jQuery.ajax({
+                  url: "/assignments/instant_flash",
+                  method: "get",
+                  data: "",
+                  success: function(data, textStatus, xhr){
+                      jQuery("#application-flash-div").html(data);
+                  },
+              })
             } else {
               event.preventDefault();
             }

--- a/app/views/sign_up_sheet/_add_signup_topics.html.erb
+++ b/app/views/sign_up_sheet/_add_signup_topics.html.erb
@@ -4,8 +4,8 @@
 <% end %>
 
 <% @sign_up_topics = SignUpTopic.where(['assignment_id = ?', @assignment.id]) %>
-<% @slots_filled = SignUpTopic.filled_slots(@assignment.id)  %>
-<% @slots_waitlisted = SignUpTopic.find_waitlisted_slots(@assignment.id) %>
+<% @slots_filled = SignUpTopic.find_slots_filled(@assignment.id)  %>
+<% @slots_waitlisted = SignUpTopic.find_slots_waitlisted(@assignment.id) %>
 <% @participants = SignedUpTeam.find_team_participants(@assignment.id, session[:ip])  %>
 
 <a id="teamsAndMembers" onclick="showHideTeamAndMembers(<%= @sign_up_topics.size%>)">Hide all teams</a>

--- a/app/views/sign_up_sheet/_add_signup_topics_staggered.html.erb
+++ b/app/views/sign_up_sheet/_add_signup_topics_staggered.html.erb
@@ -1,7 +1,7 @@
 <% @assignment = Assignment.find(params[:id]) %>
 <% @sign_up_topics = SignUpTopic.where(['assignment_id = ?', @assignment.id]) %>
-<% @slots_filled = SignUpTopic.filled_slots(@assignment.id)  %>
-<% @slots_waitlisted = SignUpTopic.find_waitlisted_slots(@assignment.id) %>
+<% @slots_filled = SignUpTopic.find_slots_filled(@assignment.id)  %>
+<% @slots_waitlisted = SignUpTopic.find_slots_waitlisted(@assignment.id) %>
 <% @participants = SignedUpTeam.find_team_participants(@assignment.id, session[:ip])  %>
 <!--Zhewei: the reason why we(E1524) put an empty form_tag is because these reasons:-->
 <!--1.Now we decide to remove the 'Edit sign up sheet' icon on assignment pop up dialog and merge these content into assignment->edit->topics panel-->

--- a/app/views/student_task/view.html.erb
+++ b/app/views/student_task/view.html.erb
@@ -47,7 +47,7 @@ to display the label "Your team" in the student assignment tasks-->
   <%end%>
 
   <!--Your work-->
-  <% if @authorization == 'participant' or @can_submit == true %>
+  <% if (@authorization == 'participant' or @can_submit == true) && @has_submissions %>
     <li>
       <% if @topics.size > 0 %>
         <% if @topic_id and @assignment.submission_allowed(@topic_id) %>
@@ -65,8 +65,8 @@ to display the label "Your team" in the student assignment tasks-->
       <% end %>
     </li>
   <% end %>
-
-  <% if @authorization == 'participant' or @can_review == true %>
+  <%#  Added boolean to hide this tab for assignments with no submissions/review deadlines  %>
+  <% if (@authorization == 'participant' or @can_review == true) && @has_submissions  %>
     <li>
       <!--alias_name means if one participant is a reader, it will show 'Your readings' to see others' work; if one participant is not a reader, it will show 'Others' work' on the screen.-->
       <% if @authorization != 'reader' %>

--- a/db/migrate/20201117090451_add_teammate_review_deadline_type.rb
+++ b/db/migrate/20201117090451_add_teammate_review_deadline_type.rb
@@ -1,0 +1,9 @@
+class AddTeammateReviewDeadlineType < ActiveRecord::Migration
+  def self.up
+    DeadlineType.create :name => "teammate_review"
+  end
+
+  def self.down
+    DeadlineType.find_by_name("teammate_review").destroy
+  end
+end

--- a/spec/controllers/sign_up_sheet_controller_spec.rb
+++ b/spec/controllers/sign_up_sheet_controller_spec.rb
@@ -80,7 +80,7 @@ describe SignUpSheetController do
         allow(SignedUpTeam).to receive(:find_by).with(topic_id: 1).and_return(signed_up_team)
         allow(SignedUpTeam).to receive(:where).with(topic_id: 1, is_waitlisted: true).and_return([signed_up_team2])
         allow(Team).to receive(:find).with(2).and_return(team)
-        allow(SignUpTopic).to receive(:waitlisted_topics).with(1, 2).and_return(nil)
+        allow(SignUpTopic).to receive(:find_waitlisted_topics).with(1, 2).and_return(nil)
         params = {
           id: 1,
           topic: {
@@ -157,7 +157,7 @@ describe SignUpSheetController do
         allow(SignedUpTeam).to receive(:find_by).with(topic_id: 2).and_return(signed_up_team)
         allow(SignedUpTeam).to receive(:where).with(topic_id: 2, is_waitlisted: true).and_return([signed_up_team2])
         allow(Team).to receive(:find).with(2).and_return(team)
-        allow(SignUpTopic).to receive(:waitlisted_topics).with(1, 2).and_return(nil)
+        allow(SignUpTopic).to receive(:find_waitlisted_topics).with(1, 2).and_return(nil)
         allow_any_instance_of(SignUpSheetController).to receive(:undo_link)
           .with("The topic: \"Hello world!\" has been successfully updated. ").and_return('OK')
         params = {
@@ -179,8 +179,8 @@ describe SignUpSheetController do
 
   describe '#list' do
     before(:each) do
-      allow(SignUpTopic).to receive(:filled_slots).with(1).and_return([topic])
-      allow(SignUpTopic).to receive(:find_waitlisted_slots).with(1).and_return([])
+      allow(SignUpTopic).to receive(:find_slots_filled).with(1).and_return([topic])
+      allow(SignUpTopic).to receive(:find_slots_waitlisted).with(1).and_return([])
       allow(SignUpTopic).to receive(:where).with(assignment_id: 1, private_to: nil).and_return([topic])
       allow(participant).to receive(:team).and_return(team)
     end

--- a/spec/models/due_date_spec.rb
+++ b/spec/models/due_date_spec.rb
@@ -130,4 +130,9 @@ describe "due_date_functions" do
   it "review submission_allowed default permission NO" do
     expect(DueDate.default_permission('review', 'submission_allowed')).to be == DeadlineRight::NO
   end
+  
+  it "teammate_review submission_allowed default permission NO" do
+    expect(DueDate.default_permission('teammate_review', 'submission_allowed')).to be == DeadlineRight::NO
+    # E2074/ensure teammate reviews cannot be added past deadline
+  end
 end


### PR DESCRIPTION
### E2074. Extensions to teammate review
There were several changes implemented to add the teammate review deadline functionality:

LIVE LINK: http://ec2-3-21-125-253.us-east-2.compute.amazonaws.com:3000/

1.  ```teammate_review``` DeadlineType was added (through a migration script), to support differentiation between other deadline types
2.  Another checkbox is conditionally displayed on the assignment edit page under the due-dates tab above the previous "Team formation deadline" checkbox. It is displayed when the current assignment allows for teams to be formed and is hidden when not enabled. After being clicked, another row is added to the due date table itself for the use to select a teammate review deadline.
3.  The logic was updated in the assignment controller regarding parsing of the currently selected inputs. Previously, this was done in a for loop and ended up overwriting values, showing and hiding parts of the form erratically. This has been corrected to be done in one pass.
4.  0-round-review assignments. This allows for instructors to have a singular assignment when the only purpose is to peer review teammates. After setting the assignment to 0 review rounds, the user can then add the teammate review deadline (or any other deadline type) and create an assignment strictly for that purpose.
5.  Teammate review date restriction. Now teammate reviews can have a set deadline and can restrict the users based on preconfigured settings. These new permissions have been appended in the DeadlineRight model as well. When the deadline has passed, students will no longer see a button to edit or modify a previous teammate review.
6.  Extra conditional hiding values on the student task pages. When assignments only feature teammate reviews, the "Your Work" and "Others's Work" tabs are hidden on the student task page. This prevents user confusion from submissions on assignments not associated with a deliverable.
7.  Rspec testing. There were a couple tests for the new deadline in the rspec folder to ensure its stability over time.
8.  Quick view to see who has performed teammate reviews. On the list submissions page, there is now a red dot that is shown to the left of a participant's name if he/she has not reviewed all of their teammates. If there are any red dots on the screen, then a message at the bottom displays a message to explain what it is. 

