### PR TITLE
E2142. Improve e-mail notifications

### DIFF
--- a/app/controllers/submitted_content_controller.rb
+++ b/app/controllers/submitted_content_controller.rb
@@ -139,13 +139,37 @@ class SubmittedContentController < ApplicationController
                             assignment_id: assignment.id,
                             operation: "Submit File")
     ExpertizaLogger.info LoggerMessage.new(controller_name, @participant.name, 'The file has been submitted.', request)
-    # send message to reviewers when submission has been updated
-    # If the user has no team: 1) there are no reviewers to notify; 2) calling email will throw an exception. So rescue and ignore it.
-    participant.assignment.email(participant.id) rescue nil
+
+    # Notify all reviewers assigned to this reviewee
+    mail_assigned_reviewers(team)
+
     if params[:origin] == 'review'
       redirect_to :back
     else
       redirect_to action: 'edit', id: participant.id
+    end
+  end
+
+  def mail_assigned_reviewers(team)
+    maps = ResponseMap.where(reviewed_object_id: @participant.assignment.id, reviewee_id: team.id, type: 'ReviewResponseMap')
+    unless maps.nil?
+      maps.each do |map|
+        reviewer = User.find(Participant.find(map.reviewer_id).user_id)
+        Mailer.sync_message(
+          {
+            :to => reviewer.email,
+            subject:  "Assignment '#{@participant.assignment.name}': A submission has been updated since you last reviewed it",
+            cc: User.find_by(@participant.assignment.instructor_id).email,
+            :body => {
+              :obj_name => @participant.assignment.name,
+              :link => "https://expertiza.ncsu.edu/response/new?id=#{map.id}",
+              :type => 'submission',
+              :first_name => ApplicationHelper::get_user_first_name(User.find(Participant.find(map.reviewer_id).user_id)),
+              :partial_name => 'updated_submission_since_review'
+           }
+          }
+        ).deliver_now
+      end
     end
   end
 

--- a/app/mailers/mail_worker.rb
+++ b/app/mailers/mail_worker.rb
@@ -36,22 +36,15 @@ class MailWorker
   def email_reminder(emails, deadline_type)
     assignment = Assignment.find(self.assignment_id)
     subject = "Message regarding #{deadline_type} for assignment #{assignment.name}"
-    body = "This is a reminder to complete #{deadline_type} for assignment #{assignment.name}."
+    body = "This is a reminder to complete #{deadline_type} for assignment #{assignment.name}. \
+    Deadline is #{self.due_at}.If you have already done the  #{deadline_type}, Please ignore this mail."
 
     emails.each do |mail|
-      user = User.where({email: mail}).first
-      participant_assignment_id = Participant.where(user_id: user.id, parent_id: self.assignment_id).id
-
-      link_to_destination = "Please follow the lilnk: http://expertiza.ncsu.edu/student_task/view?id=#{participant_assignment_id}"
-      body = body + link_to_destination + " Deadline is #{self.due_at}.If you have already done the  #{deadline_type}, Please ignore this mail.";
-
-
-      @mail = Mailer.delayed_message(bcc: mail, subject: subject, body: body)
-      @mail.deliver_now
       Rails.logger.info mail
     end
 
-
+    @mail = Mailer.delayed_message(bcc: emails, subject: subject, body: body)
+    @mail.deliver_now
   end
 
   def find_participant_emails

--- a/app/mailers/mailer.rb
+++ b/app/mailers/mailer.rb
@@ -54,6 +54,7 @@ class Mailer < ActionMailer::Base
     @body = defn[:body]
     @type = defn[:body][:type]
     @obj_name = defn[:body][:obj_name]
+    @link = defn[:body][:link]
     @first_name = defn[:body][:first_name]
     @partial_name = defn[:body][:partial_name]
 

--- a/app/views/mailer/partials/_updated_submission_since_review_html.html.erb
+++ b/app/views/mailer/partials/_updated_submission_since_review_html.html.erb
@@ -1,0 +1,6 @@
+Hi <%= @first_name %>,</br>
+<p>
+  A <%=@type%> you were reviewing for Assignment '<%= @obj_name %>' has been updated since you last review.<br>
+  Hence, to update your review please click on the following link.<br>
+  <% if @link != nil %><a href="<%= @link %>"><%= @link %></a><% end %>
+</p>

--- a/app/views/mailer/partials/_updated_submission_since_review_plain.html.erb
+++ b/app/views/mailer/partials/_updated_submission_since_review_plain.html.erb
@@ -1,0 +1,5 @@
+Hi <%= @first_name %>,
+
+A <%=@type%> you were reviewing for Assignment '<%= @obj_name %>' has been updated since you last review.
+Hence, to update your review please click on the following link.
+<% if @link != nil %><%= @link %><% end %>

--- a/spec/models/mailer_spec.rb
+++ b/spec/models/mailer_spec.rb
@@ -17,4 +17,22 @@ describe 'Tests mailer' do
     expect(email.to[0]).to eq('expertiza.development@gmail.com')
     expect(email.subject).to eq('Test')
   end
+  it 'should correctly populate the template with the right partial ' do
+    # Send the email, then test that it got queued
+    email = Mailer.sync_message(
+      to: 'oigewe@ncsu.edu',
+      subject: "Test",
+      body: {
+        obj_name: 'assignment',
+        type: 'submission',
+        first_name: 'User',
+        partial_name: 'updated_submission_since_review'
+      }
+    ).deliver_now
+
+    expect(email.from[0]).to eq("expertiza.development@gmail.com")
+    expect(email.to[0]).to eq('expertiza.development@gmail.com')
+    expect(email.subject).to eq('Test')
+    # expect(email.body.to_s).to eq('asd') FIXME Not sure how to get the body of the email
+  end
 end


### PR DESCRIPTION
Issue #717: When students' accounts are created by importing a CSV file on the Users page, they receive e-mails with their user-ID and password. But if an account is created by adding them as participants to an assignment when they don't already have an account, e-mail is not sent. Students should receive e-mails upon account creation, regardless of how their account is created. So this involves adding a call to the e-mailer … or, perhaps, moving an email call from the Users controller to the point where an account is actually created. [Make sure emailer is running; if you have trouble, email expertiza-support@ncsu.edu.]
Issue #345: Second, evidently if a submission is revised after review, the system e-mails the reviewer saying to revise the review. This is just fine ... except if the last round of review has been completed. The message telling reviewers to revise their reviews should not be sent after the last review deadline has passed. It would also be nice to fix the message so it tells which review (Review 1, Review 2, etc.) has been revised, and gives the reviewer a link directly to it.
Issue #111: Deadline reminders should include a link on where to go to perform the needed function.