### PR TITLE
Refactoring for ParticipantsController

### DIFF
--- a/app/controllers/participants_controller.rb
+++ b/app/controllers/participants_controller.rb
@@ -50,6 +50,7 @@ class ParticipantsController < ApplicationController
     # E1721 changes End.
   end
 
+  #when you change the duties, changes the permissions based on the new duty you go to
   def update_authorizations
     permissions = Participant.get_permissions(params[:authorization])
     can_submit = permissions[:can_submit]

--- a/app/controllers/participants_controller.rb
+++ b/app/controllers/participants_controller.rb
@@ -206,6 +206,7 @@ class ParticipantsController < ApplicationController
     user = {}
     user[:name] = team_user.name
     user[:fullname] = team_user.fullname
+    #set by default
     permission_granted = false
     assignment.participants.each do |participant|
       permission_granted = participant.permission_granted? if team_user.id == participant.user.id

--- a/app/controllers/participants_controller.rb
+++ b/app/controllers/participants_controller.rb
@@ -157,7 +157,7 @@ class ParticipantsController < ApplicationController
   end
 
   # Deletes participants from an assignment
-  def delete_assignment_participant
+  def delete
     contributor = AssignmentParticipant.find(params[:id])
     name = contributor.name
     assignment_id = contributor.assignment

--- a/app/controllers/participants_controller.rb
+++ b/app/controllers/participants_controller.rb
@@ -207,14 +207,12 @@ class ParticipantsController < ApplicationController
     user[:name] = team_user.name
     user[:fullname] = team_user.fullname
     permission_granted = false
-    has_signature = false
-    signature_valid = false
     assignment.participants.each do |participant|
       permission_granted = participant.permission_granted? if team_user.id == participant.user.id
     end
     # If permission is granted, set the publisting rights string
     user[:pub_rights] = permission_granted ? "Granted" : "Denied"
-    user[:verified] = permission_granted && has_signature && signature_valid
+    user[:verified] = permission_granted
     user
   end
 

--- a/app/controllers/participants_controller.rb
+++ b/app/controllers/participants_controller.rb
@@ -212,7 +212,7 @@ class ParticipantsController < ApplicationController
     end
     # If permission is granted, set the publisting rights string
     user[:pub_rights] = permission_granted ? "Granted" : "Denied"
-    user[:verified] = permission_granted
+    user[:verified] = false
     user
   end
 

--- a/app/views/participants/_participant.html.erb
+++ b/app/views/participants/_participant.html.erb
@@ -16,7 +16,7 @@
   <td align = "left"><%= participant.can_take_quiz == false ? 'no' : 'yes' %></td>
   <td align = "left"><%= participant.handle(session[:ip]) %></td>
 
-  <td align="left" ><%= link_to 'Remove', {:controller => controller, :action => 'destroy', :id => participant.id}, :method => :delete %></td>
+  <td align="left" ><%= link_to 'Remove', {:controller => 'participants', :action => 'destroy', :id => participant.id}, :method => :delete %></td>
 
   <!-- E726 Fall2012 Changes Begin -->
   <% authorization = Participant.get_authorization(participant.can_submit, participant.can_review, participant.can_take_quiz) %>

--- a/app/views/review_mapping/_list_review_mappings.html.erb
+++ b/app/views/review_mapping/_list_review_mappings.html.erb
@@ -72,7 +72,7 @@
       <div style="text-align:right">
         <!-- ACS removed check to see if it is a team assignment-->
         <% if assignment.max_team_size < 2 %>
-          <%= link_to 'delete', :controller=> 'participants', :action => 'delete_assignment_participant', :id => contributor.id %><br/>
+          <%= link_to 'delete', :controller=> 'participants', :action => 'delete', :id => contributor.id %><br/>
         <% end %>
         <%= link_to 'add reviewer', :action => 'select_reviewer', :id => assignment.id, :contributor_id => contributor.id %><br/>
         <%= link_to 'delete outstanding reviewers', :action => 'delete_outstanding_reviewers', :id => assignment.id, :contributor_id => contributor.id %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -203,7 +203,7 @@ resources :institution, except: [:destroy] do
       get :add
       post :add
       get :auto_complete_for_user_name
-      get :delete_assignment_participant
+      get :delete
       get :list
       get :change_handle
       get :inherit

--- a/spec/controllers/participants_controller_spec.rb
+++ b/spec/controllers/participants_controller_spec.rb
@@ -47,13 +47,13 @@ describe ParticipantsController do
     end
   end
 
-  describe '#delete_assignment_participant' do
+  describe '#delete' do
     it 'deletes the assignment_participant and redirects to #review_mapping/list_mappings page' do
       allow(Participant).to receive(:find).with('1').and_return(participant)
       allow(participant).to receive(:destroy).and_return(true)
       params = {id: 1}
       session = {user: instructor}
-      get :delete_assignment_participant, params, session
+      get :delete, params, session
       expect(response).to redirect_to('/review_mapping/list_mappings?id=1')
     end
   end

--- a/spec/controllers/participants_controller_spec.rb
+++ b/spec/controllers/participants_controller_spec.rb
@@ -165,7 +165,7 @@ describe ParticipantsController do
       allow(participant).to receive(:user).and_return(student)
       allow(student).to receive(:name).and_return('name')
       allow(student).to receive(:fullname).and_return('fullname')
