### PR TITLE
E2142. Improve e-mail notifications

### DIFF
--- a/app/controllers/submitted_content_controller.rb
+++ b/app/controllers/submitted_content_controller.rb
@@ -65,6 +65,7 @@ class SubmittedContentController < ApplicationController
         ExpertizaLogger.error LoggerMessage.new(controller_name, @participant.name, "The URL or URI is invalid. Reason: #{$ERROR_INFO}", request)
         flash[:error] = "The URL or URI is invalid. Reason: #{$ERROR_INFO}"
       end
+      Team.mail_assigned_reviewers(@participant)
       ExpertizaLogger.info LoggerMessage.new(controller_name, @participant.name, 'The link has been successfully submitted.', request)
       undo_link("The link has been successfully submitted.")
     end
@@ -141,35 +142,12 @@ class SubmittedContentController < ApplicationController
     ExpertizaLogger.info LoggerMessage.new(controller_name, @participant.name, 'The file has been submitted.', request)
 
     # Notify all reviewers assigned to this reviewee
-    mail_assigned_reviewers(team)
+    Team.mail_assigned_reviewers(@participant)
 
     if params[:origin] == 'review'
       redirect_to :back
     else
       redirect_to action: 'edit', id: participant.id
-    end
-  end
-
-  def mail_assigned_reviewers(team)
-    maps = ResponseMap.where(reviewed_object_id: @participant.assignment.id, reviewee_id: team.id, type: 'ReviewResponseMap')
-    unless maps.nil?
-      maps.each do |map|
-        reviewer = User.find(Participant.find(map.reviewer_id).user_id)
-        Mailer.sync_message(
-          {
-            :to => reviewer.email,
-            subject:  "Assignment '#{@participant.assignment.name}': A submission has been updated since you last reviewed it",
-            cc: User.find_by(@participant.assignment.instructor_id).email,
-            :body => {
-              :obj_name => @participant.assignment.name,
-              :link => "https://expertiza.ncsu.edu/response/new?id=#{map.id}",
-              :type => 'submission',
-              :first_name => ApplicationHelper::get_user_first_name(User.find(Participant.find(map.reviewer_id).user_id)),
-              :partial_name => 'updated_submission_since_review'
-           }
-          }
-        ).deliver_now
-      end
     end
   end
 

--- a/app/controllers/submitted_content_controller.rb
+++ b/app/controllers/submitted_content_controller.rb
@@ -65,7 +65,7 @@ class SubmittedContentController < ApplicationController
         ExpertizaLogger.error LoggerMessage.new(controller_name, @participant.name, "The URL or URI is invalid. Reason: #{$ERROR_INFO}", request)
         flash[:error] = "The URL or URI is invalid. Reason: #{$ERROR_INFO}"
       end
-      Team.mail_assigned_reviewers(@participant)
+      @participant.mail_assigned_reviewers()
       ExpertizaLogger.info LoggerMessage.new(controller_name, @participant.name, 'The link has been successfully submitted.', request)
       undo_link("The link has been successfully submitted.")
     end
@@ -142,7 +142,7 @@ class SubmittedContentController < ApplicationController
     ExpertizaLogger.info LoggerMessage.new(controller_name, @participant.name, 'The file has been submitted.', request)
 
     # Notify all reviewers assigned to this reviewee
-    Team.mail_assigned_reviewers(@participant)
+    @participant.mail_assigned_reviewers()
 
     if params[:origin] == 'review'
       redirect_to :back

--- a/app/controllers/submitted_content_controller.rb
+++ b/app/controllers/submitted_content_controller.rb
@@ -65,7 +65,7 @@ class SubmittedContentController < ApplicationController
         ExpertizaLogger.error LoggerMessage.new(controller_name, @participant.name, "The URL or URI is invalid. Reason: #{$ERROR_INFO}", request)
         flash[:error] = "The URL or URI is invalid. Reason: #{$ERROR_INFO}"
       end
-      @participant.mail_assigned_reviewers()
+      @participant.mail_assigned_reviewers
       ExpertizaLogger.info LoggerMessage.new(controller_name, @participant.name, 'The link has been successfully submitted.', request)
       undo_link("The link has been successfully submitted.")
     end
