### PR TITLE
added delete_all method for teams_controller

### DIFF
--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -68,6 +68,15 @@ class TeamsController < ApplicationController
     @team = Team.find(params[:id])
   end
 
+  def delete_all
+    # Deletes all the teams assigned to a course, by finding them via node_object_id
+    root_node = Object.const_get(session[:team_type] + "Node").find_by(node_object_id: params[:id])
+    child_nodes = root_node.get_teams.map { |e| e.node_object_id}
+    course_teams = Team.where(id: child_nodes)
+    course_teams.destroy_all if course_teams
+    redirect_to action: 'list', id: params[:id]
+  end
+
   def delete
     # delete records in team, teams_users, signed_up_teams table
     @team = Team.find_by(id: params[:id])

--- a/spec/controllers/teams_controller_spec.rb
+++ b/spec/controllers/teams_controller_spec.rb
@@ -29,6 +29,15 @@ describe TeamsController do
         expect { @c_team.delete }.to change(Team, :count).by(-1)
       end
     end
+
+      context "with two course teams " do
+        it "deletes all course teams" do
+          @course = create(:course)
+          @team_1 = create(:course_team)
+          @team_2 = create(:course_team)
+          expect { CourseTeam.delete_all }.to change(Team, :count).by(-2)
+        end
+    end
   end
 
   describe "Testing copy functionality - " do


### PR DESCRIPTION
Added delete_all method for teams_controller, for allowing "Delete All" functionality in teams for a course.