-      expect(ParticipantsController.get_user_info(student, assignment)).to be({:name=>'name', :fullname=>'fullname', :pub_rights=>'Granted', :verified=>false})
+      expect(ParticipantsController.send(:get_user_info, [student, assignment])).to be({:name=>'name', :fullname=>'fullname', :pub_rights=>'Granted', :verified=>false})
     end
   end
 end

--- a/spec/controllers/participants_controller_spec.rb
+++ b/spec/controllers/participants_controller_spec.rb
@@ -165,7 +165,8 @@ describe ParticipantsController do
       allow(participant).to receive(:user).and_return(student)
       allow(student).to receive(:name).and_return('name')
       allow(student).to receive(:fullname).and_return('fullname')
-      expect(ParticipantsController.send(:get_user_info, [student, assignment])).to be({:name=>'name', :fullname=>'fullname', :pub_rights=>'Granted', :verified=>false})
+      pc = ParticipantsController.new
+      expect(pc.send(:get_user_info, student, assignment).to be({:name=>'name', :fullname=>'fullname', :pub_rights=>'Granted', :verified=>false})
     end
   end
 end

--- a/spec/controllers/participants_controller_spec.rb
+++ b/spec/controllers/participants_controller_spec.rb
@@ -165,7 +165,7 @@ describe ParticipantsController do
       allow(participant).to receive(:user).and_return(student)
       allow(student).to receive(:name).and_return('name')
       allow(student).to receive(:fullname).and_return('fullname')
-      expect(ParticipantsController.get_user_info(user, assignment)).to be({:name=>'name', :fullname=>'fullname', :pub_rights=>'Granted', :verified=>false})
+      expect(ParticipantsController.get_user_info(student, assignment)).to be({:name=>'name', :fullname=>'fullname', :pub_rights=>'Granted', :verified=>false})
     end
   end
 end

--- a/spec/controllers/participants_controller_spec.rb
+++ b/spec/controllers/participants_controller_spec.rb
@@ -5,6 +5,8 @@ describe ParticipantsController do
   let(:participant) { build(:participant) }
   let(:assignment_node) { build(:assignment_node) }
   let(:assignment) { build(:assignment) }
+  let(:team) { build(:team) }
+  let(:participant) { build(:participant)}
   describe '#action_allowed?' do
     context 'when current user is student' do
       it 'allows update_duties action' do
@@ -153,6 +155,17 @@ describe ParticipantsController do
       get :bequeath_all, params, session
       expect(flash[:note]).to eq 'All assignment participants are already part of the course'
       expect(response).to redirect_to('/participants/list?model=Assignment')
+    end
+  end
+
+  describe '#get_user_info' do
+    it 'gives the user information from the the team user' do
+      allow(assignment).to receive(:participants).and_return([participant])
+      allow(participant).to receive(:permission_granted?).and_return(true)
+      allow(participant).to receive(:user).and_return(student)
+      allow(student).to receive(:name).and_return('name')
+      allow(student).to receive(:fullname).and_return('fullname')
+      expect(ParticipantsController.get_user_info(user, assignment)).to be({:name=>'name', :fullname=>'fullname', :pub_rights=>'Granted', :verified=>false})
     end
   end
 end

--- a/spec/controllers/participants_controller_spec.rb
+++ b/spec/controllers/participants_controller_spec.rb
@@ -166,7 +166,7 @@ describe ParticipantsController do
       allow(student).to receive(:name).and_return('name')
       allow(student).to receive(:fullname).and_return('fullname')
       pc = ParticipantsController.new
-      expect(pc.send(:get_user_info, student, assignment)).to be({:name=>'name', :fullname=>'fullname', :pub_rights=>'Granted', :verified=>false})
+      expect(pc.send(:get_user_info, student, assignment)).to eq({:name=>'name', :fullname=>'fullname', :pub_rights=>'Granted', :verified=>false})
     end
   end
 end

--- a/spec/controllers/participants_controller_spec.rb
+++ b/spec/controllers/participants_controller_spec.rb
@@ -166,7 +166,7 @@ describe ParticipantsController do
       allow(student).to receive(:name).and_return('name')
       allow(student).to receive(:fullname).and_return('fullname')
       pc = ParticipantsController.new
-      expect(pc.send(:get_user_info, student, assignment).to be({:name=>'name', :fullname=>'fullname', :pub_rights=>'Granted', :verified=>false})
+      expect(pc.send(:get_user_info, student, assignment)).to be({:name=>'name', :fullname=>'fullname', :pub_rights=>'Granted', :verified=>false})
     end
   end
 end


### PR DESCRIPTION
participants_controller.rb has some things that need fixed according to #1758.

- [x] update_authorizations: It is not clear why the method is named as it is, needs a method comment to explain why.
- [x] Why is there a delete_assignment_participant, but no delete_course_participant? And should it be just delete?
- [x] Removes a participant from the assignment
- [x] What do has_signature and signature_valid do? They are set to false, then immediately used in an expression, & not used anywhere else, yet they are local variables! So why are they even needed?
- [x] Get_user_info does not have spec test case
- [x] has_signature and signature_valid are essentially not needed
- [x] Unsure if user[:verified] should be equal to permission_granted or false boolean
- [x] They can be removed.

Creating PR to run my Spec test and to utilize this PR to organize my work. Not ready for merging.