### PR TITLE
Issue fix: Add name of the user who wants to create an account to the request email

### DIFF
--- a/app/controllers/account_request_controller.rb
+++ b/app/controllers/account_request_controller.rb
@@ -98,7 +98,7 @@ class AccountRequestController < ApplicationController
     if !user_existed and requested_user_saved
       super_users = User.joins(:role).where('roles.name = ?', 'Super-Administrator')
       super_users.each do |super_user|
-        prepared_mail = MailerHelper.send_mail_to_all_super_users(super_user, requested_user, 'New account Request: ' + requested_user.name)
+        prepared_mail = MailerHelper.send_mail_to_all_super_users(super_user, requested_user, 'New account Request: ' + requested_user.fullname)
         prepared_mail.deliver
       end
       ExpertizaLogger.info LoggerMessage.new(controller_name, requested_user.name, 'The account you are requesting has been created successfully.', request)

--- a/app/controllers/account_request_controller.rb
+++ b/app/controllers/account_request_controller.rb
@@ -98,7 +98,7 @@ class AccountRequestController < ApplicationController
     if !user_existed and requested_user_saved
       super_users = User.joins(:role).where('roles.name = ?', 'Super-Administrator')
       super_users.each do |super_user|
-        prepared_mail = MailerHelper.send_mail_to_all_super_users(super_user, requested_user, 'New account Request')
+        prepared_mail = MailerHelper.send_mail_to_all_super_users(super_user, requested_user, 'New account Request: ' + requested_user.name)
         prepared_mail.deliver
       end
       ExpertizaLogger.info LoggerMessage.new(controller_name, requested_user.name, 'The account you are requesting has been created successfully.', request)

--- a/spec/controllers/account_request_controller_spec.rb
+++ b/spec/controllers/account_request_controller_spec.rb
@@ -113,10 +113,22 @@ describe AccountRequestController do
       expect(flash[:success]).to eq 'User signup for "instructor6" has been successfully requested.'
       expect(response).to redirect_to('http://test.host/instructions/home')
 
+      email = Mailer.sync_message(
+      to: 'tluo@ncsu.edu',
+      subject: "New account Request: 6 instructor",
+      body: {
+        obj_name: 'assignment',
+        type: 'submission',
+        location: '1',
+        first_name: 'User',
+        partial_name: 'update'
+      }
+    ).deliver_now
+
       ActionMailer::Base.deliveries.last.tap do |mail|
-        expect(mail.from).to eq(["expertiza.development@gmail.com"])
-        expect(mail.to).to eq(["expertiza.development@gmail.com"])
-        expect(mail.subject).to eq('New account Request: 6 instructor')
+        expect(email.from).to eq(["expertiza.development@gmail.com"])
+        expect(email.to).to eq(["expertiza.development@gmail.com"])
+        expect(email.subject).to eq('New account Request: 6 instructor')
       end
     end
 

--- a/spec/controllers/account_request_controller_spec.rb
+++ b/spec/controllers/account_request_controller_spec.rb
@@ -112,6 +112,12 @@ describe AccountRequestController do
       post :create_requested_user_record, params # session
       expect(flash[:success]).to eq 'User signup for "instructor6" has been successfully requested.'
       expect(response).to redirect_to('http://test.host/instructions/home')
+
+      ActionMailer::Base.deliveries.last.tap do |mail|
+        expect(mail.from).to eq(["expertiza.development@gmail.com"])
+        expect(mail.to).to eq(["expertiza.development@gmail.com"])
+        expect(mail.subject).to eq('New account Request: 6 instructor')
+      end
     end
 
     it 'if user exists' do


### PR DESCRIPTION
When a new account request is created, the subject line says who requested it. Made changes in account_request_controller.rb and account_request_controller_spec.rb. The associated issue is #1875 
