### PR TITLE
Improvements to Team Management as an Instructor - Inheritance and Bequeathal

### DIFF
--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -119,17 +119,27 @@ class TeamsController < ApplicationController
     redirect_to controller: 'teams', action: 'list', id: assignment.id
   end
 
-  # Copies existing teams from an assignment up to a course
-  # The team and team members are all copied.
-  def bequeath
-    team = AssignmentTeam.find(params[:id])
-    assignment = Assignment.find(team.parent_id)
-    if assignment.course_id >= 0
+  def bequeath_all
+    if session[:team_type] == 'Course'
+      flash[:error] = 'Invalid team type: if you want an assignment to inherit these teams, navigate to the list of teams associated with the assignment'
+      redirect_to controller: 'teams', action: 'list', id: params[:id]
+      return
+    end
+    assignment = Assignment.find(params[:id])
+    if assignment.course_id
       course = Course.find(assignment.course_id)
-      team.copy(course.id)
-      flash[:note] = 'The team "' + team.name + '" was successfully copied to "' + course.name + '"'
+      if course.course_teams.any?
+        flash[:error] = 'The course already has associated teams'
+        redirect_to controller: 'teams', action: 'list', id: assignment.id
+        return
+      end
+      teams = assignment.teams
+      teams.each do |team|
+        team.copy(course.id)
+      end
+      flash[:note] = teams.length.to_s + ' teams were successfully copied to "' + course.name + '"'
     else
-      flash[:error] = "This assignment is not #{url_for(controller: 'assignment', action: 'assign', id: assignment.id)} with a course."
+      flash[:error] = 'No course was found for this assignment.'
     end
     redirect_to controller: 'teams', action: 'list', id: assignment.id
   end

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -121,7 +121,7 @@ class TeamsController < ApplicationController
 
   def bequeath_all
     if session[:team_type] == 'Course'
-      flash[:error] = 'Invalid team type: if you want an assignment to inherit these teams, navigate to the list of teams associated with the assignment'
+      flash[:error] = 'Invalid team type for bequeathal'
       redirect_to controller: 'teams', action: 'list', id: params[:id]
       return
     end

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -21,6 +21,7 @@ class TeamsController < ApplicationController
     allowed_types = %w[Assignment Course]
     session[:team_type] = params[:type] if params[:type] && allowed_types.include?(params[:type])
     @assignment = Assignment.find_by(id: params[:id]) if session[:team_type] == 'Assignment'
+    # @course = Course.find(params[:id]) if session[:team_type] == 'Course'
     begin
       @root_node = Object.const_get(session[:team_type] + 'Node').find_by(node_object_id: params[:id])
       @child_nodes = @root_node.get_teams
@@ -70,6 +71,10 @@ class TeamsController < ApplicationController
 
   def delete_all
     root_node = Object.const_get(session[:team_type] + 'Node').find_by(node_object_id: params[:id])
+    if root_node.nil?
+      flash[:warning] = "Error detected" 
+      return
+    end
     child_nodes = root_node.get_teams.map(&:node_object_id)
     Team.destroy_all(id: child_nodes) if child_nodes
     redirect_to action: 'list', id: params[:id]
@@ -103,7 +108,7 @@ class TeamsController < ApplicationController
   # The team and team members are all copied.
   def inherit
     assignment = Assignment.find(params[:id])
-    if assignment.course_id >= 0
+    if assignment.course_id
       course = Course.find(assignment.course_id)
       teams = course.get_teams
       if teams.empty?

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -21,7 +21,6 @@ class TeamsController < ApplicationController
     allowed_types = %w[Assignment Course]
     session[:team_type] = params[:type] if params[:type] && allowed_types.include?(params[:type])
     @assignment = Assignment.find_by(id: params[:id]) if session[:team_type] == 'Assignment'
-    # @course = Course.find(params[:id]) if session[:team_type] == 'Course'
     begin
       @root_node = Object.const_get(session[:team_type] + 'Node').find_by(node_object_id: params[:id])
       @child_nodes = @root_node.get_teams
