### PR TITLE
Issue Fix: Teammate review still appears, even when teams not being used

### DIFF
--- a/app/views/assignments/edit/_due_dates.html.erb
+++ b/app/views/assignments/edit/_due_dates.html.erb
@@ -165,7 +165,7 @@
         '<option value="2">Late</option>' +
         '<option value="3">Yes</option>' +
         '</select></td>';
-        if( <%= @assignment_form.assignment.max_team_size != 1 %>)
+        if( <%= @assignment_form.assignment.max_team_size > 1 %>)
         {
           html += '<td align="center" class="due_date_teammate_review_allowed_id" width="10%">';
           html += '<select id="due_date_teammate_review_allowed_id" name="assignment_form[due_date][][teammate_review_allowed_id]" class="form-control" style="width: 75px">'
@@ -175,20 +175,21 @@
           '<option value="3">Yes</option>' +
           '</select></td>';
         }
-      
-        html += '<td align="center" class="due_date_review_of_review_allowed_id" width="10%">';
-        // if(deadline_type == 'team_formation'){
-        //     html += '<select id="due_date_review_of_review_allowed_id" name="assignment_form[due_date][][review_of_review_allowed_id]" disabled>'
-        // }
-        // else{
+        if( <%= @assignment_form.assignment.num_metareviews_allowed > 0 %>)
+        {
+          html += '<td align="center" class="due_date_review_of_review_allowed_id" width="10%">';
+          // if(deadline_type == 'team_formation'){
+          //     html += '<select id="due_date_review_of_review_allowed_id" name="assignment_form[due_date][][review_of_review_allowed_id]" disabled>'
+          // }
+          // else{
             html += '<select id="due_date_review_of_review_allowed_id" name="assignment_form[due_date][][review_of_review_allowed_id]" class="form-control" style="width: 75px">'
-        // }
-        html +=
-        '<option value="1">No</option>' +
-        '<option value="2">Late</option>' +
-        '<option value="3">Yes</option>' +
-        '</select></td>';
-
+          // }
+          html +=
+          '<option value="1">No</option>' +
+          '<option value="2">Late</option>' +
+          '<option value="3">Yes</option>' +
+          '</select></td>';
+        }
         if (<%= @assignment_form.assignment.require_quiz == nil ? false : @assignment_form.assignment.require_quiz %>)
         {
             html += '<td align="center" class="due_date_quiz_allowed_id" width="10%">' +
@@ -530,10 +531,12 @@ function addDaysOrMonth(mul, type) {
 <th width=5% style="text-align:center;">Use Date Updater</th>
 <th width=10% style="text-align:center;">Submission allowed</th>
 <th width=8% style="text-align:center;">Review allowed</th>
-<%if @assignment_form.assignment.max_team_size != 1 %>
+<%if @assignment_form.assignment.max_team_size > 1 %>
   <th width=8% style="text-align:center;">Teammate review allowed</th>
 <% end %>
-<th width=10% style="text-align:center;">Meta-review allowed</th>
+<%if @assignment_form.assignment.num_metareviews_allowed > 0 %>
+  <th width=10% style="text-align:center;">Meta-review allowed</th>
+<% end %>
 <%if @assignment_form.assignment.require_quiz%>
   <th width=9% style="text-align:center;">Has quiz</th>
 <%end%>

--- a/app/views/assignments/edit/_due_dates.html.erb
+++ b/app/views/assignments/edit/_due_dates.html.erb
@@ -165,7 +165,7 @@
         '<option value="2">Late</option>' +
         '<option value="3">Yes</option>' +
         '</select></td>';
-        if( <%= @assignment_form.assignment.max_team_size == 1 %>)
+        if( <%= @assignment_form.assignment.max_team_size != 1 %>)
         {
           html += '<td align="center" class="due_date_teammate_review_allowed_id" width="10%">';
           html += '<select id="due_date_teammate_review_allowed_id" name="assignment_form[due_date][][teammate_review_allowed_id]" class="form-control" style="width: 75px">'
@@ -530,7 +530,7 @@ function addDaysOrMonth(mul, type) {
 <th width=5% style="text-align:center;">Use Date Updater</th>
 <th width=10% style="text-align:center;">Submission allowed</th>
 <th width=8% style="text-align:center;">Review allowed</th>
-<%if @assignment_form.assignment.max_team_size == 1 %>
+<%if @assignment_form.assignment.max_team_size != 1 %>
   <th width=8% style="text-align:center;">Teammate review allowed</th>
 <% end %>
 <th width=10% style="text-align:center;">Meta-review allowed</th>

--- a/app/views/assignments/edit/_due_dates.html.erb
+++ b/app/views/assignments/edit/_due_dates.html.erb
@@ -165,7 +165,7 @@
         '<option value="2">Late</option>' +
         '<option value="3">Yes</option>' +
         '</select></td>';
-        if( <%= @assignment_form.assignment.teams? %>)
+        if( <%= @assignment_form.assignment.max_team_size == 1 %>)
         {
           html += '<td align="center" class="due_date_teammate_review_allowed_id" width="10%">';
           html += '<select id="due_date_teammate_review_allowed_id" name="assignment_form[due_date][][teammate_review_allowed_id]" class="form-control" style="width: 75px">'
@@ -530,7 +530,7 @@ function addDaysOrMonth(mul, type) {
 <th width=5% style="text-align:center;">Use Date Updater</th>
 <th width=10% style="text-align:center;">Submission allowed</th>
 <th width=8% style="text-align:center;">Review allowed</th>
-<%if @assignment_form.assignment.teams? %>
+<%if @assignment_form.assignment.max_team_size == 1 %>
   <th width=8% style="text-align:center;">Teammate review allowed</th>
 <% end %>
 <th width=10% style="text-align:center;">Meta-review allowed</th>

--- a/app/views/assignments/edit/_due_dates.html.erb
+++ b/app/views/assignments/edit/_due_dates.html.erb
@@ -175,7 +175,7 @@
           '<option value="3">Yes</option>' +
           '</select></td>';
         }
-        if( <%= @assignment_form.assignment.num_metareviews_allowed > 0 %>)
+        if( <%= @assignment_form.assignment.num_metareviews_required > 0 %>)
         {
           html += '<td align="center" class="due_date_review_of_review_allowed_id" width="10%">';
           // if(deadline_type == 'team_formation'){
@@ -534,7 +534,7 @@ function addDaysOrMonth(mul, type) {
 <%if @assignment_form.assignment.max_team_size > 1 %>
   <th width=8% style="text-align:center;">Teammate review allowed</th>
 <% end %>
-<%if @assignment_form.assignment.num_metareviews_allowed > 0 %>
+<%if @assignment_form.assignment.num_metareviews_required > 0 %>
   <th width=10% style="text-align:center;">Meta-review allowed</th>
 <% end %>
 <%if @assignment_form.assignment.require_quiz%>

--- a/app/views/assignments/edit/_due_dates.html.erb
+++ b/app/views/assignments/edit/_due_dates.html.erb
@@ -165,15 +165,17 @@
         '<option value="2">Late</option>' +
         '<option value="3">Yes</option>' +
         '</select></td>';
-
-        html += '<td align="center" class="due_date_teammate_review_allowed_id" width="10%">';
-        html += '<select id="due_date_teammate_review_allowed_id" name="assignment_form[due_date][][teammate_review_allowed_id]" class="form-control" style="width: 75px">'
-         html +=
-        '<option value="1">No</option>' +
-        '<option value="2">Late</option>' +
-        '<option value="3">Yes</option>' +
-        '</select></td>';
-
+        if( <%= @assignment_form.assignment.teams? %>)
+        {
+          html += '<td align="center" class="due_date_teammate_review_allowed_id" width="10%">';
+          html += '<select id="due_date_teammate_review_allowed_id" name="assignment_form[due_date][][teammate_review_allowed_id]" class="form-control" style="width: 75px">'
+          html +=
+          '<option value="1">No</option>' +
+          '<option value="2">Late</option>' +
+          '<option value="3">Yes</option>' +
+          '</select></td>';
+        }
+      
         html += '<td align="center" class="due_date_review_of_review_allowed_id" width="10%">';
         // if(deadline_type == 'team_formation'){
         //     html += '<select id="due_date_review_of_review_allowed_id" name="assignment_form[due_date][][review_of_review_allowed_id]" disabled>'
@@ -528,7 +530,9 @@ function addDaysOrMonth(mul, type) {
 <th width=5% style="text-align:center;">Use Date Updater</th>
 <th width=10% style="text-align:center;">Submission allowed</th>
 <th width=8% style="text-align:center;">Review allowed</th>
-<th width=8% style="text-align:center;">Teammate review allowed</th>
+<%if @assignment_form.assignment.teams? %>
+  <th width=8% style="text-align:center;">Teammate review allowed</th>
+<% end %>
 <th width=10% style="text-align:center;">Meta-review allowed</th>
 <%if @assignment_form.assignment.require_quiz%>
   <th width=9% style="text-align:center;">Has quiz</th>

--- a/spec/features/assignment_creation_page_spec.rb
+++ b/spec/features/assignment_creation_page_spec.rb
@@ -52,6 +52,16 @@ describe "Assignment creation page", js: true do
 		)
 	end
 	
+	it "is able to create without teams" do
+		assignment_creation_setup(1,'private assignment for test')
+		click_button 'Create'
+
+		assignment = Assignment.where(name: 'private assignment for test').first
+		expect(assignment).to have_attributes(
+			teams?: false
+		)
+	end
+
 	# instructor can check "has quiz" box and set the number of quiz questions
 	it "is able to create with quiz" do
 		assignment_creation_setup(1,'private assignment for test')


### PR DESCRIPTION
Fix to issue #1867. 
Seems to be a problem for metareview limit changing that needs to be fixed first, but my code changes should work once the metareview limit is fixed, but assignments without teams no longer show teammate review deadlines 