@@ -139,10 +139,10 @@ class SubmittedContentController < ApplicationController
                             user: participant.name,
                             assignment_id: assignment.id,
                             operation: "Submit File")
-    ExpertizaLogger.info LoggerMessage.new(controller_name, @participant.name, 'The file has been submitted.', request)
+    ExpertizaLogger.info LoggerMessage.new(controller_name, participant.name, 'The file has been submitted.', request)
 
     # Notify all reviewers assigned to this reviewee
-    @participant.mail_assigned_reviewers()
+    participant.mail_assigned_reviewers
 
     if params[:origin] == 'review'
       redirect_to :back

--- a/app/controllers/submitted_content_controller.rb
+++ b/app/controllers/submitted_content_controller.rb
@@ -139,13 +139,37 @@ class SubmittedContentController < ApplicationController
                             assignment_id: assignment.id,
                             operation: "Submit File")
     ExpertizaLogger.info LoggerMessage.new(controller_name, @participant.name, 'The file has been submitted.', request)
-    # send message to reviewers when submission has been updated
-    # If the user has no team: 1) there are no reviewers to notify; 2) calling email will throw an exception. So rescue and ignore it.
-    participant.assignment.email(participant.id) rescue nil
+
+    # Notify all reviewers assigned to this reviewee
+    mail_assigned_reviewers(team)
+
     if params[:origin] == 'review'
       redirect_to :back
     else
       redirect_to action: 'edit', id: participant.id
+    end
+  end
+
+  def mail_assigned_reviewers(team)
+    maps = ResponseMap.where(reviewed_object_id: @participant.assignment.id, reviewee_id: team.id, type: 'ReviewResponseMap')
+    unless maps.nil?
+      maps.each do |map|
+        reviewer = User.find(Participant.find(map.reviewer_id).user_id)
+        Mailer.sync_message(
+          {
+            :to => reviewer.email,
+            subject:  "Assignment '#{@participant.assignment.name}': A submission has been updated since you last reviewed it",
+            cc: User.find_by(@participant.assignment.instructor_id).email,
+            :body => {
+              :obj_name => @participant.assignment.name,
+              :link => "https://expertiza.ncsu.edu/response/new?id=#{map.id}",
+              :type => 'submission',
+              :first_name => ApplicationHelper::get_user_first_name(User.find(Participant.find(map.reviewer_id).user_id)),
+              :partial_name => 'updated_submission_since_review'
+           }
+          }
+        ).deliver_now
+      end
     end
   end
 

--- a/app/mailers/mail_worker.rb
+++ b/app/mailers/mail_worker.rb
@@ -36,22 +36,15 @@ class MailWorker
   def email_reminder(emails, deadline_type)
     assignment = Assignment.find(self.assignment_id)
     subject = "Message regarding #{deadline_type} for assignment #{assignment.name}"
-    body = "This is a reminder to complete #{deadline_type} for assignment #{assignment.name}."
+    body = "This is a reminder to complete #{deadline_type} for assignment #{assignment.name}. \
+    Deadline is #{self.due_at}.If you have already done the  #{deadline_type}, Please ignore this mail."
 
     emails.each do |mail|
-      user = User.where({email: mail}).first
-      participant_assignment_id = Participant.where(user_id: user.id, parent_id: self.assignment_id).id
-
-      link_to_destination = "Please follow the lilnk: http://expertiza.ncsu.edu/student_task/view?id=#{participant_assignment_id}"
-      body = body + link_to_destination + " Deadline is #{self.due_at}.If you have already done the  #{deadline_type}, Please ignore this mail.";
-
-
-      @mail = Mailer.delayed_message(bcc: mail, subject: subject, body: body)
-      @mail.deliver_now
       Rails.logger.info mail
     end
 
-
+    @mail = Mailer.delayed_message(bcc: emails, subject: subject, body: body)
+    @mail.deliver_now
   end
 
   def find_participant_emails

--- a/app/mailers/mail_worker.rb
+++ b/app/mailers/mail_worker.rb
@@ -60,7 +60,7 @@ class MailWorker
 
   def find_participant_emails
     emails = []
-    participants = Participant.where(parent_id: self.assignment_id)
+    participants = Participant.includes(:user).where(parent_id: self.assignment_id)
     participants.each do |participant|
       emails << participant.user.email unless participant.user.nil?
     end