@@ -71,10 +70,6 @@ class TeamsController < ApplicationController
 
   def delete_all
     root_node = Object.const_get(session[:team_type] + 'Node').find_by(node_object_id: params[:id])
-    if root_node.nil?
-      flash[:warning] = "Error detected" 
-      return
-    end
     child_nodes = root_node.get_teams.map(&:node_object_id)
     Team.destroy_all(id: child_nodes) if child_nodes
     redirect_to action: 'list', id: params[:id]

--- a/app/controllers/teams_users_controller.rb
+++ b/app/controllers/teams_users_controller.rb
@@ -34,6 +34,7 @@ class TeamsUsersController < ApplicationController
   end
 
   def create
+    puts 'Got here'
     user = User.find_by(name: params[:user][:name].strip)
     unless user
       urlCreate = url_for controller: 'users', action: 'new'
@@ -49,7 +50,13 @@ class TeamsUsersController < ApplicationController
           urlAssignmentParticipantList = url_for controller: 'participants', action: 'list', id: assignment.id, model: 'Assignment', authorization: 'participant'
           flash[:error] = "\"#{user.name}\" is not a participant of the current assignment. Please <a href=\"#{urlAssignmentParticipantList}\">add</a> this user before continuing."
         else
-          add_member_return = team.add_member(user, team.parent_id)
+          begin 
+            add_member_return = team.add_member(user, team.parent_id)
+          rescue
+            flash[:error] = "The user #{user.name} is already a member of the team #{team.name}"
+            redirect_back
+            return
+          end
           flash[:error] = 'This team already has the maximum number of members.' if add_member_return == false
           # E2115 Mentor Management
           # Kick off the Mentor Management workflow

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -47,6 +47,15 @@ class Assignment < ActiveRecord::Base
   DEFAULT_MAX_REVIEWERS = 3
   DEFAULT_MAX_OUTSTANDING_REVIEWS = 2
 
+  def user_on_team? (user)
+    teams = self.teams
+    users = []
+    teams.each do | team |
+      users << team.users
+    end
+    users.flatten.include? user
+  end
+
   def self.max_outstanding_reviews
     DEFAULT_MAX_OUTSTANDING_REVIEWS
   end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -69,6 +69,15 @@ class Course < ActiveRecord::Base
     end
   end
 
+  def user_on_team?(user)
+    teams = get_teams
+    users = []
+    teams.each do |team|
+      users << team.users
+    end
+    users.flatten.include? user
+  end
+
   require 'analytic/course_analytic'
   include CourseAnalytic
 end

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -61,7 +61,7 @@ class Team < ActiveRecord::Base
   # Add member to the team, changed to hash by E1776
   def add_member(user, _assignment_id = nil)
     raise "The user #{user.name} is already a member of the team #{name}" if user?(user)
-
+    
     can_add_member = false
     unless full?
       can_add_member = true

--- a/app/views/participants/_links.html.erb
+++ b/app/views/participants/_links.html.erb
@@ -8,7 +8,7 @@
                      :authorization => @authorization}
 %>
 <br/>
-<% if params[:model] == 'Assignment' and @parent.course_id and  @parent.course_id > 0 %>
+<% if params[:model] == 'Assignment' && @parent.course_id %>
   <%= link_to 'Copy participants from course', :action => 'inherit', :id => @root_node.node_object_id %>  |
   <%= link_to 'Copy participants to course', :action => 'bequeath_all', :id => @root_node.node_object_id %><BR/>
 <% end %>

--- a/app/views/teams/_team.html.erb
+++ b/app/views/teams/_team.html.erb
@@ -20,4 +20,5 @@
   :model=> modelType,
   :id=>@root_node.node_object_id %>
 |<%= link_to 'Delete All Teams', :action => 'delete_all', :id=> @root_node.node_object_id, :model => @model %>
+|<%= link_to 'Bequeath All Teams', :action=>'bequeath_all', :id => @root_node.node_object_id, :model => @model %>
 |<%= render :partial => '/shared_scripts/back' %>

