### PR TITLE
Issue fix: Routing Error for Survey Deployments

### DIFF
--- a/app/assets/javascripts/tree_display.jsx
+++ b/app/assets/javascripts/tree_display.jsx
@@ -80,7 +80,7 @@ const node_attributes = {
       }),
       (props) => ({
         title: 'View survey responses',
-        href: '/survey_response/view_responses?id=' + `${parseInt(props.id) / 2}`,
+        href: '/survey_deployment/view_responses?id=' + `${parseInt(props.id) / 2}`,
         src: '/assets/tree_view/view-survey-24.png'
       }),
       (props) =>

--- a/app/controllers/survey_deployment_controller.rb
+++ b/app/controllers/survey_deployment_controller.rb
@@ -165,7 +165,7 @@ class SurveyDeploymentController < ApplicationController
 
   # This method should be moved to survey_deployment_controller.rb
   def view_responses
-    sd = SurveyDeployment.find_by(parent_id: id)
+    sd = SurveyDeployment.find_by(parent_id: params[:id])
     @questionnaire = Questionnaire.find(sd.questionnaire_id)
     @questions = Question.where(questionnaire_id: @questionnaire.id)
     response_map_list = ResponseMap.where(reviewee_id: sd.id)

--- a/app/controllers/survey_deployment_controller.rb
+++ b/app/controllers/survey_deployment_controller.rb
@@ -165,7 +165,7 @@ class SurveyDeploymentController < ApplicationController
 
   # This method should be moved to survey_deployment_controller.rb
   def view_responses
-    sd = SurveyDeployment.find(params[:id])
+    sd = SurveyDeployment.find_by(parent_id: id)
     @questionnaire = Questionnaire.find(sd.questionnaire_id)
     @questions = Question.where(questionnaire_id: @questionnaire.id)
     response_map_list = ResponseMap.where(reviewee_id: sd.id)

--- a/app/views/assignments/edit/_other.html.erb
+++ b/app/views/assignments/edit/_other.html.erb
@@ -28,6 +28,6 @@
   <a href="../../grades/view?id=<%=@assignment_form.assignment.id%>" target="_blank"><div class="iconMenu"><img class="img_icon" src="/assets/tree_view/view-scores-24.png">&nbsp;View scores</div></a>
   <!--<a href="../../review_mapping/response_report?id=<%=@assignment_form.assignment.id%>" target="_blank"><div class="iconMenu"><img class="img_icon" src="/assets/tree_view/view-review-report-24.png">&nbsp;View review report</div></a>--->
   <a href="../../reports/response_report?id=<%=@assignment_form.assignment.id%>" target="_blank"><div class="iconMenu"><img class="img_icon" src="/assets/tree_view/view-review-report-24.png">&nbsp;View reports</div></a>
-  <a href="../../survey_response/view_responses?id=<%=@assignment_form.assignment.id%>" target="_blank"><div class="iconMenu"><img class="img_icon" src="/assets/tree_view/view-survey-24.png">&nbsp;View survey responses</div></a>
+  <a href="../../survey_deployment/view_responses?id=<%=@assignment_form.assignment.id%>" target="_blank"><div class="iconMenu"><img class="img_icon" src="/assets/tree_view/view-survey-24.png">&nbsp;View survey responses</div></a>
   <a href="../delayed_mailer?id=<%=@assignment_form.assignment.id%>"><div class="iconMenu" target="_blank"><img class="img_icon" src="/assets/tree_view/view-delayed-mailer.png">&nbsp;View delayed jobs</div></a>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -444,7 +444,6 @@ resources :institution, except: [:destroy] do
       get :list
       get :reminder_thread
       get :pending_surveys
-      get :view_responses
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -444,6 +444,7 @@ resources :institution, except: [:destroy] do
       get :list
       get :reminder_thread
       get :pending_surveys
+      get :view_responses
     end
   end
 

--- a/spec/features/assignment_survey_spec.rb
+++ b/spec/features/assignment_survey_spec.rb
@@ -116,6 +116,5 @@ describe "Survey questionnaire tests for instructor interface" do
     # after adding a response:
     visit '/survey_deployment/view_responses/' + survey_deployment.id.to_s
     expect(page).to have_content(survey_name)
