### PR TITLE
Rubrics tab weight check

### DIFF
--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -109,9 +109,6 @@ class AssignmentsController < ApplicationController
     else
       # SAVE button was used (do a redirect)
       redirect_to edit_assignment_path @assignment_form.assignment.id
-      if @assignment_form.rubric_weight_error
-        flash[:note] = "A rubric has no ScoredQuestions, but still has a weight. Please change the weight to 0."
-      end
     end
   end
 
@@ -505,6 +502,9 @@ class AssignmentsController < ApplicationController
       flash[:error] = "There has been some submissions for the rounds of reviews that you're trying to reduce. You can only increase the round of review."
     elsif @assignment_form.update_attributes(assignment_form_params, current_user)
       # flash[:note] = 'The assignment was successfully saved....'
+      if @assignment_form.rubric_weight_error
+        flash[:note] = "A rubric has no ScoredQuestions, but still has a weight. Please change the weight to 0."
+      end
     else
       flash[:error] = "Failed to save the assignment: #{@assignment_form.errors.get(:message)}"
     end

--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -506,7 +506,7 @@ class AssignmentsController < ApplicationController
         flash[:error] = "A rubric has no ScoredQuestions, but still has a weight. Please change the weight to 0."
       end
     else
-      flash[:error] = "Failed to save the assignment: #{@assignment_form.errors}"
+      flash[:error] = "Failed to save the assignment: #{@assignment_form.errors.to_s}"
     end
     ExpertizaLogger.info LoggerMessage.new("", session[:user].name, "The assignment was saved: #{@assignment_form.as_json}", request)
   end

--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -503,6 +503,8 @@ class AssignmentsController < ApplicationController
   def update_feedback_attributes
     if params[:set_pressed][:bool] == 'false'
       flash[:error] = "There has been some submissions for the rounds of reviews that you're trying to reduce. You can only increase the round of review."
+    elsif @assignment_form.update_attributes(assignment_form_params, current_user)
+      # flash[:note] = 'The assignment was successfully saved....'
     else
       flash[:error] = "Failed to save the assignment: #{@assignment_form.errors.get(:message)}"
     end

--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -506,7 +506,7 @@ class AssignmentsController < ApplicationController
         flash[:error] = "A rubric has no ScoredQuestions, but still has a weight. Please change the weight to 0."
       end
     else
-      flash[:error] = "Failed to save the assignment: #{@assignment_form.errors.full_messages.join(' ')}"
+      flash[:error] = "Failed to save the assignment: #{@assignment_form.errors}"
     end
     ExpertizaLogger.info LoggerMessage.new("", session[:user].name, "The assignment was saved: #{@assignment_form.as_json}", request)
   end

--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -506,7 +506,7 @@ class AssignmentsController < ApplicationController
         flash[:error] = "A rubric has no ScoredQuestions, but still has a weight. Please change the weight to 0."
       end
     else
-      flash[:error] = "Failed to save the assignment: #{@assignment_form.errors[:message]}"
+      flash[:error] = "Failed to save the assignment: #{@assignment_form.errors.full_messages.join(' ')}"
     end
     ExpertizaLogger.info LoggerMessage.new("", session[:user].name, "The assignment was saved: #{@assignment_form.as_json}", request)
   end

--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -502,7 +502,7 @@ class AssignmentsController < ApplicationController
       flash[:error] = "There has been some submissions for the rounds of reviews that you're trying to reduce. You can only increase the round of review."
     elsif @assignment_form.update_attributes(assignment_form_params, current_user)
       # flash[:note] = 'The assignment was successfully saved....'
-      if @assignment_form.rubric_weight_error
+      if @assignment_form.rubric_weight_error(assignment_form_params)
         flash[:note] = "A rubric has no ScoredQuestions, but still has a weight. Please change the weight to 0."
       end
     else

--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -109,7 +109,7 @@ class AssignmentsController < ApplicationController
     else
       # SAVE button was used (do a redirect)
       redirect_to edit_assignment_path @assignment_form.assignment.id
-      if @assignment_form.assignment.rubric_weight_error
+      if @assignment_form.rubric_weight_error
         flash[:error] = "A rubric has no ScoredQuestions, but still has a weight. Please change the weight to 0."
       end
     end

--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -109,6 +109,9 @@ class AssignmentsController < ApplicationController
     else
       # SAVE button was used (do a redirect)
       redirect_to edit_assignment_path @assignment_form.assignment.id