--- a/app/views/teams/list.html.erb
+++ b/app/views/teams/list.html.erb
@@ -8,18 +8,18 @@
 <div id="tabs">
   <ul>
     <li><a href="#tabs-1" id="General">Teams</a></li>
-    <% if session[:team_type] == 'Assignment' and @assignment.max_team_size > 1 %>
+    <% if session[:team_type] == 'Assignment' && @assignment.max_team_size > 1 %>
       <li><a href="#tabs-2" id="Topics">Students without teams</a></li>
     <% end %>
   </ul>
   <div id="tabs-1"><%= render partial: 'team' %></div>
-    <% if session[:team_type] == 'Assignment' and @assignment.max_team_size > 1 %>
+    <% if session[:team_type] == 'Assignment'&& @assignment.max_team_size > 1 %>
       <% participants_without_team = get_participants_without_team(@assignment) %>
       <div id="tabs-2">
         <table>
           <th>name</th>
           <% participants_without_team.each_with_index do |participant, index| %>
-            <tr class=<%= index % 2 == 0 ? 'odd' : 'even' %>><td><%= participant.name(session[:ip]) %></td></tr>
+            <tr class=<%= index.odd? ? 'odd' : 'even' %>><td><%= participant.name(session[:ip]) %></td></tr>
           <% end %>
         </table>
       </div>

--- a/app/views/teams/list_assignments.html.erb
+++ b/app/views/teams/list_assignments.html.erb
@@ -1,17 +1,17 @@
 <h1>Assignments</h1>
 
 
-<% if @assignments.length == 0 %>
+<% if @assignments.length.zero? %>
   <h4>No team assignments are defined</h4>
 <% else %>
   <table>
     <tr><th>Title</th><th>Directory Path</th></tr>
-    <% for assignment in @assignments %>
+    <% @assignments.each do |assignment| %>
       <tr>
         <td><%= link_to assignment.name, :action => 'list',
           :id=> assignment.id %>&nbsp;&nbsp;</td>
         <td><%= assignment.directory_path %></td>
       </tr>
-    <% end -%>
+    <% end %>
   </table>
 <% end %>

--- a/app/views/teams/new.html.erb
+++ b/app/views/teams/new.html.erb
@@ -28,7 +28,7 @@
 <% end %>
 
 <BR/>
-<% if not @parent.instance_of?(Course) and not @parent.course.nil? %>
+<% if !@parent.instance_of?(Course) && !@parent.course.nil? && !@parent.teams?%>
   <H2> Inherit Teams From Course </H2>
   <p> Use the teams that are currently defined for the course.</p>
   <%= form_tag :action => 'inherit' do %>

--- a/app/views/teams/new.html.erb
+++ b/app/views/teams/new.html.erb
@@ -6,7 +6,6 @@
   assignment was created.</p>
 
 <%= form_tag :action => 'create_teams' do %>
-    <!-- BUG FIX: Check if the parent is course, then set the max size as 4 otherwise the max team size of assignment team-->
     <% if @parent.is_a?(Course)%>
           Team Size:<%= select_tag 'team_size', options_for_select(2..4), size: 1 %>
     <% else %>
@@ -28,7 +27,7 @@
 <% end %>
 
 <BR/>
-<% if !@parent.instance_of?(Course) && !@parent.course.nil? && !@parent.teams?%>
+<% if @parent.instance_of?(Assignment) && !@parent.course.nil? && !@parent.course.course_teams.size.zero?%>
   <H2> Inherit Teams From Course </H2>
   <p> Use the teams that are currently defined for the course.</p>
   <%= form_tag :action => 'inherit' do %>

--- a/app/views/tree_display/_page_footer.html.erb
+++ b/app/views/tree_display/_page_footer.html.erb
@@ -2,9 +2,8 @@
   <table id="theTable" width="80%" cell="5">
     <tr id="header"><th colspan="5" width="70%">Details</th><th width="10%">Actions</th></tr>
     <%