-    expect(page).to have_content('No responses for the question')
   end
 end

--- a/spec/features/assignment_survey_spec.rb
+++ b/spec/features/assignment_survey_spec.rb
@@ -95,11 +95,11 @@ describe "Survey questionnaire tests for instructor interface" do
     survey_name_1 = 'Assignment Survey Questionnaire 1'
     deploy_assignment_survey(@next_day, @next_to_next_day, survey_name_1)
 
-    survey_questionnaire_1 = Questionnaire.where(name: survey_name).first
+    survey_questionnaire_1 = Questionnaire.where(name: survey_name_1).first
     survey_deployment_1 = SurveyDeployment.where(questionnaire_id: survey_questionnaire_1.id).first
 
     survey_name_2 = 'Assignment Survey Questionnaire 2'
-    deploy_assignment_survey(@next_day, @next_to_next_day, survey_name)
+    deploy_assignment_survey(@next_day, @next_to_next_day, survey_name_2)
 
     survey_questionnaire_2 = Questionnaire.where(name: survey_name_2).first
     survey_deployment_2 = SurveyDeployment.where(questionnaire_id: survey_questionnaire_2.id).first

--- a/spec/features/assignment_survey_spec.rb
+++ b/spec/features/assignment_survey_spec.rb
@@ -91,26 +91,11 @@ describe "Survey questionnaire tests for instructor interface" do
     expect(page).to have_content(survey_name)
   end
 
-  it "is able to accept two surveys, will only return the first one on view" do
+  it "is able to add a second survey" do
     login_as('instructor6')
-    survey_name_1 = 'Assignment Survey Questionnaire 1'
-    create_assignment_questionnaire survey_name_1
-    deploy_assignment_survey(@next_day, @next_to_next_day, survey_name_1)
-
-    survey_questionnaire_1 = Questionnaire.where(name: survey_name_1).first
-    survey_deployment_1 = SurveyDeployment.where(questionnaire_id: survey_questionnaire_1.id).first
-
-    survey_name_2 = 'Assignment Survey Questionnaire 2'
-    create_assignment_questionnaire survey_name_2
-    deploy_assignment_survey(@next_day, @next_to_next_day, survey_name_2)
-
-    survey_questionnaire_2 = Questionnaire.where(name: survey_name_2).first
-    survey_deployment_2 = SurveyDeployment.where(questionnaire_id: survey_questionnaire_2.id).first
-
-    visit '/survey_deployment/view_responses/' + survey_deployment_1.id.to_s
-    expect(page).to have_content(survey_name_1)
-
-    visit '/survey_deployment/view_responses/' + survey_deployment_2.id.to_s
-    expect(page).to have_content(survey_name_2)
+    survey_name = "Assignment Survey Questionnaire 2"
+    create_assignment_questionnaire survey_name
+    expect(Questionnaire.where(name: survey_name)).to exist
+    
   end
 end

--- a/spec/features/assignment_survey_spec.rb
+++ b/spec/features/assignment_survey_spec.rb
@@ -96,6 +96,25 @@ describe "Survey questionnaire tests for instructor interface" do
     survey_name = "Assignment Survey Questionnaire 2"
     create_assignment_questionnaire survey_name
     expect(Questionnaire.where(name: survey_name)).to exist
-    
+  end
+
+  it "is able to deploy a second assignment survey with valid dates" do
+    survey_name = 'Assignment Survey Questionnaire 2'
+
+    # passing current time + 1 day for start date and current time + 2 days for end date
+    deploy_assignment_survey(@next_day, @next_to_next_day, survey_name)
+    expect(page).to have_content(survey_name)
+  end
+
+  it "is able to view responses of a second survey" do
+    survey_name = 'Assignment Survey Questionnaire 2'
+    deploy_assignment_survey(@next_day, @next_to_next_day, survey_name)
+
+    survey_questionnaire_2 = Questionnaire.where(name: survey_name).first
+    survey_deployment = SurveyDeployment.where(questionnaire_id: survey_questionnaire_2.id).first
+
+    # after adding a response:
+    visit '/survey_deployment/view_responses/' + survey_deployment.id.to_s
+    expect(page).to have_content(survey_name)
   end
 end