+      if @assignment_form.rubric_weight_error
+        flash[:error] = "A rubric has no ScoredQuestions, but still has a weight. Please change the weight to 0."
+      end
     end
   end
 

--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -501,9 +501,9 @@ class AssignmentsController < ApplicationController
     if params[:set_pressed][:bool] == 'false'
       flash[:error] = "There has been some submissions for the rounds of reviews that you're trying to reduce. You can only increase the round of review."
     elsif @assignment_form.update_attributes(assignment_form_params, current_user)
-      # flash[:note] = 'The assignment was successfully saved....'
+      flash[:note] = 'The assignment was successfully saved....'
       if @assignment_form.rubric_weight_error(assignment_form_params)
-        flash[:note] = "A rubric has no ScoredQuestions, but still has a weight. Please change the weight to 0."
+        flash[:error] = "A rubric has no ScoredQuestions, but still has a weight. Please change the weight to 0."
       end
     else
       flash[:error] = "Failed to save the assignment: #{@assignment_form.errors.get(:message)}"

--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -506,7 +506,7 @@ class AssignmentsController < ApplicationController
         flash[:error] = "A rubric has no ScoredQuestions, but still has a weight. Please change the weight to 0."
       end
     else
-      flash[:error] = "Failed to save the assignment: #{@assignment_form.errors.get(:message)}"
+      flash[:error] = "Failed to save the assignment: #{@assignment_form.errors[:message]}"
     end
     ExpertizaLogger.info LoggerMessage.new("", session[:user].name, "The assignment was saved: #{@assignment_form.as_json}", request)
   end

--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -110,7 +110,7 @@ class AssignmentsController < ApplicationController
       # SAVE button was used (do a redirect)
       redirect_to edit_assignment_path @assignment_form.assignment.id
       if @assignment_form.rubric_weight_error
-        flash[:error] = "A rubric has no ScoredQuestions, but still has a weight. Please change the weight to 0."
+        flash[:note] = "A rubric has no ScoredQuestions, but still has a weight. Please change the weight to 0."
       end
     end
   end
@@ -503,8 +503,6 @@ class AssignmentsController < ApplicationController
   def update_feedback_attributes
     if params[:set_pressed][:bool] == 'false'
       flash[:error] = "There has been some submissions for the rounds of reviews that you're trying to reduce. You can only increase the round of review."
-    elsif @assignment_form.update_attributes(assignment_form_params, current_user)
-      flash[:note] = 'The assignment was successfully saved....'
     else
       flash[:error] = "Failed to save the assignment: #{@assignment_form.errors.get(:message)}"
     end

--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -109,7 +109,7 @@ class AssignmentsController < ApplicationController
     else
       # SAVE button was used (do a redirect)
       redirect_to edit_assignment_path @assignment_form.assignment.id
-      if @assignment_form.rubric_weight_error
+      if @assignment_form.assignment.rubric_weight_error
         flash[:error] = "A rubric has no ScoredQuestions, but still has a weight. Please change the weight to 0."
       end
     end

--- a/app/models/assignment_form.rb
+++ b/app/models/assignment_form.rb
@@ -117,9 +117,9 @@ class AssignmentForm
         end
       end
       unless scored_questionnaire || assignment_questionnaire[:questionnaire_weight].to_i == 0
-        assignment_form.rubric_weight_error = true
+        @rubric_weight_error = true
       else
-        assignment_form.rubric_weight_error = false
+        @rubric_weight_error = false
       end
 
       total_weight += assignment_questionnaire[:questionnaire_weight].to_i

--- a/app/models/assignment_form.rb
+++ b/app/models/assignment_form.rb
@@ -46,6 +46,7 @@ class AssignmentForm
         if question.is_a? ScoredQuestion
           scored_questionnaire = true
         end
+        puts scored_questionnaire
       end
       unless scored_questionnaire || assignment_questionnaire[:questionnaire_weight].to_i.zero?
         true

--- a/app/models/assignment_form.rb
+++ b/app/models/assignment_form.rb
@@ -51,8 +51,6 @@ class AssignmentForm
       puts scored_questionnaire
       unless scored_questionnaire || assignment_questionnaire[:questionnaire_weight].to_i.zero?
         error = true
-      else
-        error = false
       end
     end
     error