--- a/app/mailers/mail_worker.rb
+++ b/app/mailers/mail_worker.rb
@@ -60,7 +60,7 @@ class MailWorker
 
   def find_participant_emails
     emails = []
-    participants = Participant.includes(:user).where(parent_id: self.assignment_id)
+    participants = Participant.where(parent_id: self.assignment_id)
     participants.each do |participant|
       emails << participant.user.email unless participant.user.nil?
     end

--- a/app/mailers/mail_worker.rb
+++ b/app/mailers/mail_worker.rb
@@ -37,7 +37,7 @@ class MailWorker
     assignment = Assignment.find(self.assignment_id)
     subject = "Message regarding #{deadline_type} for assignment #{assignment.name}"
 
-    # Defining the body of mail
+    # Defining the body of mail 
     body = "This is a reminder to complete #{deadline_type} for assignment #{assignment.name}.\n"
 
     emails.each do |mail|

--- a/app/mailers/mail_worker.rb
+++ b/app/mailers/mail_worker.rb
@@ -36,15 +36,22 @@ class MailWorker
   def email_reminder(emails, deadline_type)
     assignment = Assignment.find(self.assignment_id)
     subject = "Message regarding #{deadline_type} for assignment #{assignment.name}"
-    body = "This is a reminder to complete #{deadline_type} for assignment #{assignment.name}. \
-    Deadline is #{self.due_at}.If you have already done the  #{deadline_type}, Please ignore this mail."
+    body = "This is a reminder to complete #{deadline_type} for assignment #{assignment.name}."
 
     emails.each do |mail|
+      user = User.where({email: mail}).first
+      participant_assignment_id = Participant.where(user_id: user.id, parent_id: self.assignment_id).id
+
+      link_to_destination = "Please follow the lilnk: http://expertiza.ncsu.edu/student_task/view?id=#{participant_assignment_id}"
+      body = body + link_to_destination + " Deadline is #{self.due_at}.If you have already done the  #{deadline_type}, Please ignore this mail.";
+
+
+      @mail = Mailer.delayed_message(bcc: mail, subject: subject, body: body)
+      @mail.deliver_now
       Rails.logger.info mail
     end
 
-    @mail = Mailer.delayed_message(bcc: emails, subject: subject, body: body)
-    @mail.deliver_now
+
   end
 
   def find_participant_emails

--- a/app/mailers/mailer.rb
+++ b/app/mailers/mailer.rb
@@ -54,6 +54,7 @@ class Mailer < ActionMailer::Base
     @body = defn[:body]
     @type = defn[:body][:type]
     @obj_name = defn[:body][:obj_name]
+    @link = defn[:body][:link]
     @first_name = defn[:body][:first_name]
     @partial_name = defn[:body][:partial_name]
 

--- a/app/mailers/mailer.rb
+++ b/app/mailers/mailer.rb
@@ -60,7 +60,6 @@ class Mailer < ActionMailer::Base
 
     defn[:to] = 'expertiza.development@gmail.com' if Rails.env.development? || Rails.env.test?
     mail(subject: defn[:subject],
-         # content_type: "text/html",
          to: defn[:to])
   end
 

--- a/app/models/participant.rb
+++ b/app/models/participant.rb
@@ -73,8 +73,7 @@ class Participant < ActiveRecord::Base
   # send email to team's reviewers in case a new submission is made
   def mail_assigned_reviewers
     # Find review mappings for the work done by this participant's team