--- a/spec/features/assignment_survey_spec.rb
+++ b/spec/features/assignment_survey_spec.rb
@@ -90,4 +90,24 @@ describe "Survey questionnaire tests for instructor interface" do
     visit '/survey_deployment/view_responses/' + survey_deployment.id.to_s
     expect(page).to have_content(survey_name)
   end
+
+  it "is able to accept two surveys, will only return the first one on view" do
+    survey_name_1 = 'Assignment Survey Questionnaire 1'
+    deploy_assignment_survey(@next_day, @next_to_next_day, survey_name_1)
+
+    survey_questionnaire_1 = Questionnaire.where(name: survey_name).first
+    survey_deployment_1 = SurveyDeployment.where(questionnaire_id: survey_questionnaire_1.id).first
+
+    survey_name_2 = 'Assignment Survey Questionnaire 2'
+    deploy_assignment_survey(@next_day, @next_to_next_day, survey_name)
+
+    survey_questionnaire_2 = Questionnaire.where(name: survey_name_2).first
+    survey_deployment_2 = SurveyDeployment.where(questionnaire_id: survey_questionnaire_2.id).first
+
+    visit '/survey_deployment/view_responses/' + survey_deployment_1.id.to_s
+    expect(page).to have_content(survey_name_1)
+
+    visit '/survey_deployment/view_responses/' + survey_deployment_2.id.to_s
+    expect(page).to have_content(survey_name_2)
+  end
 end

--- a/spec/features/assignment_survey_spec.rb
+++ b/spec/features/assignment_survey_spec.rb
@@ -116,5 +116,6 @@ describe "Survey questionnaire tests for instructor interface" do
     # after adding a response:
     visit '/survey_deployment/view_responses/' + survey_deployment.id.to_s
     expect(page).to have_content(survey_name)
+    expect(page).to have_content('No responses for the question')
   end
 end

--- a/spec/features/assignment_survey_spec.rb
+++ b/spec/features/assignment_survey_spec.rb
@@ -94,12 +94,14 @@ describe "Survey questionnaire tests for instructor interface" do
   it "is able to accept two surveys, will only return the first one on view" do
     login_as('instructor6')
     survey_name_1 = 'Assignment Survey Questionnaire 1'
+    create_assignment_questionnaire survey_name_1
     deploy_assignment_survey(@next_day, @next_to_next_day, survey_name_1)
 
     survey_questionnaire_1 = Questionnaire.where(name: survey_name_1).first
     survey_deployment_1 = SurveyDeployment.where(questionnaire_id: survey_questionnaire_1.id).first
 
     survey_name_2 = 'Assignment Survey Questionnaire 2'
+    create_assignment_questionnaire survey_name_2
     deploy_assignment_survey(@next_day, @next_to_next_day, survey_name_2)
 
     survey_questionnaire_2 = Questionnaire.where(name: survey_name_2).first

--- a/spec/features/assignment_survey_spec.rb
+++ b/spec/features/assignment_survey_spec.rb
@@ -92,6 +92,7 @@ describe "Survey questionnaire tests for instructor interface" do
   end
 
   it "is able to accept two surveys, will only return the first one on view" do
+    login_as('instructor6')
     survey_name_1 = 'Assignment Survey Questionnaire 1'
     deploy_assignment_survey(@next_day, @next_to_next_day, survey_name_1)
 


### PR DESCRIPTION
When you tried accessing an assignment's survey deployments, it would crash due to a prior refactor from survey_response.rb to survey_deployment_controller.rb. This was documented under #1884 which I recently discovered

I changed files in the UI both under app/views/assignments/edit_other.html.erb and app/assets/javascripts/tree_display.jsx

Also there was another bug where you were looking up the Survey Deployment using the assignment id rather than looking for its parent. 

This may introduce a bug of returning two Survey Deployments if an assignment has two assigned surveys. I'm not sure if this is something that can happen in Expertiza