--- a/app/models/assignment_form.rb
+++ b/app/models/assignment_form.rb
@@ -51,6 +51,7 @@ class AssignmentForm
       else
         false
       end
+    end
   end
 
   def update(attributes, user, vary_by_topic_desired = false)

--- a/app/models/assignment_form.rb
+++ b/app/models/assignment_form.rb
@@ -40,7 +40,8 @@ class AssignmentForm
     attributes.each do |assignment_questionnaire|
       # Check rubrics to make sure weight is 0 if there are no Scored Questions
       scored_questionnaire = false
-      questions = Question.where(questionnaire_id: assignment_questionnaire.questionnaire.id)
+      questionnaire = Questionnaire.find(assignment_questionnaire[:questionnaire_id])
+      questions = Question.where(questionnaire_id: questionnaire.id)
       questions.each do |question|
         if question.is_a? ScoredQuestion
           scored_questionnaire = true

--- a/app/models/assignment_form.rb
+++ b/app/models/assignment_form.rb
@@ -37,6 +37,7 @@ class AssignmentForm
   end
 
   def rubric_weight_error(attributes)
+    error = false
     attributes[:assignment_questionnaire].each do |assignment_questionnaire|
       # Check rubrics to make sure weight is 0 if there are no Scored Questions
       scored_questionnaire = false
@@ -46,14 +47,15 @@ class AssignmentForm
         if question.is_a? ScoredQuestion
           scored_questionnaire = true
         end
-        puts scored_questionnaire
       end
+      puts scored_questionnaire
       unless scored_questionnaire || assignment_questionnaire[:questionnaire_weight].to_i.zero?
-        true
+        error = true
       else
-        false
+        error = false
       end
     end
+    error
   end
 
   def update(attributes, user, vary_by_topic_desired = false)

--- a/app/models/assignment_form.rb
+++ b/app/models/assignment_form.rb
@@ -116,7 +116,7 @@ class AssignmentForm
           scored_questionnaire = true
         end
       end
-      unless scored_questionnaire || assignment_questionnaire[:questionnaire_weight].to_i == 0
+      unless scored_questionnaire || assignment_questionnaire[:questionnaire_weight].to_i.zero?
         @rubric_weight_error = true
       else
         @rubric_weight_error = false

--- a/app/models/assignment_form.rb
+++ b/app/models/assignment_form.rb
@@ -37,7 +37,7 @@ class AssignmentForm
   end
 
   def rubric_weight_error(attributes)
-    attributes.each do |assignment_questionnaire|
+    attributes[:assignment_questionnaire].each do |assignment_questionnaire|
       # Check rubrics to make sure weight is 0 if there are no Scored Questions
       scored_questionnaire = false
       questionnaire = Questionnaire.find(assignment_questionnaire[:questionnaire_id])

--- a/app/models/assignment_form.rb
+++ b/app/models/assignment_form.rb
@@ -40,7 +40,7 @@ class AssignmentForm
     attributes.each do |assignment_questionnaire|
       # Check rubrics to make sure weight is 0 if there are no Scored Questions
       scored_questionnaire = false
-      questions = Question.where(questionnaire_id: assignment_questionnaire[:questionnaire_id])
+      questions = Question.where(questionnaire_id: assignment_questionnaire.questionnaire.id)
       questions.each do |question|
         if question.is_a? ScoredQuestion
           scored_questionnaire = true

--- a/app/models/assignment_form.rb
+++ b/app/models/assignment_form.rb
@@ -48,7 +48,6 @@ class AssignmentForm
           scored_questionnaire = true
         end
       end
-      puts scored_questionnaire
       unless scored_questionnaire || assignment_questionnaire[:questionnaire_weight].to_i.zero?
         error = true
       end

--- a/app/models/assignment_form.rb
+++ b/app/models/assignment_form.rb
@@ -24,6 +24,7 @@ class AssignmentForm
     @assignment.num_review_of_reviews = @assignment.num_metareviews_allowed
     @assignment_questionnaires = Array(args[:assignment_questionnaires])
     @due_dates = Array(args[:due_dates])
+    @assignment.rubric_weight_error = false
   end
 
   # create a form object for this assignment_id
@@ -34,7 +35,6 @@ class AssignmentForm
     assignment_form.due_dates = AssignmentDueDate.where(parent_id: assignment_id)
     assignment_form.set_up_assignment_review
     assignment_form.tag_prompt_deployments = TagPromptDeployment.where(assignment_id: assignment_id)