-      index = 1
-    @child_nodes.each do |node|
-      if index % 2 == 0
+    @child_nodes.each_with_index do |node, index|
+      if index.odd?
         rowtype = "odd"
       else
         rowtype = "even"
@@ -14,7 +13,6 @@
   <%= render :partial=> '/tree_display/entry', :locals => {:search => @search, :node => node, :prefix => node.node_object_id.to_s+"_"+index.to_s, :depth => 0, :rowtype => rowtype} %>
   <!-- End Listing -->
   <%
-      index+=1
     end
   %>
 </table>

--- a/app/views/tree_display/_page_footer.html.erb
+++ b/app/views/tree_display/_page_footer.html.erb
@@ -2,7 +2,7 @@
   <table id="theTable" width="80%" cell="5">
     <tr id="header"><th colspan="5" width="70%">Details</th><th width="10%">Actions</th></tr>
     <%
-    @child_nodes.each_with_index do |node, index|
+    @child_nodes.each_with_index do |node,index|
       if index.odd?
         rowtype = "odd"
       else

--- a/app/views/tree_display/actions/_teams_actions.html.erb
+++ b/app/views/tree_display/actions/_teams_actions.html.erb
@@ -3,7 +3,7 @@
   <%= link_to image_tag("delete_icon.png", :border=>0, :alt => "Delete Team", :title => "Delete Team"), :controller=>'teams', :action=>'delete', :id => node.node_object_id %>
   <%= link_to image_tag("edit_icon.png", :border=>0, :alt => "Edit Team Name", :title => "Edit Team Name"), :controller=>'teams', :action=>'edit', :id => node.node_object_id %>
 
-  <% if session[:team_type] == 'Assignment' and @root_node.belongs_to_course? %>
+  <% if session[:team_type] == 'Assignment' && @root_node.belongs_to_course? && @assignment.course.course_teams.empty?%>
       <%= link_to image_tag("copy_icon.png", :border=>0, :alt => "Copy Team to Course", :title => "Copy Team to Course" ), :controller => 'teams', :action=>'bequeath', :id => node.node_object_id %>
   <% end %>
 </TD>

--- a/app/views/tree_display/actions/_teams_actions.html.erb
+++ b/app/views/tree_display/actions/_teams_actions.html.erb
@@ -2,8 +2,4 @@
   <%= link_to image_tag("plus.png", :border=>0,:alt => "Add Team Member", :title => "Add Team Member" ), :controller=>'teams_users', :action=>'new', :id => node.node_object_id %>
   <%= link_to image_tag("delete_icon.png", :border=>0, :alt => "Delete Team", :title => "Delete Team"), :controller=>'teams', :action=>'delete', :id => node.node_object_id %>
   <%= link_to image_tag("edit_icon.png", :border=>0, :alt => "Edit Team Name", :title => "Edit Team Name"), :controller=>'teams', :action=>'edit', :id => node.node_object_id %>
-
-  <% if session[:team_type] == 'Assignment' && @root_node.belongs_to_course? && @assignment.course.course_teams.empty?%>
-      <%= link_to image_tag("copy_icon.png", :border=>0, :alt => "Copy Team to Course", :title => "Copy Team to Course" ), :controller => 'teams', :action=>'bequeath', :id => node.node_object_id %>
-  <% end %>
 </TD>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -464,7 +464,7 @@ Expertiza::Application.routes.draw do
   resources :teams, only: %i[new create edit update] do
     collection do
       get :list
-      post ':id', action: :update
+      #post ':id', action: :update
       post :create_teams
       post :inherit
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -464,7 +464,6 @@ Expertiza::Application.routes.draw do
   resources :teams, only: %i[new create edit update] do
     collection do
       get :list
-      #post ':id', action: :update
       post :create_teams
       post :inherit
     end

--- a/spec/controllers/teams_controller_spec.rb
+++ b/spec/controllers/teams_controller_spec.rb
@@ -267,7 +267,7 @@ describe TeamsController do
         allow_any_instance_of(Course).to receive(:course_teams).and_return([])
         allow_any_instance_of(Assignment).to receive(:teams).and_return([team1, team2])
         post :bequeath_all, para, session