-    mappings = ResponseMap.includes(reviewer: [:user]) # prefetch the reviewer, user for preparing the emails
-                          .where(reviewed_object_id: self.assignment.id,
+    mappings = ResponseMap.where(reviewed_object_id: self.assignment.id,
                                  reviewee_id: self.team.id,
                                  type: 'ReviewResponseMap')
     unless mappings.nil?

--- a/app/models/participant.rb
+++ b/app/models/participant.rb
@@ -71,9 +71,8 @@ class Participant < ActiveRecord::Base
   end
 
   # send email to team's reviewers in case a new submission is made
-  def mail_assigned_reviewers()
-    team = self.team
-    maps = ResponseMap.where(reviewed_object_id: self.assignment.id, reviewee_id: team.id, type: 'ReviewResponseMap')
+  def mail_assigned_reviewers
+    maps = ResponseMap.where(reviewed_object_id: self.assignment.id, reviewee_id: self.team.id, type: 'ReviewResponseMap')
     unless maps.nil?
       maps.each do |map|
         reviewer = User.find(Participant.find(map.reviewer_id).user_id)

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -291,29 +291,5 @@ class Team < ActiveRecord::Base
     team_user = TeamsUser.where(user_id: user_id).find { |team_user| team_user.team.parent_id == parent_id }
     team_user.destroy rescue nil
   end
-
-  # send email to team's reviewers in case a new submission is made
-  def self.mail_assigned_reviewers(participant)
-    team = participant.team
-    maps = ResponseMap.where(reviewed_object_id: participant.assignment.id, reviewee_id: team.id, type: 'ReviewResponseMap')
-    unless maps.nil?
-      maps.each do |map|
-        reviewer = User.find(Participant.find(map.reviewer_id).user_id)
-        Mailer.sync_message(
-            {
-                :to => reviewer.email,
-                subject:  "Assignment '#{participant.assignment.name}': A submission has been updated since you last reviewed it",
-                cc: User.find_by(participant.assignment.instructor_id).email,
-                :body => {
-                    :obj_name => participant.assignment.name,
-                    :link => "https://expertiza.ncsu.edu/response/new?id=#{map.id}",
-                    :type => 'submission',
-                    :first_name => ApplicationHelper::get_user_first_name(User.find(Participant.find(map.reviewer_id).user_id)),
-                    :partial_name => 'updated_submission_since_review'
-                }
-            }
-        ).deliver_now
-      end
-    end
-  end
+  
 end

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -291,4 +291,29 @@ class Team < ActiveRecord::Base
     team_user = TeamsUser.where(user_id: user_id).find { |team_user| team_user.team.parent_id == parent_id }
     team_user.destroy rescue nil
   end
+
+  # send email to team's reviewers in case a new submission is made
+  def self.mail_assigned_reviewers(participant)
+    team = participant.team
+    maps = ResponseMap.where(reviewed_object_id: participant.assignment.id, reviewee_id: team.id, type: 'ReviewResponseMap')
+    unless maps.nil?
+      maps.each do |map|
+        reviewer = User.find(Participant.find(map.reviewer_id).user_id)
+        Mailer.sync_message(
+            {
+                :to => reviewer.email,
+                subject:  "Assignment '#{participant.assignment.name}': A submission has been updated since you last reviewed it",
+                cc: User.find_by(participant.assignment.instructor_id).email,
+                :body => {
+                    :obj_name => participant.assignment.name,
+                    :link => "https://expertiza.ncsu.edu/response/new?id=#{map.id}",
+                    :type => 'submission',
+                    :first_name => ApplicationHelper::get_user_first_name(User.find(Participant.find(map.reviewer_id).user_id)),
+                    :partial_name => 'updated_submission_since_review'
+                }
+            }
+        ).deliver_now
+      end
+    end
+  end
 end

--- a/app/views/mailer/partials/_updated_submission_since_review_html.html.erb
+++ b/app/views/mailer/partials/_updated_submission_since_review_html.html.erb
@@ -1,0 +1,6 @@
+Hi <%= @first_name %>,</br>
+<p>
+  A <%=@type%> you were reviewing for Assignment '<%= @obj_name %>' has been updated since you last review.<br>
+  Hence, to update your review please click on the following link.<br>
+  <% if @link != nil %><a href="<%= @link %>"><%= @link %></a><% end %>
+</p>

--- a/app/views/mailer/partials/_updated_submission_since_review_plain.html.erb
+++ b/app/views/mailer/partials/_updated_submission_since_review_plain.html.erb
@@ -1,0 +1,5 @@
+Hi <%= @first_name %>,
+
+A <%=@type%> you were reviewing for Assignment '<%= @obj_name %>' has been updated since you last review.
+Hence, to update your review please click on the following link.
+<% if @link != nil %><%= @link %><% end %>

--- a/spec/features/assignment_submission_spec.rb
+++ b/spec/features/assignment_submission_spec.rb
@@ -136,4 +136,29 @@ describe "assignment submisstion test" do
     click_on 'Upload file'
     expect(page).to have_content "File type error"
   end
+
+  describe "notification of reviewers" do
+
+    it "does not notify the reviewer/s when no reviews have been submitted" do
+      signup_topic
+
+      attach_file('uploaded_file',
+                  Rails.root + "spec/features/assignment_submission_files/valid_assignment_file.jpg")
+
+      expect { click_on 'Upload file' }.to change { ActionMailer::Base.deliveries.count }.by(0)
+    end
+
+    it "notifies the reviewer/s who have reviewed the previous submission of the new submission" do
+      signup_topic
+
+      reviewer = AssignmentParticipant.find_by(user: User.find_by(name: "student2065")) # An arbitrary reviewer on the assignment
+      create(:review_response_map, reviewer: reviewer) # a reviewer submits a review for this team
+
+      attach_file('uploaded_file',
+                  Rails.root + "spec/features/assignment_submission_files/valid_assignment_file.jpg")
+
+      expect { click_on 'Upload file' }.to change { ActionMailer::Base.deliveries.count }.by(1)
+    end
+  end
+
 end

--- a/spec/models/mailer_spec.rb
+++ b/spec/models/mailer_spec.rb
@@ -17,4 +17,22 @@ describe 'Tests mailer' do
     expect(email.to[0]).to eq('expertiza.development@gmail.com')
     expect(email.subject).to eq('Test')
   end
+  it 'should correctly populate the template with the right partial ' do
+    # Send the email, then test that it got queued
+    email = Mailer.sync_message(
+      to: 'oigewe@ncsu.edu',
+      subject: "Test",
+      body: {
+        obj_name: 'assignment',
+        type: 'submission',
+        first_name: 'User',
+        partial_name: 'updated_submission_since_review'
+      }
+    ).deliver_now
+
+    expect(email.from[0]).to eq("expertiza.development@gmail.com")
+    expect(email.to[0]).to eq('expertiza.development@gmail.com')
+    expect(email.subject).to eq('Test')
+    # expect(email.body.to_s).to eq('asd') FIXME Not sure how to get the body of the email
+  end
 end

--- a/spec/models/mailer_spec.rb
+++ b/spec/models/mailer_spec.rb
@@ -17,22 +17,4 @@ describe 'Tests mailer' do
     expect(email.to[0]).to eq('expertiza.development@gmail.com')
     expect(email.subject).to eq('Test')
   end
-  it 'should correctly populate the template with the right partial ' do
-    # Send the email, then test that it got queued
-    email = Mailer.sync_message(
-      to: 'oigewe@ncsu.edu',
-      subject: "Test",
-      body: {
-        obj_name: 'assignment',
-        type: 'submission',
-        first_name: 'User',
-        partial_name: 'updated_submission_since_review'
-      }
-    ).deliver_now
-
-    expect(email.from[0]).to eq("expertiza.development@gmail.com")
-    expect(email.to[0]).to eq('expertiza.development@gmail.com')
-    expect(email.subject).to eq('Test')
-    # expect(email.body.to_s).to eq('asd') FIXME Not sure how to get the body of the email
-  end
 end

--- a/spec/models/participant_spec.rb
+++ b/spec/models/participant_spec.rb
@@ -8,6 +8,7 @@ describe Participant do
   let(:participant3) { build(:participant, can_review: false, user: build(:student, name: "King", fullname: "Titan, King", id: 3)) }
   let(:participant4) { Participant.new }
   let(:assignment) { build(:assignment, id: 1, name: 'no assgt') }
+  let(:participant5) { build(:participant, user: user, assignment: assignment) }
   let(:review_response_map) { build(:review_response_map, assignment: assignment, reviewer: participant, reviewee: team) }
   let(:answer) { Answer.new(answer: 1, comments: 'Answer text', question_id: 1) }
   let(:response) { build(:response, id: 1, map_id: 1, response_map: review_response_map, scores: [answer]) }
@@ -139,4 +140,18 @@ describe Participant do
       expect(Participant.sort_by_name(unsorted)).to eq(sorted)
     end
   end
+
+  describe 'check if email is being sent or not' do
+
+    it 'participants assignment reviewers are sent email for a new submission' do
+
+      allow(AssignmentTeam).to receive(:team).and_return(team)
+      allow(TeamsUser).to receive(:find_by).and_return(team_user)
+      allow(ResponseMap).to receive(:where).and_return([review_response_map])
+      expect { participant5.mail_assigned_reviewers }.to change { ActionMailer::Base.deliveries.count }.by(1)
+    end
+  end
+
+
 end
+

--- a/spec/workers/sidekiq_mail_worker_spec.rb
+++ b/spec/workers/sidekiq_mail_worker_spec.rb
@@ -7,20 +7,30 @@ describe MailWorker do
   before(:each) do
     allow(Assignment).to receive(:find).with('1').and_return(assignment)
     allow(Participant).to receive(:where).with(parent_id: '1').and_return([participant])
+    allow(User).to receive(:where).with(email: "psingh22@ncsu.edu").and_return([user])
+    allow(Participant).to receive(:find).with(user_id: '1', parent_id: '1').and_return([participant])
   end
 
   describe 'Tests mailer with sidekiq' do
-    it "should send email to required email address with proper content" do
-      Sidekiq::Testing.inline!
-      MailWorker.perform_async("1", "metareview", "2018-12-31 00:00:01")
+    it "should have sent welcome email after user was created" do
       email = ActionMailer::Base.deliveries.first
       expect(email.from[0]).to eq("expertiza.development@gmail.com")
-      # expect(email.bcc[0]).to eq(user.email)
       expect(email.to[0]).to eq("expertiza.development@gmail.com")
-      # expect(email.subject).to eq('Message regarding teammate review for assignment ' + assignment.name)
-      expect(email.subject).to eq('Your Expertiza account and password has been created')
+      expect(email.subject).to eq("Your Expertiza account and password has been created")
     end
 
+    it "should send reminder email to required email address with proper content" do
+      Sidekiq::Testing.inline!
+      ActionMailer::Base.deliveries.clear
+      worker = MailWorker.new
+      worker.perform("1", "metareview", "2018-12-31 00:00:01")
+      expect(ActionMailer::Base.deliveries.size).to eq(1)
+      email = ActionMailer::Base.deliveries.first
+      expect(email.from[0]).to eq("expertiza.development@gmail.com")
+      expect(email.bcc[0]).to eq("psingh22@ncsu.edu")
+      expect(email.subject).to eq("Message regarding teammate review for assignment no assignment")
+      expect(email.body).to eq("This is a reminder to complete teammate review for assignment no assignment.\nPlease follow the link: http://expertiza.ncsu.edu/student_task/view?id=1\nDeadline is 2018-12-31 00:00:01. If you have already done the teammate review, then please ignore this mail.")
+    end
 
     it "should expect the queue size of one" do
       Sidekiq::Testing.fake!


### PR DESCRIPTION
Issue #717: When students' accounts are created by importing a CSV file on the Users page, they receive e-mails with their user-ID and password. But if an account is created by adding them as participants to an assignment when they don't already have an account, e-mail is not sent. Students should receive e-mails upon account creation, regardless of how their account is created. So this involves adding a call to the e-mailer … or, perhaps, moving an email call from the Users controller to the point where an account is actually created. [Make sure emailer is running; if you have trouble, email expertiza-support@ncsu.edu.]

Issue #345: Second, evidently if a submission is revised after review, the system e-mails the reviewer saying to revise the review. This is just fine ... except if the last round of review has been completed. The message telling reviewers to revise their reviews should not be sent after the last review deadline has passed. It would also be nice to fix the message so it tells which review (Review 1, Review 2, etc.) has been revised, and gives the reviewer a link directly to it.

Issue #111: Deadline reminders should include a link on where to go to perform the needed function.

@arnavjulka @griffinbrookshire @reubenjohn

---
About Expertiza Bot
- If you have any questions about comments given by the expertiza-bot [(example)](https://github.com/expertiza/expertiza/pull/1877#issuecomment-762412918), you could create a comment in your pull request with the format `/dispute [UUID1] [UUID2]` [(example)](https://github.com/expertiza/expertiza/pull/1877#issuecomment-762430057) then the professor and TAs will be notified.
- [Here is a video](https://tinyurl.com/internet-bots) about how to communicate to expertiza-bot.