-    assignment_form.rubric_weight_error = false
     assignment_form
   end
 

--- a/app/models/assignment_form.rb
+++ b/app/models/assignment_form.rb
@@ -24,7 +24,7 @@ class AssignmentForm
     @assignment.num_review_of_reviews = @assignment.num_metareviews_allowed
     @assignment_questionnaires = Array(args[:assignment_questionnaires])
     @due_dates = Array(args[:due_dates])
-    @assignment.rubric_weight_error = false
+    @rubric_weight_error = false
   end
 
   # create a form object for this assignment_id

--- a/spec/controllers/assignments_controller_spec.rb
+++ b/spec/controllers/assignments_controller_spec.rb
@@ -277,7 +277,7 @@ describe AssignmentsController do
 
       context 'when update assignment_form is called on an empty questionnaire of non-zero weight' do
         it 'shows an error message and redirects to assignments#edit page' do
-          @params[assignment_form][assignment_questionnaire][0]["questionnaire_weight"] = "100"
+          @params[:assignment_form][:assignment_questionnaire][0]["questionnaire_weight"] = "100"
           session = {user: instructor}
           post :update, @params, session
           expect(flash[:note]).to eq('The assignment was successfully saved....')

--- a/spec/controllers/assignments_controller_spec.rb
+++ b/spec/controllers/assignments_controller_spec.rb
@@ -219,6 +219,7 @@ describe AssignmentsController do
         allow(AssignmentQuestionnaire).to receive(:new).and_return(new_assignment_questionnaire)
         allow(Questionnaire).to receive(:find).with('666').and_return(questionnaire)
         allow(new_assignment_questionnaire).to receive(:save).and_return(true)
+        allow(AssignmentForm).to receive(:rubric_weight_error).and_return(false)
         @params = {
           vary_by_topic: true,
           id: 1,

--- a/spec/controllers/assignments_controller_spec.rb
+++ b/spec/controllers/assignments_controller_spec.rb
@@ -219,7 +219,6 @@ describe AssignmentsController do
         allow(AssignmentQuestionnaire).to receive(:new).and_return(new_assignment_questionnaire)
         allow(Questionnaire).to receive(:find).with('666').and_return(questionnaire)
         allow(new_assignment_questionnaire).to receive(:save).and_return(true)
-        allow(AssignmentForm).to receive(:rubric_weight_error).and_return(false)
         @params = {
           vary_by_topic: true,
           id: 1,
@@ -229,7 +228,7 @@ describe AssignmentsController do
           },
           assignment_form: {
             assignment_questionnaire: [{"assignment_id" => "1", "questionnaire_id" => "666", "dropdown" => "true",
-                                        "questionnaire_weight" => "100", "notification_limit" => "15", "used_in_round" => "1"}],
+                                        "questionnaire_weight" => "0", "notification_limit" => "15", "used_in_round" => "1"}],
             assignment: {
               instructor_id: 2,
               course_id: 1,

--- a/spec/controllers/assignments_controller_spec.rb
+++ b/spec/controllers/assignments_controller_spec.rb
@@ -274,6 +274,17 @@ describe AssignmentsController do
           expect(response).to render_template('assignments/edit/_topics')
         end
       end
+
+      context 'when update assignment_form is called on an empty questionnaire of non-zero weight' do
+        it 'shows an error message and redirects to assignments#edit page' do
+          @params[assignment_form][assignment_questionnaire][0]["questionnaire_weight"] = "100"
+          session = {user: instructor}
+          post :update, @params, session
+          expect(flash[:note]).to eq('The assignment was successfully saved....')
+          expect(flash[:error]).to eq("A rubric has no ScoredQuestions, but still has a weight. Please change the weight to 0.")
+          expect(response).to render_template('assignments/edit/_topics')
+        end
+      end
     end
   end
 


### PR DESCRIPTION
PR to check the weight of questions in a rubric and flash a warning if the weight is 0 (has no ScoredQuestions). 
For Johns issue #2023 

Not ready as of 9-4. 
![image](https://user-images.githubusercontent.com/41524135/132107486-9cdd4bbc-3bca-481f-9169-93c53c9218d3.png)

Changing the review rubric to my 9-1-21 Test, which one has a section header inside it, does not give my flash warning. May be because the flash[:note] = 'The assignment was successfully saved....' is called immediately after in update_feedback_attributes(). 

Is there a way to flash two messages at once?