-        expect(flash[:note]).to eq('2 teams were successfully copied to \'TestCourse\'')
+        expect(flash[:note]).to eq("2 teams were successfully copied to \"TestCourse\"")
       end
     end
   end

--- a/spec/controllers/teams_users_controller_spec.rb
+++ b/spec/controllers/teams_users_controller_spec.rb
@@ -300,7 +300,7 @@ describe TeamsUsersController do
         }
         post :create, params, session
         # Expect to throw error
-        expect(flash[:error]).to eq 'The user student2065 is already a member of the team team1'
+        expect(flash[:error]).to eq 'The user student2065 is already a member of the team team5'
         # Expect the response to redirect back to 'test.host'
         expect(response).to redirect_to('http://test.host/')
       end

--- a/spec/models/assignment_spec.rb
+++ b/spec/models/assignment_spec.rb
@@ -20,6 +20,21 @@ describe Assignment do
   let(:questionnaire1) { build(:questionnaire, id: 1, type: 'ReviewQuestionnaire') }
   let(:questionnaire2) { build(:questionnaire, id: 2, type: 'MetareviewQuestionnaire') }
 
+  describe '#user_on_team?' do
+    context 'when the user is not on a team associated with the assignment' do
+      it 'returns false' do
+        allow_any_instance_of(Team).to receive(:users).and_return([instructor])
+        expect(assignment.user_on_team?(student)).to be_falsey
+      end
+    end
+    context 'when the user is on a team associated with the assignment' do
+      it 'returns true' do
+        allow_any_instance_of(Team).to receive(:users).and_return([student])
+        expect(assignment.user_on_team?(student)).to be_truthy
+      end
+    end
+  end
+
   describe '.max_outstanding_reviews' do
     it 'returns 2 by default' do
       expect(Assignment.max_outstanding_reviews).to eq(2)

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -110,4 +110,21 @@ describe CourseTeam do
       end
     end
   end
+
+  describe '#user_on_team?' do
+    context 'when the user is not on a team associated with the assignment' do
+      it 'returns false' do
+        allow(course).to receive(:teams).and_return([course_team1])
+        allow_any_instance_of(Team).to receive(:users).and_return([user1])
+        expect(course.user_on_team?(user2)).to be_falsey
+      end
+    end
+    context 'when the user is on a team associated with the assignment' do
+      it 'returns true' do
+        allow(course).to receive(:get_teams).and_return([course_team1])
+        allow_any_instance_of(CourseTeam).to receive(:users).and_return([user1, user2])
+        expect(course.user_on_team?(user2)).to be_truthy
+      end
+    end
+  end
 end

--- a/spec/support/teams_shared.rb
+++ b/spec/support/teams_shared.rb
@@ -16,7 +16,7 @@ shared_context 'object initializations' do
   let(:team2) { build_stubbed(:assignment_team, id: 2, parent_id: assignment1.id) }
   let(:team3) { build_stubbed(:assignment_team, id: 3, parent_id: assignment1.id) }
   let(:team4) { build_stubbed(:assignment_team, id: 4, parent_id: assignment1.id) }
-  let(:team5) { build_stubbed(:course_team, id: 5, parent_id: course1.id) }
+  let(:team5) { build_stubbed(:course_team, id: 5, name: 'team5', parent_id: course1.id) }
   let(:team6) { build_stubbed(:course_team, id: 6, parent_id: course1.id) }
   let(:team7) { build_stubbed(:assignment_team, name: 'test', parent_id: course1.id) }
   let(:team8) { build_stubbed(:assignment_team, id: 1, name: 'wolfers', parent_id: assignment1.id) }


### PR DESCRIPTION
disallow inheriting teams from course when teams exist
refactors bequeathal adds restrictions on the usage of both inheritance and bequeathal. should decrease the number of bugs and crashes in team management 