### PR TITLE
Issue Fix: remove the random number on student_review#list

### DIFF
--- a/app/views/student_review/list.html.erb
+++ b/app/views/student_review/list.html.erb
@@ -1,4 +1,4 @@
-<h2>Reviews for "<%= @assignment.name %>"</h2>
+-<h2>Reviews for "<%= @assignment.name %>"</h2>
 
 <!-- Added the feature to find the reviews and meta-reviews left for students by E1839 @Rayan Dasoriya -->
 <% if @assignment.num_reviews_allowed.nil? || @assignment.num_reviews_allowed == -1%>
@@ -18,7 +18,6 @@
 <% end %>
 
 <% if check_reviewable_topics(@assignment) or @assignment.get_current_stage(@topic_id) == "Finished" %>
-    <%= @review_mappings.count %>
     <%= render :partial => 'responses', :locals => {:mappings => @review_mappings, :title => 'Review'} %>
     <!-- Temporary fix for Staggered Deadline assignment issue preventing students from reviewing 04-23-19 -->
     <!-- We need to perform the same check, but on the topic that is being reviewed and not the topic that the reviewer wrote on -->


### PR DESCRIPTION
Issue fix for the random number in other work tab discovered by @kpiryani10 in #1894 
This was on Line 21 of app/views/student_reviews/list.html.erb where  <%= @review_mappings.count %> was being printed, so it wasn't entirely a random number.
This line of code is now removed, and I'm no longer seeing the number being printed. I'm not introducing any tests for this, as it's a pretty easy to verify fix.


![image](https://user-images.githubusercontent.com/38589044/110337502-fb9bbc00-7ff3-11eb-8922-1ea07187d929.png)
