### PR TITLE
E2159. Expertiza internationalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Expertiza
 =========
-
+ 
 [![Build Status](https://travis-ci.org/expertiza/expertiza.svg?branch=master)](https://travis-ci.org/expertiza/expertiza)
 [![Coverage Status](https://coveralls.io/repos/github/expertiza/expertiza/badge.svg?branch=master)](https://coveralls.io/github/expertiza/expertiza?branch=master)
 [![Maintainability](https://api.codeclimate.com/v1/badges/f3a41f16c2b6e45aa9d4/maintainability)](https://codeclimate.com/github/expertiza/expertiza/maintainability)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -23,11 +23,9 @@ class ApplicationController < ActionController::Base
       if @current_user.locale != "no_pref"
         I18n.locale = @current_user.locale
       elsif params[:controller] == "courses" && params[:id]
-        course = Course.find(params[:id])
-        I18n.locale = course.get_locale
+        I18n.locale = Course.get_locale(params[:id])
       elsif params[:controller] == "assignments" && params[:id]
-        assignment = Assignment.find(params[:id])
-        I18n.locale = assignment.get_locale
+        I18n.locale = Assignment.get_locale(id)
       else
         I18n.locale = I18n.default_locale
       end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,6 +16,23 @@ class ApplicationController < ActionController::Base
   before_action :set_time_zone
   before_action :authorize
   before_action :filter_utf8
+  before_action :set_locale
+
+  def set_locale
+    if logged_in?
+      if @current_user.locale != "no_pref"
+        I18n.locale = @current_user.locale
+      elsif params[:controller] == "courses" && params[:id]
+        course = Course.find(params[:id])
+        I18n.locale = course.get_locale
+      elsif params[:controller] == "assignments" && params[:id]
+        assignment = Assignment.find(params[:id])
+        I18n.locale = assignment.get_locale
+      else
+        I18n.locale = I18n.default_locale
+      end
+    end
+  end
 
   def filter_utf8
     remove_non_utf8(params)

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -7,7 +7,8 @@
 # change access permission from public to private or vice versa
 class CoursesController < ApplicationController
   include AuthorizationHelper
-  
+  before_action :set_language_choices
+
   autocomplete :user, :name
   require 'fileutils'
 
@@ -162,5 +163,16 @@ class CoursesController < ApplicationController
     @course.directory_path = params[:course][:directory_path]
     @course.info = params[:course][:info]
     @course.private = params[:course][:private].nil? ? 0 : params[:course][:private]
+    @course.locale = params[:course][:locale]
+  end
+
+  private
+
+  def set_language_choices
+    # Set the available languages
+    @languages = [%w[English en_US], %w[Hindi hi_IN]]
+
+    # Set the default language
+    @default_language = %w[English en_US]
   end
 end

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -581,7 +581,8 @@ class Assignment < ActiveRecord::Base
   end
 
   # Get locale value
-  def get_locale
+  def get_locale(id)
+    assignment = Assignment.find(id)
     self.course.locale
   end
 

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -580,6 +580,11 @@ class Assignment < ActiveRecord::Base
     questionnaire_ids
   end
 
+  # Get locale value
+  def get_locale
+    self.course.locale
+  end
+
   private
 
   #returns true if assignment has staggered deadline and topic_id is nil

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -69,9 +69,10 @@ class Course < ActiveRecord::Base
     end
   end
 
-  # Get locale value
-  def get_locale
-    self.locale
+  # Get course's locale value
+  def get_locale(id)
+    course = Course.find(:id)
+    course.locale
   end
 
   require 'analytic/course_analytic'

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -1,4 +1,8 @@
 class Course < ActiveRecord::Base
+  enum locale: {
+      en_US: 1,
+      hi_IN: 2
+  }
   has_many :ta_mappings, dependent: :destroy
   has_many :tas, through: :ta_mappings
   has_many :assignments, dependent: :destroy
@@ -63,6 +67,11 @@ class Course < ActiveRecord::Base
       end
       raise error_msg
     end
+  end
+
+  # Get locale value
+  def get_locale
+    self.locale
   end
 
   require 'analytic/course_analytic'

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,9 @@
 class User < ActiveRecord::Base
+  enum locale: {
+      no_pref: 0,
+      en_US: 1,
+      hi_IN: 2
+  }
   acts_as_authentic do |config|
     config.validates_uniqueness_of_email_field_options = {if: -> { false }} # Don't validate email uniqueness
     config.crypto_provider = Authlogic::CryptoProviders::Sha1

--- a/app/views/assignments/edit.html.erb
+++ b/app/views/assignments/edit.html.erb
@@ -1,4 +1,4 @@
-<h1>Editing Assignment: <%=@assignment_form.assignment.name%></h1>
+<h1><%=t ".editing_assignment" %>: <%=@assignment_form.assignment.name%></h1>
 
 
   <%= form_for @assignment_form.assignment, html: { id: 'assignment_form' } do %>

--- a/app/views/courses/_course.html.erb
+++ b/app/views/courses/_course.html.erb
@@ -12,5 +12,7 @@
 <p><label for="course_info">Course Information</label><br/>
 <%= text_field 'course', 'info'  %></p>
 
+<p><label>Default Language</label><br/>
+  <%= select("course", "locale", @languages, {:selected => @course ? @course.locale : @default_language}) %></p>
 <!--[eoform:user]-->
 <br/>

--- a/app/views/courses/edit.html.erb
+++ b/app/views/courses/edit.html.erb
@@ -1,4 +1,4 @@
-<h1>Edit Course</h1>
+<h1><%=t ".edit_course"%></h1>
 
 <%= form_for @course do %>
   <%= render :partial => 'course' %>

--- a/app/views/profile/edit.html.erb
+++ b/app/views/profile/edit.html.erb
@@ -21,7 +21,9 @@
     <%= render :partial => 'limit' %>
   <% end %>
   <p class="form-inline"><label class="width-266">Preferred Time Zone: </label>
-  <%= time_zone_select("user", "timezonepref", ActiveSupport::TimeZone.all,{}, {:class => 'form-control width-250'})%></p>
+    <%= time_zone_select("user", "timezonepref", ActiveSupport::TimeZone.all,{}, {:class => 'form-control width-250'})%></p>
+  <p class="form-inline"><label class="width-266">Preferred Language: </label>
+    <%= f.select :locale, [["No preference", "no_pref"], ["English","en_US"], ["Hindi","hi_IN"]] ,{:selected => @user.locale}, {:class => 'form-control width-250'}%></p>
 
   <%= f.submit 'Save', class: "btn btn-default btn-md" %>
 </table>

--- a/app/views/student_task/_publishing_rights.html.erb
+++ b/app/views/student_task/_publishing_rights.html.erb
@@ -1,5 +1,5 @@
 <br/>
-<div class="flash_note">Select an assignment from the list
-  or set <strong><%= link_to 'publishing rights', :controller => 'publishing', :action => 'view' %></strong> for your work.
+<div class="flash_note"><%=t ".select_assignment" %>
+  <strong><%= link_to t('.publishing_rights'), :controller => 'publishing', :action => 'view' %></strong> <%=t ".for_work" %>
 </div>
 <br/>

--- a/app/views/student_task/list.html.erb
+++ b/app/views/student_task/list.html.erb
@@ -3,7 +3,7 @@
 
 <div style="">
   <div class="taskbox" style="width:18%; display: inline; float:left; margin-right: 10px;" >
-    <strong>&nbsp;&nbsp;<span class="tasknum">&nbsp;<%= @tasknotstarted.size.to_s %>&nbsp;</span> Tasks not yet started<br></strong><br>
+    <strong>&nbsp;&nbsp;<span class="tasknum">&nbsp;<%= @tasknotstarted.size.to_s %>&nbsp;</span> <%=t ".tasks_not_started" %><br></strong><br>
 
     <% @tasknotstarted.each do |student_task|
       participant = student_task.participant
@@ -40,11 +40,11 @@
 
     <span>&nbsp; &raquo;
       <%= link_to student_task.assignment.name + " " + student_task.current_stage, :controller => controller, :action => action, :id => participant.id %>
-      (<%= student_task.relative_deadline %> left)
+      (<%= student_task.relative_deadline %> <%=t ".left" %>)
     </span><br/>
   <% end %>
 
-  <br/> <strong> &nbsp;&nbsp;<span class="revnum">&nbsp;<%= @taskrevisions.size.to_s %>&nbsp;</span> Revisions<br></strong><br>
+  <br/> <strong> &nbsp;&nbsp;<span class="revnum">&nbsp;<%= @taskrevisions.size.to_s %>&nbsp;</span> <%=t ".revisions" %><br></strong><br>
   <% @taskrevisions.each do |student_task|
     participant = student_task.participant
     stage = student_task.current_stage
@@ -67,12 +67,12 @@
 <% end %>
 <br/>
 
-<strong>Students who have teamed with you<br></strong><br>
+<strong><%=t ".student_team" %><br></strong><br>
 
 <% @students_teamed_with.keys.each do |course_id| %>
     <strong>&nbsp;&nbsp;<span class="tasknum">&nbsp;<%= @students_teamed_with[course_id].size.to_s %>&nbsp;</span>
       <%if course_id.nil?%>
-        assignments not associated with any course
+        <%=t ".not_associated" %>
       <%else%>
         <%=  Course.find(course_id).name %>
       <%end%>
@@ -87,14 +87,14 @@
 <div class="topictable" style="float: left;width: 80%;margin-bottom: 10px; display: inline; ">  
  <table class="table table-striped" cellpadding="2">
     <tr class="taskheader">
-      <th>Assignment</th>
-      <th>Course</th>
-      <th>Topic</th>
-      <th>Current Stage</th>
-      <th>Review Grade</th>
-      <th>Badges</th>
-      <th>Stage Deadline <img src="/assets/info.png" title="You can change 'Preferred Time Zone' in 'Profile' in the banner."/></th>
-      <th>Publishing Rights <img src="/assets/info.png" title="Grant publishing rights"/></th>
+      <th><%=t ".assignment_name" %></th>
+      <th><%=t ".course" %></th>
+      <th><%=t ".topic" %></th>
+      <th><%=t ".current_stage" %></th>
+      <th><%=t ".review_grade" %></th>
+      <th><%=t ".badges" %></th>
+      <th><%=t ".stage_deadline" %><img src="/assets/info.png" title="You can change 'Preferred Time Zone' in 'Profile' in the banner."/></th>
+      <th><%=t ".publishing_rights" %><img src="/assets/info.png" title="Grant publishing rights"/></th>
     </tr>
     <% @student_tasks.each do |student_task| %>
       <% participant = student_task.participant %>

--- a/app/views/student_task/list.html.erb
+++ b/app/views/student_task/list.html.erb
@@ -1,4 +1,4 @@
-<h1>Assignments</h1>
+<h1><%=t ".assignments" %></h1>
 
 
 <div style="">

--- a/app/views/student_task/view.html.erb
+++ b/app/views/student_task/view.html.erb
@@ -2,33 +2,33 @@
 
 <h1>
   <% if @assignment.spec_location == nil|| @assignment.spec_location.length==0%>
-      Submit or Review work for <%= @assignment.name %>
+    <%=t ".submit_review" %> <%= @assignment.name %>
   <% else %>
-      Submit or Review work for <%= link_to @assignment.name, @assignment.spec_location %>
+    <%=t ".submit_review" %> <%= link_to @assignment.name, @assignment.spec_location %>
   <% end %>
 
 </h1>
 
 <div class="flash_note">
-  Next: Click the activity you wish to perform on the assignment titled: <%= @assignment.name %>
+  <%=t ".next_click" %> <%= @assignment.name %>
 </div>
 <% if @assignment.spec_location && @assignment.spec_location.length > 0 %>
-  <a href="<%= @assignment.spec_location %>" target="new">Assignment Description</a>
+  <a href="<%= @assignment.spec_location %>" target="new"><%=t ".assignment_description" %></a>
 <% end %>
 <ul>
   <%if @topics.size > 0 %>
     <% if @authorization == 'participant' || @authorization == 'submitter' %>
       <li>
-        <%= link_to 'Signup sheet', :controller=>'sign_up_sheet', :action => 'list', :id => @participant.id%>
-        (Sign up for a topic)
+        <%= link_to t('.signup_sheet'), :controller=>'sign_up_sheet', :action => 'list', :id => @participant.id%>
+        <%=t ".signup_topic" %>
       </li>
       <!--Show bookmarks if they are allowed for this assignment-->
       <% if @use_bookmark %>
         <li>
             <% if @topic_id and @assignment.submission_allowed(@topic_id) %>
-              <%= link_to "View bookmarks", :controller=>'bookmarks', :action=> 'list', :id => @topic_id %> (View bookmarks others have submitted for your topic)
+              <%= link_to "View bookmarks", :controller=>'bookmarks', :action=> 'list', :id => @topic_id %> <%=t ".view_bookmarks_lengthy" %>
             <% else %>
-              <font color="gray">View bookmarks</font> (You have to choose a topic first)
+              <font color="gray"><%=t ".view_bookmarks" %></font><%=t ".choose_topic" %>
             <% end %>
         </li>
       <% end %>
@@ -40,8 +40,8 @@ to display the label "Your team" in the student assignment tasks-->
   <%if @assignment.max_team_size > 1 %>
     <% if @authorization == 'participant' %>
       <li>
-        <%= link_to 'Your team', view_student_teams_path(student_id: @participant.id) %>
-        (View and manage your team)
+        <%= link_to t('.your_team'), view_student_teams_path(student_id: @participant.id) %>
+        <%=t ".view_team" %>
       </li>
     <% end %>
   <%end%>
@@ -51,16 +51,16 @@ to display the label "Your team" in the student assignment tasks-->
     <li>
       <% if @topics.size > 0 %>
         <% if @topic_id and @assignment.submission_allowed(@topic_id) %>
-          <%= link_to 'Your work', :controller => 'submitted_content', :action => 'edit', :id => @participant.id %> (Submit and view your work)
+          <%= link_to t(".your_work"), :controller => 'submitted_content', :action => 'edit', :id => @participant.id %> <%=t ".submit_work" %>
         <% else %>
           <!--if one team do not hold a topic (still in waitlist), they cannot submit their work.-->
-          <font color="gray">Your work</font> (You have to choose a topic first)
+          <font color="gray"><%=t ".your_work" %></font> <%=t ".choose_topic" %>
         <% end %>
       <% else %>
         <% if @assignment.submission_allowed(@topic_id) %>
-          <%= link_to 'Your work', :controller => 'submitted_content', :action => 'edit', :id => @participant.id %> (Submit and view your work)
+          <%= link_to t(".your_work"), :controller => 'submitted_content', :action => 'edit', :id => @participant.id %> <%=t ".submit_work" %>
         <% else %>
-          <font color="gray">Your work</font> (You are not allowed to submit your work right now)
+          <font color="gray"><%=t ".your_work" %></font> <%=t ".not_allowed" %>
         <% end %>
       <% end %>
     </li>
@@ -70,9 +70,9 @@ to display the label "Your team" in the student assignment tasks-->
     <li>
       <!--alias_name means if one participant is a reader, it will show 'Your readings' to see others' work; if one participant is not a reader, it will show 'Others' work' on the screen.-->
       <% if @authorization != 'reader' %>
-        <% @alias_name = "Others' work" %>
+        <% @alias_name = t(".others_work") %>
       <% else %>
-        <% @alias_name = "Your readings" %>
+        <% @alias_name = t(".your_readings") %>
       <% end %>
       <!--Zhewei: professor mentioned that a submission is reviewable if the submission is in a stage where reviews can be done. It does not depend on the stage of the topic the reviewer is writing on-->
       <!--Akshay: Fix Issue 1218 - this link is disabled if assignment does not require any peer reviews-->
@@ -83,7 +83,7 @@ to display the label "Your team" in the student assignment tasks-->
       <% else %>
         <font color="gray"><%= @alias_name%></font>
       <% end %>
-      (Give feedback to others on their work)
+      <%=t ".give_feedback" %>
     </li>
   <% end %>
 
@@ -92,11 +92,11 @@ to display the label "Your team" in the student assignment tasks-->
     <% if @authorization == 'participant' or @can_take_quiz == true %>
       <li>
         <% if @assignment.require_quiz and (@assignment.quiz_allowed(@topic_id) or @assignment.current_stage(@topic_id) == "Finished") %>
-          <%= link_to "Take quizzes", student_quizzes_path(:id => @participant.id) %>
+          <%= link_to t(".take_quizzes"), student_quizzes_path(:id => @participant.id) %>
         <% else %>
-          <font color="gray">Take quizzes</font>
+          <font color="gray"><%=t ".take_quizzes" %></font>
         <% end %>
-        (Take quizzes over the work you have read)
+        <%=t ".quizzes_read" %>
       </li>
     <% end %>
   <%end%>
@@ -105,22 +105,22 @@ to display the label "Your team" in the student assignment tasks-->
     <li>
       <!--Only if the assignment supports self-review and students submitted self-review can he or she view scores.-->
       <% if @assignment.is_selfreview_enabled and unsubmitted_self_review?(@participant.id) %>
-        <font color="gray">Your scores</font> (You have to submit self-review under 'Your work' before checking 'Your scores'.)
+        <font color="gray"><%=t ".your_scores" %></font> <%=t ".self_review" %>
       <% else %>
-        <%= link_to "Your scores", controller: 'grades', action: 'view_team', id: @participant.id %>
-        (View feedback on your work)  &nbsp;  <%= link_to "Alternate View",  controller: 'grades', action: 'view_my_scores', id: @participant.id %>
+        <%= link_to t(".your_scores"), controller: 'grades', action: 'view_team', id: @participant.id %>
+        <%=t ".view_feedback" %>  &nbsp;  <%= link_to t(".alternate_view"),  controller: 'grades', action: 'view_my_scores', id: @participant.id %>
       <% end %>
     </li>
   <% end %>
     <%if @can_provide_suggestions == true %>
-      <li><%= link_to "Suggest a topic",{:controller => 'suggestion', :action => 'new', :id => @assignment.id} %></li>
+      <li><%= link_to t(".suggest_topic"),{:controller => 'suggestion', :action => 'new', :id => @assignment.id} %></li>
     <% end %>
 
     <% if @assignment.current_stage(@topic_id) == "Complete" %>
       <!-- removed code for survey assignment add in line above && SurveyHelper::is_user_eligible_for_survey?	(@assignment.id, session[:user].id)  -->
-      <li><%= link_to "Take a survey",{:controller => 'survey_response', :action => 'begin_survey', :id => @assignment.id} %> (This will log you out)</li>
+      <li><%= link_to t(".take_survey"),{:controller => 'survey_response', :action => 'begin_survey', :id => @assignment.id} %> <%=t ".log_you_out" %></li>
     <% end %>
-    <li><%= link_to "Change your handle", {:controller => 'participants', :action => 'change_handle', :id => @participant.id} %> (Provide a different handle for this assignment)</li>
+    <li><%= link_to t(".change_handle"), {:controller => 'participants', :action => 'change_handle', :id => @participant.id} %> <%=t ".different_handle" %></li>
   </ul>
   <br>
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -55,7 +55,10 @@ module Expertiza
 
       # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
       # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
-      # config.i18n.default_locale = :de
+
+      # Languages for the application
+      config.i18n.available_locales = [:en_US, :hi_IN]
+      config.i18n.default_locale = :en_US # english
 
       # Do not swallow errors in after_commit/after_rollback callbacks.
       config.active_record.raise_in_transactional_callbacks = true

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,5 +1,0 @@
-# Sample localization file for English. Add more files in this directory for other locales.
-# See http://github.com/svenfuchs/rails-i18n/tree/master/rails%2Flocale for starting points.
-
-en:
-  hello: "Hello world"

--- a/config/locales/en_US.yml
+++ b/config/locales/en_US.yml
@@ -1,10 +1,504 @@
+# Sample localization file for English. Add more files in this directory for other locales.
+# See http://github.com/svenfuchs/rails-i18n/tree/master/rails%2Flocale for starting points.
+
 en_US:
+  # This section of keys are for the pages related to Courses
+  course:
+
+    edit:
+      course_title: "Edit course"
+
+    course:
+      institute_name: "Institution Name"
+      course_name: "Course Name"
+      course_directory: "Course Directory"
+      directory_warning: "(Mandatory field. No space or special chars.)"
+      course_info: "Course Information"
+      language: "Select language"
+      assignment_name: "Assignment Name"
+
+    view_teaching_assistants:
+      teaching_assistants: "Teaching Assistants"
+      course: "Course"
+      teaching_assistant_name: "Teaching Assistant Name"
+
+    add_individual:
+      enter_user_login: "Enter a user login:"
+      add_ta: "Add TA"
+
+  participant:
+    list:
+      participants: "Participants:"
+
+  shared_scripts:
+    user_list:
+      email: "E-mail on ..."
+      permissions: "Permissions ..."
+      name: "Name"
+      full_name: "Full Name"
+      email_address: "Email Address"
+      role: "Role"
+      parent: "Parent"
+      badges: "Badges"
+      review: "Review"
+      submissions: "Submissions"
+      metareview: "Metareview"
+      submit: "Submit"
+      take_quiz: "Take quiz"
+      handle: "Handle"
+      action: "Action"
+
+    add_individual:
+      enter_login: "Enter a user login:"
+      add: "Add"
+      participant: "participant"
+      reader: "reader"
+      reviewer: "reviewer"
+      submitter: "submitter"
+
+  teams:
+    list:
+      teams_for: "Teams for"
+      teams: "Teams"
+      students_without_team: "Students without teams"
+      name: "name"
+      show_members: "Show all team members"
+
+    new:
+      create_teams_for: "Create Teams for"
+      automatically: "Automatically"
+      uses_insofar: "Uses, insofar as possible, the number of members specified when the assignment was created."
+      team_size: "Team Size:"
+      create_teams: "Create Teams"
+      manually: "Manually"
+      specify_team_them: "Specify Team name, then add members to team, one by one."
+      inherit_teams: "Inherent Teams From Course"
+      use_the_teams: "Use the teams that are currently defined for the course."
+      team_name: "Team Name"
+
+  assignment:
+    new:
+      create_new: "Create New"
+      public: "Public"
+      private: "Private"
+      assignment: "Assignment"
+      general: "General"
+      rubrics: "Rubrics"
+      review_strategy: "Review strategy"
+      due_date: "Due date"
+      create_button: "Create"
+
+
+    edit:
+      general:
+        assignment_name: "Assignment name:"
+        course: "Course"
+        submission_directory: "Submission directory"
+        mandatory_field: "(Mandatory field. No space or special char.)"
+        description_url: "Description URL"
+        calibration: "Calibration"
+        has_team: "Has teams?"
+        has_quiz: "Has quiz?"
+        has_badge: "Has badge?"
+        staggered_deadline: "Staggered deadline assignment?"
+        mico_task: "Micro Task Assignment?"
+        review_reviewers: "Reviews visible to all other reviewers?"
+        calibrate_training: "Calibration for training?"
+        reputation_algorithm: "Reputation Alogorithm?"
+        use_simicheck: "Use simicheck?"
+        allow_feedback: "Allow feedback comments to be tagged by the author?"
+        available: "Available to students?"
+
+      rubrics:
+        review_varies: "Review varies by round?"
+        questionaire: "Questionaire"
+        use_dropdown: "Use dropdown"
+        instead: "instead?"
+        scored_question: "Scored-question"
+        display_style: "display style"
+        weight: "Weight"
+        notification_limit: "Notification Limit"
+        author_feedback: "Author Feedback"
+        review: "Review"
+
+      review_strategy:
+        review_strategy: "Review Strategy:"
+        review_topic: "Review topic Threshold (k):"
+        max_num_reviews: "Maximum number of reviews per submission:"
+        max_review_limit: "Has Max Review Limit?"
+        set_num_reviews: "Set Allowed Number of Reviews per reviewer"
+        set req_reviews: "Set Required Number of Reviews per reviewer"
+        meta_review: "Has Meta Review Limit?"
+        set_num_meta: "Set Allowed Number of MetaReviews per reviewer"
+        set_req_meta: "Set Required Number of MetaReviews per reviewer"
+        anon_review: "Is Anonymous Review?"
+        self_review: "Allow self reviews?"
+
+      due_dates:
+        num_review_rounds: "Number of review rounds:"
+        timezone: "Timezone : "
+        meta_deadline: "Use metareview deadline"
+        show_hide: "Show/Hide Date Updater"
+        deadline_type: "Deadline Type"
+        date_time: "Date & Time"
+        use_updater: "Use Date Updater"
+        submission_allowed: "Submission allowed"
+        review_allowed: "Review allowed"
+        teammate_review: "Teammate review allowed"
+        meta_allowed: "Meta-review allowed"
+        has_quiz: "Has quiz"
+        reminder: "Reminder(hrs)"
+        due_date_names: "Due date name"
+        description_url: "Description URL"
+        round: "Round"
+
+      late_policy:
+        apply_penalty: "Apply penalty policy:"
+        late_policty: "New late policty"
+
+      calibration:
+        particpant_name: "Participant name"
+        action: "Action"
+        submitted_item: "Submitted item(s)"
+        submit_calibration: "Submit reviews for calibrations"
+
+  # end of keys for pages related to Courses
+
+  # keys for pages Student Views
   student_task:
     list:
       assignments: "Assignments"
-  assignments:
+      tasks_not_started: "Tasks not yet started"
+      revisions: "Revisions"
+      student_team: "Students who have teamed with you"
+      not_associated: "assignments not associated with any course"
+      assignment_name: "Assignment"
+      course: "Course"
+      topic: "Topic"
+      current_stage: "Current Stage"
+      review_grade: "Review Grade"
+      badges: "Badges"
+      stage_deadline: "Stage Deadline"
+      publishing_rights: "Publishing Rights"
+      left: "left"
+
+    publishing_rights:
+      select_assignment: "Select an assignment from the list or set"
+      publishing_rights: "publishing rights"
+      for_work: "for your work."
+
+    view:
+      submit_review: "Submit or Review work for"
+      next_click: "Next: Click the activity you wish to perform on the assignment titled:"
+      assignment_description: "Assignment Description"
+      signup_sheet: "Signup sheet"
+      signup_topic: "(Sign up for a topic)"
+      view_bookmarks: "View bookmarks"
+      view_bookmarks_lengthy: "(View bookmarks others have submitted for your topic)"
+      your_team: "Your team"
+      view_team: "(View and manage your team)"
+      submit_work: "(Submit and view your work)"
+      your_work: "Your work"
+      others_work: "Others' work"
+      your_readings: "Your readings"
+      choose_topic: "(You have to choose a topic first)"
+      not_allowed: "(You are not allowed to submit you work right now)"
+      give_feedback: "(Give feedback to others on their work)"
+      take_quizzes: "Take quizzes"
+      quizzes_read: "(Take quizzes over the work you have read)"
+      your_scores: "Your scores"
+      alternate_view: "Alternate View"
+      view_feedback: "(View feedback on your work)"
+      suggest_topic: "Suggest a topic"
+      take_survey: "Take a survey"
+      change_handle: "Change your handle"
+      self_review: "(You have to submit self-review under 'Your work' before checking 'Your scores'.)"
+      log_you_out: "(This will log you out)"
+      different_handle: "(Provide a different handle for this assignment)"
+      back: "Back"
+
+  sign_up_sheet:
+    list:
+      signup_sheet: "Signup sheet for"
+      assignment_lower: "assignment"
+      your_topics: "Your topic(s):"
+      waitlisted: "(waitlisted)"
+      back: "Back"
+
+    table_header:
+      topic_num: "Topic #"
+      topic_name: "Topic name(s)"
+      micro_payment: "Micro- payment"
+      num_slots: "Num. of slots"
+      available_slots: "Available slots"
+      num_waitlist: "Num. on waitlist"
+      bookmarks: "Bookmarks"
+      actions: "Actions"
+      advertise: "Advertise- ment(s)"
+
+    suggested_topic:
+      approved_suggestion: "Your approved suggested topic"
+
+  student_teams:
     edit:
-      editing_assignment: "Editing Assignment"
-  courses:
+      edit_team: "Edit Team"
+      team_name: "Team Name:"
+      back: "Back"
+
+    view:
+      team_info: "Team Information for"
+      no_team: "You no longer have a team!"
+      name_team: "Name team"
+      team_name: "Team name:"
+      team_name_up: "Team Name:"
+      team_members: "Team members"
+      username: "Username"
+      fullname: "Full name"
+      email_address: "Email address"
+      review_action: "Review action"
+      send_invite: "Send invitations"
+      status: "Status"
+      accepted: "Accepted"
+      declined: "Declined"
+      wait_reply: "Waiting for replay"
+      invite_people: "Invite people"
+      enter_user: "Enter user login: "
+      users_waiting: "Users waiting for this topic:"
+      user_id: "User id"
+      email: "Email"
+      received_invitation: "Received Invitations"
+      from: "From"
+      team_name_no_colon: "Team Name"
+      reply: "Reply"
+      ad_for_team: "Advertisement for teammates"
+      back: "Back"
+
+  submitted_content:
     edit:
-      edit_course: "Edit Course"
+      back: "Back"
+
+    title:
+      submit_work: "Submit work for"
+
+    self_review:
+      self_review: "Self Review:"
+      work_not_submitted: "(Work has not yet been submitted)"
+
+    hyperlink:
+      hyperlink_action: "Hyperlink Actions:"
+      hide_link: "hide links"
+
+    main:
+      submit_hyperlink: "Submit a hyperlink:"
+      quiz: "Quiz:"
+      view_quiz: "View quiz"
+      edit_quiz: "Edit quiz"
+
+    submitted_files:
+      submit_file: "Submit a file:"
+      or: "or"
+
+  student_review:
+    list:
+      reviews_for: "Reviews for"
+      your_instructor_expects: "Your instructor expects you to do"
+      you_are_not_allowed: "You are not allowed to do any extra reviews."
+      perform_exactly: "You should perform exactly"
+      may_perform_between_1: "You may perform between"
+      may_perform_between_2: "and"
+      required_to_do: "You are required to do"
+      reviews: "reviews."
+      num_reviews_left: "Number of reviews left:"
+      note1: "Note: You can't have more than 2 outstanding reviews. You must complete one of your outstanding reviews before selecting another."
+      note2_1: "Note: You can't do more than"
+      note2_2: "reviews according to assignment policy."
+      reviews_cannot: "Reviews cannot be performed at this time"
+      metareviews_for: "Metareviews for"
+      metareviews_allowed: "Number of Meta-Reviews Allowed:"
+      metareviews: "meta-reviews"
+      metareviews_left: "Number of Meta-Reviews left:"
+      back: "Back"
+
+    responses:
+      view: "View"
+      edit: "Edit"
+      update: "Update"
+      latest_update_at: "  -- latest update at"
+      begin: "Begin"
+      show_calibration_results: "Show calibration results"
+      review_done_at: "Review done at --"
+      no_previous_available: "No previous versions available"
+
+    set_dynamic_review:
+      i_don't_care: "I don't care which topic I review."
+      select_topic: "Select a topic below to begin a new review:"
+      request_new_submission: "Request a new submission to review"
+
+    set_dynamic_metareview:
+      request_new_metareview: "Request a new metareview to perform"
+
+  grades:
+    view_my_scores:
+      score_for: "Score for"
+      reputation: "Reputation"
+      back: "Back"
+
+    view_team:
+      summary_report: "Summary Report for assignment:"
+      team: "Team:"
+      topic: "Topic:"
+      average_peer_review: "Average peer review score:"
+      show_submission: "Show Submission"
+      no_submission: "No Submission"
+      question: "Question"
+      toggle_question_list: "toggle question list"
+      hide_tags: "hide tags"
+      color_legend: "color legend"
+      interaction_legend: "interaction legend"
+      criterion: "Criterion"
+      metric1: "metric-1"
+      review: "Review"
+      score: "Score"
+      comment: "Comment"
+      additional_comments: "Additional Comments"
+      no_review_of: "NO REVIEW OF"
+      type_exists: "TYPE EXISTS"
+      grade_and_comment: "Grade and comment for submission"
+      grade: "Grade:"
+      comment2: "Comment:"
+
+    participant_charts:
+      hide_stats: "hide stats"
+      stats: "Stats"
+
+    participant:
+      show_submission: "show submission"
+
+    participant_title:
+      submitted_work: "Submitted work"
+      reviewing: "Reviewing"
+      author_feedback: "Author Feedback"
+      teammate_review: "Teammate Review"
+      contributor: "Contributor"
+      average: "Average"
+      range: "Range"
+      final_score: "Final Score"
+
+
+  participants:
+    change_handle:
+      create_or_change: "Create or Change Handle for Current Assignment"
+      your: "Your"
+      handle: "handle"
+      is_the_way: "is the way you will be known to your reviewers."
+      for_example: "For example, if you are writing on a wiki, you might not want to use your Expertiza user-ID to show up on the wiki, because then your reviewers would know who they are reviewing. So, you are allowed to set up a handle instead. If you have a handle, then your wiki account is named after your handle, and your reviewers see your handle, but not your user-ID."
+      if_you_do_not: "If you do not have a handle, your user-ID will be used instead."
+      two_ways: "You can set up a handle in two ways:"
+      handle_for: "You can set up a handle for"
+      only_this_assignment: "only this assignment"
+      by_entering: "by entering a handle below."
+      you_can_set_up_default: "You can set up a \"default\" handle by editing your"
+      note_that: "Note that if you change your handle by editing your"
+      your_new_handle: "your new handle will be used for all"
+      future: "future"
+      assignments_if: "assignments; if you want the change to apply to this assignment too, you must also change it below."
+      change_handle: "Change handle"
+      for_current: "for current assignment"
+      warning: "Warning:"
+      you_must: "You must have a wiki account named after your handle.  If you do not, please e-mail your instructor or the course staff."
+      back: "Back"
+
+  popup:
+    self_review_popup:
+      no_review_done: " No review has been done yet"
+      reviewer_score: " Reviewer's score "
+      self_review_of: " self review "
+      question: " Question "
+      score: "Score"
+      comments: "Comments"
+      other_reviewer_score: "Reviewer Score (Σ weighted score/Σ weighted available score)"
+      additional_comments: "Additional comments"
+      no_comments: "No comments"
+
+  student_quizzes:
+    index:
+      quiz_for: "Quiz for"
+      assignment_not_support: "This assignment does not support quizzes"
+
+    responses:
+      work_not_submit: "Work has not been submitted yet"
+      begin: "Begin"
+
+    set_dynamic_quiz:
+      select_topic: "Select a topic below to take a new quiz"
+      request_new_quiz: "Request for a new quiz"
+
+    finished_quiz:
+      answers: "Answers"
+      quiz_score: "Quiz score: "
+
+    review_questions:
+      quiz_listings: " Listing of all quiz questions for : "
+      quiz_create: " Quiz created by: "
+      topic: " Topic: "
+      quiz_taker: "Quiz taker"
+      quiz_score: "Quiz score"
+      avg_score: "Average score for quiz takers: "
+
+    take_quiz:
+      questions: "Questions"
+      submit_quiz: "Submit Quiz"
+
+  profile:
+    edit:
+      user_profile_info: "User Profile Information"
+      password_msg: "If password field is blank, the password will not be updated"
+      preferred_time_zone: "Preferred time zone "
+      save: "Save"
+
+    handle:
+      handle: "Handle"
+      handle_prof: "A 'handle' can be used to conceal your username from people who view your wiki pages. If you have a handle,
+                     your wiki account should be named after your handle instead of after your user-ID.  If you do not have a handle,
+                     your Expertiza user-ID will be used instead. A blank entry in the field below will cause the handle to be set back to your Expertiza user-ID."
+      note: "Note: By using this form, you are changing your default handle, which will be used for all future assignments. To change your handle for a specific assignment, select that assignment and choose the Change Handle action."
+    default_handle: "Default Handle:"
+  users:
+    prefs:
+      email: "E-mail Options"
+      email_option: "Check the boxes representing the times when you want to receive e-mail."
+      email_review: "When someone else reviews my work"
+      email_other_review: "When someone else submits work I am assigned to review"
+      see_review: "When someone else reviews one of my reviews (metareviews my work)"
+      send_mail: "Send me copies of emails sent for assignments"
+
+    password:
+      password_label: "Password: "
+      confirm_password: "Confirm your password: "
+
+    name:
+      name_convention: "Full name (last, first[ middle]):"
+
+    institutions:
+      inst_name: "Institution "
+
+    email:
+      email_add: "E-mail address:"
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  # end of Student Views
+

--- a/config/locales/en_US.yml
+++ b/config/locales/en_US.yml
@@ -1,0 +1,10 @@
+en_US:
+  student_task:
+    list:
+      assignments: "Assignments"
+  assignments:
+    edit:
+      editing_assignment: "Editing Assignment"
+  courses:
+    edit:
+      edit_course: "Edit Course"

--- a/config/locales/hi_IN.yml
+++ b/config/locales/hi_IN.yml
@@ -1,10 +1,529 @@
 hi_IN:
+  # This section of keys are for the pages related to Courses
+  course:
+    edit:
+      course_title: "एडिट कोर्स"
+
+    course:
+      institute_name: "इन्स्टिट्यूशन का नाम"
+      course_name: "कोर्स का नाम"
+      course_directory: "कोर्स डाइरेक्टरी"
+      directory_warning: "(आवश्यक स्थान। कोई जगह या विशेष वर्ण नहीं।)"
+      course_info: "कोर्स संबंधी जानकारी"
+      language: "भाषा चुनिए"
+
+    view_teaching_assistants:
+      teaching_assistants: "शिक्षण सहायक"
+      course: "कोर्स"
+      teaching_assistant_name: "शिक्षण सहायक का नाम"
+
+    add_individual:
+      enter_user_login: "उपयोगकर्ता का लॉगिन दर्ज करें:"
+      add_ta: "शिक्षण सहायक को शामिल करना"
+
+  participant:
+    list:
+      participants: "हिस्सा लेनेवाला"
+
+  shared_scripts:
+    user_list:
+      email: "ईमेल ..."
+      permissions: "इजाज़त ..."
+      name: "नाम"
+      full_name: "पूरा नाम"
+      email_address: " ईमेल  एड्रेस"
+      role: "भूमिका "
+      parent: "पेअरॅन्ट"
+      badges: "पदक"
+      review: "समीक्षा"
+      submissions: "सबमिशन"
+      metareview: "मेटारिव्यु"
+      submit: "सबमिट"
+      take_quiz: "प्रश्नोत्तरी लेना"
+      handle: "संभालना "
+      action: "एक्शन"
+
+    add_individual:
+      enter_login: "उपयोगकर्ता का लॉगिन दर्ज करें:"
+      add: "शामिल करना"
+      participant: "हिस्सा लेनेवाला"
+      reader: "पाठक"
+      reviewer: "समीक्षक"
+      submitter: "जमाकर्ता का नाम"
+
+  teams:
+    list:
+      teams_for: "टीम्स फॉर"
+      teams: "टीम्स"
+      students_without_team: "टीमों के बिना छात्र"
+      name: "नाम"
+      show_members: "सभी टीम नंबर दिखाएं"
+
+    new:
+      create_teams_for: "टीम्स बनाना फॉर"
+      automatically: "खुद ब खुद"
+      uses_insofar: "जब असाइनमेंट बनाया गया था, निर्दिष्ट किए गए सदस्यों की संख्या का उपयोग करता है."
+      team_size: "टीम का परिमाण:"
+      create_teams: "टीम्स बनाना"
+      manually: "मैन्युअल रूप से"
+      specify_team_them: "टीम का नाम निर्दिष्ट करें और टीम में सदस्यों को एक एक करके चुने."
+      inherit_teams: "पाठ्यक्रम से निहित टीमों "
+      use_the_teams: "वर्तमान में पाठ्यक्रम के लिए परिभाषित टीमों का प्रयोग करें."
+      team_name: "टीम का नाम"
+
+  assignment:
+    new:
+      create_new: "नया बनाओ"
+      public: "सार्वजनिक"
+      private: "प्राइवेट"
+      assignment: "असाइनमेंट"
+      general: "सामान्य"
+      rubrics: "रुब्रिकों"
+      review_strategy: "समीक्षा रणनीति"
+      due_date: "अंतिम तारीख"
+      create_button: "बनाना"
+
+    edit:
+      general:
+        assignment_name: "असाइनमेंट का नाम:"
+        course: "कोर्स"
+        submission_directory: "सबमिशन निर्देशिका "
+        mandatory_field: "(आवश्यक स्थान. कोई स्थान या विशेष पात्रों की अनुमति नहीं है.)"
+        description_url: "यूआरएल विवरण"
+        calibration: "अंशांकन "
+        has_team: "क्या आपके पास एक टीम है?"
+        has_quiz: "क्या आपके पास प्रश्नोत्तरी है?"
+        has_badge: "क्या आपके पास बैज है?"
+        staggered_deadline: "क्या यह एक चौंकाने वाली समयसीमा असाइनमेंट है?"
+        mico_task: "क्या यह एक माइक्रो टास्क असाइनमेंट है?"
+        review_reviewers: "समीक्षा अन्य समीक्षकों के लिए उपलब्ध हैं?"
+        calibrate_training: "प्रशिक्षण के लिए यह अंशांकन है?"
+        reputation_algorithm: "क्या यह एक प्रतिष्ठा एल्गोरिदम है?"
+        use_simicheck: "क्या आप सिमिचेक उपयोग करना चाहते हैं?"
+        allow_feedback: "क्या उपयोगकर्ता द्वारा टैग की गई प्रतिक्रिया टिप्पणियों की अनुमति होनी चाहिए ?"
+        available: "क्या यह छात्रों के लिए उपलब्ध है?"
+
+      rubrics:
+        review_varies: "क्या समीक्षा दौर से भिन्न होती है?"
+        questionaire: "प्रश्नावली"
+        use_dropdown: "ड्रॉप डाउन का उपयोग करें"
+        instead: " इसके बजाय क्या ?"
+        scored_question: "रन बनाए-सवाल"
+        display_style: "प्रदर्शन शैली"
+        weight: "वजन"
+        notification_limit: "विज्ञापन का हद"
+        author_feedback: "लेखक से प्रतिक्रिया"
+        review: "समीक्षा"
+
+      review_strategy:
+        review_strategy: "समीक्षा रणनीति: "
+        review_topic: " समीक्षा विषय सीमा (के):"
+        max_num_reviews: "प्रति समीक्षाकर्ता की समीक्षा की अधिकतम संख्या :"
+        max_review_limit: "क्या समीक्षा की अधिकतम सीमा है?"
+        set_num_reviews: "प्रति समीक्षाकर्ता समीक्षा की संख्या निर्धारित करें"
+        set req_reviews: "प्रति समीक्षाकर्ता समीक्षा की आवश्यक संख्या निर्धारित करें"
+        meta_review: "क्या मेटा समीक्षा की सीमा है?"
+        set_num_meta: "प्रति समीक्षाकर्ता मेटारिव्यु की संख्या निर्धारित करें"
+        set_req_meta: "प्रति समीक्षाकर्ता मेटारिव्यु की आवश्यक संख्या निर्धारित करें"
+        anon_review: "क्या यह एक अनाम समीक्षा है?"
+        self_review: "क्या आत्म समीक्षा की अनुमति है?"
+
+      due_dates:
+        num_review_rounds: "समीक्षा दौर की संख्या :"
+        timezone: "समय क्षेत्र: "
+        meta_deadline: "मेटारिव्यु की अंतिम तिथि का उपयोग करें "
+        show_hide: "दिनांक अद्यतनकर्ता को दिखाएं / छुपाएं "
+        deadline_type: "अंतिम तिथि प्रकार"
+        date_time: "दिनांक और समय"
+        use_updater: "तारीख अद्यतनकर्ता का उपयोग करें "
+        submission_allowed: "सबमिशन की अनुमति है"
+        review_allowed: "समीक्षा की अनुमति है"
+        teammate_review: "टीममाइट समीक्षा की अनुमति है"
+        meta_allowed: "मेटारिव्यु की अनुमति है"
+        has_quiz: "आपके पास प्रश्नोत्तरी है"
+        reminder: "शेष-भाग (घंटे)"
+        due_date_names: "अंतिम तारीख का नाम"
+        description_url: "यूआरएल विवरण"
+        round: "संख्या"
+
+      late_policy:
+        apply_penalty: "पेनल्टी पालिसी लागू करें:"
+        late_policty: "नई देरी पालिसी"
+
+      calibration:
+        particpant_name: "हिस्सा लेनेवाला का नाम"
+        action: "एक्शन"
+        submitted_item: "सबमिट की गई वस्तुएं "
+        submit_calibration: "अंशांकन के लिए समीक्षा सबमिट करें"
+
+  # end of Courses view
+
+  # keys for pages Student Views
   student_task:
     list:
       assignments: "असाइनमेंट"
-  assignments:
+      tasks_not_started: "असाइनमेंट अभी  शुरू नहीं हुआ है"
+      revisions: "संशोधन"
+      student_team: "छात्र जिन्होंने आपके साथ मिलकर काम किया है"
+      not_associated: "असाइनमेंट किसी भी कोर्स से जुड़े नहीं हैं"
+      assignment_name: "असाइनमेंट"
+      course: "कोर्स"
+      topic: "विषय"
+      current_stage: "वर्तमान स्थिति"
+      review_grade: "ग्रेड की समीक्षा करें"
+      badges: "बैज"
+      stage_deadline: "चरण की अंतिम तिथि"
+      publishing_rights: "प्रकाशन अधिकार"
+      left: "बाकी"
+
+    publishing_rights:
+      select_assignment: "सूची से असाइनमेंट चुनें या अपने काम के लिए"
+      publishing_rights: "प्रकाशन अधिकार"
+      for_work: "सेट करें।"
+
+    view:
+      submit_review: "सबमिट करें या काम की समीक्षा करें"
+      next_click: "अगला: शीर्षक पर असाइनमेंट पर जिस गतिविधि को आप करना चाहते हैं उसे क्लिक करें:"
+      assignment_description: "असाइनमेंट विवरण"
+      signup_sheet: "साइनअप शीट"
+      signup_topic: "(एक विषय के लिए साइन अप करें)"
+      your_team: "आपकी टीम"
+      view_team: "(अपनी टीम देखें और प्रबंधित करें)"
+      submit_work: "(सबमिट करें और अपना काम देखें)"
+#     change this
+      view_bookmarks: "View bookmarks"
+      view_bookmarks_lengthy: "(View bookmarks others have submitted for your topic)"
+      your_work: "आपका काम"
+      others_work: "दूसरों का काम"
+      your_readings: "आपकी रीडिंग"
+      choose_topic: "(आपको पहले एक विषय चुनना होगा)"
+      not_allowed: "(आपको अभी आपको काम सबमिट करने की अनुमति नहीं है)"
+      give_feedback: "(दूसरों को उनके काम पर प्रतिक्रिया दें)"
+      take_quizzes: "प्रश्नोत्तरी लें"
+      quizzes_read: "(आपके द्वारा पढ़े गए काम पर प्रश्नोत्तरी लें)"
+      your_scores: "आपके स्कोर"
+      alternate_view: "वैकल्पिक देखें"
+      view_feedback: "(अपने काम पर प्रतिक्रिया देखें)"
+      suggest_topic: "नया विषय सुझाएं"
+      take_survey: "एक सर्वेक्षण ले"
+      change_handle: "अपना हैंडल बदलें"
+      self_review: "(आपको 'अपने स्कोर' की जांच करने से पहले 'अपने काम' के तहत स्वयं समीक्षा सबमिट करनी होगी।)"
+      log_you_out: "(यह आपको लॉग आउट कर देगा)"
+      different_handle: "(इस असाइनमेंट के लिए एक अलग हैंडल प्रदान करें)"
+      back: "वापस पीछे"
+
+  sign_up_sheet:
+    list:
+      signup_sheet: "साइनअप शीट फॉर"
+      assignment_lower: "असाइनमेंट"
+      your_topics: "आपका विषय:"
+      waitlisted: "(वेटलिस्टेड)"
+      back: "वापस पीछे"
+
+    table_header:
+      topic_num: "विषय #"
+      topic_name: "विषय का नाम"
+      micro_payment: "माइक्रो - पेमेंट "
+      num_slots: "स्लॉट की संख्या"
+      available_slots: "उपलब्ध स्लॉट"
+      num_waitlist: "वैटलिस्ट में नंबर"
+      bookmarks: "बुकमार्क्स "
+      actions: " एक्शन्स"
+      advertise: "अद्वेर्तीसे - मेन्ट(स)"
+
+    suggested_topic:
+      approved_suggestion: "आपका अनुमोदित से सुझाया गया विषय"
+
+  student_teams:
     edit:
-      editing_assignment: "संपादन असाइनमेंट"
-  courses:
+      edit_team: "टीम संपादित करें"
+      team_name: "टीम का नाम:"
+      back: "वापस पीछे"
+
+    view:
+      team_info: "टीम की जानकारी"
+      no_team: "अब आपके पास कोई टीम नहीं है!"
+      name_team: "टीम को नाम दे "
+      team_name: "टीम का नाम:"
+      team_name_up: "टीम का नाम:"
+      team_members: "टीम के सदस्या"
+      username: "यूजरनाम "
+      fullname: "पूरा नाम"
+      email_address: "ईमेल  एड्रेस"
+      review_action: "रिव्यु एक्शन"
+      send_invite: "निमंत्रण भेजें"
+      status: "स्थिति"
+      accepted: "मंजूर किया"
+      declined: "रद्द हुआ"
+      wait_reply: "रीप्ले की प्रतीक्षा "
+      invite_people: "लोगो को निमंत्रण भेजे "
+      enter_user: "उपयोगकर्ता का लॉगिन दर्ज करें: "
+      users_waiting: "उपयोगकर्ता जो इस विषय की प्रतीक्षा कर रहे हैं:"
+      user_id: "यूजर ईद"
+      email: "ईमेल "
+      received_invitation: "आमंत्रण आया"
+      from: "फ्रॉम "
+      team_name_no_colon: "टीम का नाम"
+      reply: "जवाब दे"
+      ad_for_team: "टीम के साथी के लिए अद्वेर्तिसेमेन्ट"
+      back: "वापस पीछे"
+
+  submitted_content:
     edit:
-      edit_course: "पाठ्यक्रम संपादित"
+      back: "वापस पीछे"
+
+    title:
+      submit_work: " काम जमा करने का कारन "
+
+    self_review:
+      self_review: "स्वयं की समीक्षा:"
+      work_not_submitted: "(कार्य अभी तक सबमिट नहीं किया गया है)"
+
+    hyperlink:
+      hyperlink_action: "हाइपरलिंक एक्शन्स:"
+      hide_link: "लिंक छुपाएं"
+
+    main:
+      submit_hyperlink: "हाइपरलिंक सबमिट करें:"
+      quiz: "प्रश्नोत्तरी:"
+      view_quiz: "प्रश्नोत्तरी देखें"
+      edit_quiz: "प्रश्नोत्तरी बदलें"
+
+    submitted_files:
+      submit_file: "फाइल जमा करें:"
+      or: "या"
+
+  student_review:
+    list:
+      reviews_for: "इसके लिए समीक्षाएँ: "
+      your_instructor_expects: "आपके प्रशिक्षक आपसे अपेक्षा करते है कि आप करेंगे"
+      you_are_not_allowed: "आपको कोई अतिरिक्त समीक्षा करने की अनुमति नहीं है।"
+      perform_exactly: "आपको करनी चाहिए ठीक"
+      may_perform_between_1: "आप इन कई समीक्षाओं के बीच प्रदर्शन कर सकते हैं:"
+      may_perform_between_2: "और"
+      required_to_do: "आपको करना होगा"
+      reviews: "समीक्षा"
+      num_reviews_left: "शेष समीक्षाओं की संख्या:"
+      note1: "नोट: आपके पास 2 से अधिक उत्कृष्ट समीक्षा नहीं हो सकती है। किसी अन्य को चुनने से पहले आपको अपनी उत्कृष्ट समीक्षाओं में से एक पूरा करना होगा।"
+      note2_1: "नोट: आप से अधिक नहीं कर सकते हैं"
+      note2_2: "असाइनमेंट पॉलिसी के अनुसार समीक्षा।"
+      reviews_cannot: "समीक्षा इस समय नहीं की जा सकती है"
+      metareviews_for: "मेटारिव्यु फॉर"
+      metareviews_allowed: "मेटा - रिव्युस की अनुमत संख्या:"
+      metareviews: "मेटा - रिव्युस"
+      metareviews_left: "शेष मेटा - रिव्युस की संख्या:"
+      back: "वापस पीछे"
+
+    responses:
+      view: "व्यू "
+      edit: "एडिट "
+      update: "अपडेट"
+      latest_update_at: " -- नवीनतम अपडेट पर"
+      begin: "शुरू"
+      show_calibration_results: "अंशांकन परिणाम दिखाएं"
+      review_done_at: "इस पर समीक्षा की गई --"
+      no_previous_available: "कोई पिछले संस्करण उपलब्ध नहीं है"
+
+    set_dynamic_review:
+      i_don't_care: "मुझे परवाह नहीं है कि मैं किस विषय की समीक्षा करता हूं।"
+      select_topic: "एक नई समीक्षा शुरू करने के लिए नीचे एक विषय का चयन करें:"
+      request_new_submission: "समीक्षा करने के लिए एक नए सबमिशन का अनुरोध करें"
+
+    set_dynamic_metareview:
+      request_new_metareview: "परफॉर्म करने के लिए एक नए मेटायरव्यू का अनुरोध करें"
+
+  grades:
+    view_my_scores:
+      score_for: "स्कोर फॉर "
+      reputation: "रेपुटेशन"
+      back: "वापस पीछे"
+
+    view_team:
+      summary_report: "असाइनमेंट के लिए सारांश रिपोर्ट:"
+      team: "टीम:"
+      topic: "विषय:"
+      average_peer_review: "औसत सहकर्मी समीक्षा स्कोर:"
+      show_submission: "सबमिशन दिखाएं"
+      no_submission: "कोई सबमिशन नहीं"
+      question: "सवाल"
+      toggle_question_list: "प्रश्न सूची टॉगल करें"
+      hide_tags: "टैग छुपाएं"
+      color_legend: "कलर लीजेंड"
+      interaction_legend: "इंटरेक्शन लीजेंड"
+      criterion: "क्रिटेरिआ "
+      metric1: "मीट्रिक -१ "
+      review: "रिव्यु"
+      score: "स्कोर"
+      comment: "टिप्पणी"
+      additional_comments: "अतिरिक्त टिप्पणियां"
+      no_review_of: "इसका कोई रिव्यु नहीं "
+      type_exists: "यह प्रकार पहले से है"
+      grade_and_comment: "जमा करने के लिए ग्रेड और टिप्पणी"
+      grade: "ग्रेड:"
+      comment2: "टिप्पणी:"
+
+    participant_charts:
+      hide_stats: "आँकड़े छिपाएँ"
+      stats: "आँकड़े"
+
+    participant:
+      show_submission: "प्रस्तुत काम देखे"
+
+    participant_title:
+      submitted_work: "प्रस्तुत काम"
+      reviewing: "समीक्षा के लिए"
+      author_feedback: "लेखक की प्रतिक्रिया"
+      teammate_review: "टीममेट रिव्यू"
+      contributor: "योगदानकर्ता"
+      average: "औसत"
+      range: "सीमा"
+      final_score: "फाइनल स्कोर"
+
+  participants:
+    change_handle:
+      create_or_change: "वर्तमान असाइनमेंट के लिए हैंडल बनाएं या बदलें"
+      your: "आपका"
+      handle: "हैंडल"
+      is_the_way: "आपके समीक्षक आपको इस तरह से जानेगे ।"
+      for_example: "उदाहरण के लिए, यदि आप विकी पर लिख रहे हैं, तो हो सकता है कि आप विकी पर दिखाने के लिए अपने विशेषज्ञिता उपयोगकर्ता-आईडी का उपयोग नहीं करना चाहें, क्योंकि तब आपके समीक्षकों को पता चलेगा कि वे किसकी समीक्षा कर रहे हैं। तो, आपको इसके बजाय एक हैंडल सेट करने की अनुमति है। यदि आपके पास हैंडल है, तो आपके विकी खाते का नाम आपके हैंडल के नाम पर रखा गया है, और आपके समीक्षक आपके हैंडल को देखते हैं, लेकिन आपका उपयोगकर्ता-आईडी नहीं।"
+      if_you_do_not: "यदि आपके पास कोई हैंडल नहीं है, तो इसके बजाय आपके उपयोगकर्ता-आईडी का उपयोग किया जाएगा।"
+      two_ways: "आप दो तरीकों से एक हैंडल सेट अप कर सकते हैं:"
+      handle_for: "आप इसके लिए हैंडल सेट उप कर सकते है "
+      only_this_assignment: "केवल यह असाइनमेंट"
+      by_entering: "नीचे एक हैंडल दर्ज करके।"
+      you_can_set_up_default: "आप अपना \ डिफ़ॉल्ट \ हैंडल सेट उप कर सकते है अपना एडिट करके "
+      note_that: "ध्यान दें कि यदि आप अपना संपादन करके अपना हैंडल बदलते हैं"
+      your_new_handle: "आपके नए हैंडल का इस्तेमाल सभी के लिए किया जाएगा"
+      future: "भविष्य"
+      assignments_if: "असाइनमेंट्स ; यदि आप इस असाइनमेंट पर भी परिवर्तन लागू करना चाहते हैं, तो आपको इसे नीचे भी बदलना होगा।"
+      change_handle: "हैंडल बदलें"
+      for_current: "वर्तमान असाइनमेंट के लिए"
+      warning: "चेतावनी:"
+      you_must: "आपके विकी अकाउंट का नाम आपके हैंडल का नाम होना चाहिए। यदि नहीं हैं, तो कृपया अपने प्रशिक्षक या पाठ्यक्रम के कर्मचारियों को ई-मेल करें।"
+      back: "वापस पीछे"
+
+  popup:
+    self_review_popup:
+      no_review_done: "अभी तक कोई समीक्षा नहीं की गई है"
+      reviewer_score: "समीक्षक दिया हुआ अंक"
+      self_review_of: "की समीक्षा"
+      question: "प्रश्न"
+      score: "अंक"
+      comments: "प्रतिक्रिया"
+      other_reviewer_score: "समीक्षक के अंक (Σ भारित अंक / Σ भारित उपलब्ध अंक)"
+      additional_comments: "अतिरिक्त प्रतिक्रिया यदि कोई हो"
+      no_comments: "कोई प्रतिक्रिया नहीं "
+
+  student_quizzes:
+    index:
+      quiz_for: "इसके लिए प्रश्नोत्तरी है: "
+      assignment_not_support: "इस असाइनमेंट में अभी प्रश्नोत्तरी नहीं हैं"
+      back: "वापस पीछे"
+
+    responses:
+      work_not_submit: " आपका काम अभी तक प्रस्तुत नहीं किया गया है"
+      begin: "शुरू करो"
+
+    set_dynamic_quiz:
+      select_topic: "एक नई प्रश्नोत्तरी लेने के लिए नीचे दिए गए विषय का चयन करें"
+      request_new_quiz: "एक नई प्रश्नोत्तरी के लिए अनुरोध करें"
+
+    finished_quiz:
+      answers: "जवाब"
+      quiz_score: "प्रश्नोत्तरी के लिए अंक"
+      back: "वापस पीछे"
+
+    review_questions:
+      quiz_listings: "सभी प्रश्नोत्तरी इसके लिए :"
+      quiz_create: "यह प्रश्नोत्तरी उनके द्वारा बनाई गई थी: "
+      topic: "विषय :"
+      quiz_taker: "प्रश्नोत्तरी लेने वाला व्यक्ति"
+      quiz_score: "प्रश्नोत्तरी के लिए अंक"
+      avg_score: "प्रश्नोत्तरी लेने वाले के लिए औसत अंक"
+
+    take_quiz:
+      questions: "प्रशन"
+      submit_quiz: "कृपया प्रश्नोत्तरी जमा करें"
+
+  profile:
+    edit:
+      user_profile_info: "उपयोगकर्ता के जानकारी"
+      password_msg: "अगर पासवर्ड खाली है, थो वोह अपडेट नहीं होगा "
+      preferred_time_zone: " पसंदीदा समय क्षेत्र "
+      save: "संग्रह क्करें"
+
+    handle:
+      handle: "हैंडल"
+      default_handle: "डिफ़ॉल्ट हैंडल:"
+      handle_prof: " हैंडल आपका चुना हुआ नाम अन्य लोगों से छिपाता है. यदि आपके पास हैंडल है, आपका विकी अकाउंट वोह हैंडल के नॉम होणा चाहीये. अगर हैंडल नही हैं, आपके एक्सपेर्टीज़ा के यूजर ईद  (चुना हुआ नाम) उपयोग होगा. नीचे के खाली स्तान हैंडल को आपके एक्सपेर्टीज़ा में चुना हुआ नाम में बदल देगा.  "
+      note: "ध्यान दें: इस फ़ॉर्म के माध्यम से आप अपना 'डिफ़ॉल्ट हैंडल' बदल रहे हैं. अब ये आपके भविष्य के असाइनमेंट में इस्तेमाल किया जाएगा. यदि आप अपना हैंडल बदलना चाहते हैं एक विशिष्ट असाइनमेंट के लिय, आप वोह असाइनमेंट का चुनाव करके 'डिफ़ॉल्ट हैंडल' में  परिवर्तन लाये "
+
+  users:
+    prefs:
+      email: "ईमेल के विकल्प"
+      email_option: " चुनाव कीजिये जब आप ईमेल प्राप्त करना चाहते हैं "
+      email_review: "जब कोई और मेरे काम की समीक्षा करता है"
+      email_other_review: "जब कोई दूसरा काम करता है तो मुझे समीक्षा करने का काम सौंपा जाता है"
+      see_review: "जब कोई और मेरी एक समीक्षा करता है"
+      send_mail: "मुझे असाइनमेंट के लिए भेजे गए"
+
+    password:
+      password_label: "पासवर्ड: "
+      confirm_password: "अपने पासवर्ड की पुष्टि करें: "
+
+    name:
+      name_convention: "पूरा नाम (अंतिम , पहला[ मध्य]):"
+
+    institutions:
+      inst_name: "संस्था"
+
+    email:
+      email_add: "ईमेल पता:"
+
+  datetime:
+    distance_in_words:
+      about_x_hours:
+        one: "करीब 1 घंटा"
+        other: "करीब %{count} घंटे"
+      about_x_months:
+        one: "करीब 1 महीना"
+        other: "करीब %{count} महीने"
+      about_x_years:
+        one: "करीब 1 साल"
+        other: "करीब %{count} साल"
+      almost_x_years:
+        one: "करीब 1 साल"
+        other: "करीब %{count} साल"
+      half_a_minute: "आधा मिनट"
+      less_than_x_minutes:
+        zero: "0 मिनट से कम"
+        one: "1 मिनट से कम"
+        other: "%{count} मिनट से कम"
+      less_than_x_seconds:
+        zero: "0 सेकंड से कम"
+        one: "1 सेकंड से कम"
+        other: "%{count} सेकंड से कम"
+      over_x_years:
+        one: "1 साल से अधिक"
+        other: "%{count} साल से अधिक"
+      x_days:
+        one: "1 दिन"
+        other: "%{count} दिन"
+      x_hours:
+        one: "1 घंटा"
+        other: "%{count} घंटे"
+      x_minutes:
+        one: "1 मिनट"
+        other: "%{count} मिनट"
+      x_months:
+        one: "1 महीना"
+        other: "%{count} महीने"
+      x_years:
+        one: "1 साल"
+        other: "%{count} साल"
+      x_seconds:
+        one: "1 सेकंड"
+        other: "%{count} सेकंड"
+
+  # end of Student Views
+

--- a/config/locales/hi_IN.yml
+++ b/config/locales/hi_IN.yml
@@ -1,0 +1,10 @@
+hi_IN:
+  student_task:
+    list:
+      assignments: "असाइनमेंट"
+  assignments:
+    edit:
+      editing_assignment: "संपादन असाइनमेंट"
+  courses:
+    edit:
+      edit_course: "पाठ्यक्रम संपादित"

--- a/db/migrate/20211113230043_add_lang_locale_to_users.rb
+++ b/db/migrate/20211113230043_add_lang_locale_to_users.rb
@@ -1,0 +1,5 @@
+class AddLangLocaleToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :locale, :integer, default: 0
+  end
+end

--- a/db/migrate/20211114021523_add_locale_to_courses.rb
+++ b/db/migrate/20211114021523_add_locale_to_courses.rb
@@ -1,0 +1,5 @@
+class AddLocaleToCourses < ActiveRecord::Migration
+  def change
+    add_column :courses, :locale, :integer, default: 1
+  end
+end


### PR DESCRIPTION
**What’s it about**: Expertiza only supports English right now. Many Expertiza users are from other countries. We should be able to show them Expertiza messages in their own language.

Scope: The scope of this project is limited however only to static strings. i.e. user-generated content will not be automatically translated to other languages.

Breaking down internationalization into 3 sequential subproblems:
1. Language selection
2. Rendering the language
3. Translation gaps

See the [wiki page](https://expertiza.csc.ncsu.edu/index.php/CSC/ECE_517_Fall_2021_-_E2159._Expertiza_internationalization) for full details.