### PR TITLE
fix issue #311 related to sending join requests to ones own team and disallowing users from graphically spamming invites

### DIFF
--- a/app/controllers/join_team_requests_controller.rb
+++ b/app/controllers/join_team_requests_controller.rb
@@ -36,6 +36,12 @@ class JoinTeamRequestsController < ApplicationController
     @join_team_request.team_id = params[:team_id]
 
     participant = Participant.where(user_id: session[:user][:id], parent_id: params[:assignment_id]).first
+    team = Team.find(params[:team_id])
+    if team.participants.include? participant
+      flash[:error] = 'You already belong to the team'
+      redirect_back
+      return
+    end
     @join_team_request.participant_id = participant.id
     respond_to do |format|
       if @join_team_request.save

--- a/app/controllers/sign_up_sheet_controller.rb
+++ b/app/controllers/sign_up_sheet_controller.rb
@@ -493,7 +493,6 @@ class SignUpSheetController < ApplicationController
       ad_map[:name] = team.name
       ad_map[:assignment_id] = topic.assignment_id
       ad_map[:advertise_for_partner] = team.advertise_for_partner
-      ad_map[:request] = JoinTeamRequest.where(team_id: team.id).first
 
       # Append to the list
       @ad_information.append(ad_map)

--- a/app/controllers/sign_up_sheet_controller.rb
+++ b/app/controllers/sign_up_sheet_controller.rb
@@ -400,7 +400,9 @@ class SignUpSheetController < ApplicationController
 
   # This method is called when a student click on the trumpet icon. So this is a bad method name. --Yang
   def show_team
-    if !(assignment = Assignment.find(params[:assignment_id])).nil? && !(topic = SignUpTopic.find(params[:id])).nil?
+    assignment = Assignment.find(params[:assignment_id])
+    topic = SignUpTopic.find(params[:id])
+    if assignment && topic
       @results = ad_info(assignment.id, topic.id)
       @results.each do |result|
         result.keys.each do |key|
@@ -480,7 +482,7 @@ class SignUpSheetController < ApplicationController
   # clicks to see ads related to a topic
   def ad_info(_assignment_id, topic_id)
     @ad_information = []
-    @signed_up_teams = SignedUpTeam.where('topic_id = ?', topic_id.to_s)
+    @signed_up_teams = SignedUpTeam.where(topic_id: topic_id)
     # Iterate through the results of the query and get the required attributes
     @signed_up_teams.each do |signed_up_team|
       team = signed_up_team.team
@@ -491,6 +493,7 @@ class SignUpSheetController < ApplicationController
       ad_map[:name] = team.name
       ad_map[:assignment_id] = topic.assignment_id
       ad_map[:advertise_for_partner] = team.advertise_for_partner
+      ad_map[:request] = JoinTeamRequest.where(team_id: team.id).first
 
       # Append to the list
       @ad_information.append(ad_map)

--- a/app/views/sign_up_sheet/show_team.html.erb
+++ b/app/views/sign_up_sheet/show_team.html.erb
@@ -14,6 +14,7 @@
   <%# @results is the ad_info for an assignment's topic %>
   <% @results.each {|result| %>
     <% ad_request = JoinTeamRequest.where(team_id: result[:team_id], participant_id: session[:user].id).first %>
+    <% puts ad_request %>
     <%
       team_members = []
       TeamsUser.where(team_id: result[:team_id]).each{|teamuser|
@@ -33,19 +34,19 @@
           %>
           <img src="/assets/info.png" title="Send request to join this team">
           </td>
+        <% else %>
+          <% if team_members.include?(session[:user].name) %>
+            <td align="center"><img src="/assets/info.png" title="You're a member of this team and cannot request to join!"></td>
+          <% else %>
+            <td align="center"><%= link_to "Edit invitation", :controller => 'join_team_requests', :action => 'edit',
+                  :id=>ad_request.id
+                %>
+              <img src="/assets/info.png" title="Edit your request to join this team">
+            </td>
+          <% end %>
+        <% end %>
       </tr>
-    <% else %>
-      <% if team_members.include?(session[:user].name) %>
-        <td align="center"><img src="/assets/info.png" title="You're a member of this team and cannot request to join!"></td>
-      <% else %>
-        <td align="center"><%= link_to "Edit invitation", :controller => 'join_team_requests', :action => 'edit',
-              :id=>ad_request.id
-            %>
-          <img src="/assets/info.png" title="Edit your request to join this team">
-        </td>
-      <% end %>
     <% end %>
-  <% end %>
   <% } %>
 
 </table>

--- a/app/views/sign_up_sheet/show_team.html.erb
+++ b/app/views/sign_up_sheet/show_team.html.erb
@@ -1,50 +1,48 @@
 <h2>
   Partner Advertisements for Topic: <%= SignUpTopic.find(params[:id]).topic_name %>
-  </h2>
+</h2>
 
+<table class="general">
+  <tr>
+    <th width="500">Team Name</th>
+    <th width="500">Members</th>
+    <th width="500">Desired Qualifications</th>
+    <th width="500">Action</th>
+  </tr>
 
-  <table class="general">
-    <tr>
-      <th width="500">Team Name</th>
-      <th width="500">Members</th>
-      <th width="500">Desired Qualifications</th>
-      <th width="500">Action</th>
-    </tr>
+  <% count=0 %>
+  <%# @results is the ad_info for an assignment's topic %>
+  <% @results.each {|result| %>
 
-    <% count=0 %>
-    <% @results.each {|result|
-  %>
-
-<%
-    team_members = ""
-TeamsUser.where(team_id: result[:team_id]).each{|teamuser|
-  team_members+=User.find(teamuser.user_id).name+" "
-}
+    <%
+      team_members = []
+      TeamsUser.where(team_id: result[:team_id]).each{|teamuser|
+        team_members << User.find(teamuser.user_id).name
+      }
       if result[:advertise_for_partner]|| result[:advertise_for_partner] == 1
-      %>
-    <tr>
-      <td align="center" width="500"><%= result[:name] %></td>
-      <td align="center" width="500"><%= team_members  %></td>
-      <td align="center" width="500"><%= result[:comments_for_advertisement] %></td>
-      <% if  Participant.where(parent_id: result[:assignment_id], user_id: session[:user].id).first && result[:request].nil? %>
-        <td align="center"><%= link_to "Request invitation", :controller => 'join_team_requests', :action => 'new',
-          :assignment_id=>result[:assignment_id],
-          :topic_id=>result[:topic_id],
-          :team_id=>result[:team_id]
-        %>
-
-      <img src="/assets/info.png" title="Send request to join this team">
-    </td>
-  <%else%>
-     <td align="center"><%= link_to "Edit invitation", :controller => 'join_team_requests', :action => 'edit',
-          :id=>result[:request].id
-        %>
-      <img src="/assets/info.png" title="Send request to join this team">
-    </td>
-  <% end
-  end %>
-
-</tr>
+    %>
+      <tr>
+        <td align="center" width="500"><%= result[:name] %></td>
+        <td align="center" width="500"><%= team_members.join(', ') %></td>
+        <td align="center" width="500"><%= result[:comments_for_advertisement] %></td>
+        <% if  Participant.where(parent_id: result[:assignment_id], user_id: session[:user].id).first && result[:request].nil? %>
+          <td align="center"><%= link_to "Request invitation", :controller => 'join_team_requests', :action => 'new',
+            :assignment_id=>result[:assignment_id],
+            :topic_id=>result[:topic_id],
+            :team_id=>result[:team_id]
+          %>
+          <img src="/assets/info.png" title="Send request to join this team">
+          </td>
+      </tr>
+    <% else %>
+      <% if team_members.include(session[:user].name)? %>
+        <td align="center"><%= link_to "Edit invitation", :controller => 'join_team_requests', :action => 'edit',
+              :id=>result[:request].id
+            %>
+          <img src="/assets/info.png" title="Edit your request to join this team">
+        </td>
+      <% end %>
+    <% end %>
   <% } %>
 
 </table>

--- a/app/views/sign_up_sheet/show_team.html.erb
+++ b/app/views/sign_up_sheet/show_team.html.erb
@@ -35,18 +35,17 @@
           </td>
       </tr>
     <% else %>
+      <% if team_members.include?(session[:user].name) %>
+        <td align="center"><img src="/assets/info.png" title="You're a member of this team and cannot request to join!"></td>
       <% else %>
-        <% if team_members.include?(session[:user].name) %>
-          <td align="center"><img src="/assets/info.png" title="You're a member of this team and cannot request to join!"></td>
-        <% else %>
-          <td align="center"><%= link_to "Edit invitation", :controller => 'join_team_requests', :action => 'edit',
-                :id=>ad_request.id
-              %>
-            <img src="/assets/info.png" title="Edit your request to join this team">
-          </td>
-        <% end %>
+        <td align="center"><%= link_to "Edit invitation", :controller => 'join_team_requests', :action => 'edit',
+              :id=>ad_request.id
+            %>
+          <img src="/assets/info.png" title="Edit your request to join this team">
+        </td>
       <% end %>
     <% end %>
+  <% end %>
   <% } %>
 
 </table>

--- a/app/views/sign_up_sheet/show_team.html.erb
+++ b/app/views/sign_up_sheet/show_team.html.erb
@@ -35,14 +35,17 @@
           </td>
       </tr>
     <% else %>
-      <% if team_members.include(session[:user].name)? %>
+      <% if !team_members.include?(session[:user].name) %>
         <td align="center"><%= link_to "Edit invitation", :controller => 'join_team_requests', :action => 'edit',
               :id=>result[:request].id
             %>
           <img src="/assets/info.png" title="Edit your request to join this team">
         </td>
+      <% else %>
+        <td align="center"><%= "You are part of this team and cannot request to join" %></td>
       <% end %>
     <% end %>
+  <% end %>
   <% } %>
 
 </table>

--- a/app/views/sign_up_sheet/show_team.html.erb
+++ b/app/views/sign_up_sheet/show_team.html.erb
@@ -10,11 +10,25 @@
     <th width="500">Action</th>
   </tr>
 
-  <% count=0 %>
+  <% count = 0 %>
+  <% requestors = [] %>
+  <% requestors_names = [] %>
+
   <%# @results is the ad_info for an assignment's topic %>
   <% @results.each {|result| %>
-    <% ad_request = JoinTeamRequest.where(team_id: result[:team_id], participant_id: session[:user].id).first %>
-    <% puts ad_request %>
+
+    <%# Create a list of hashed requestors which have asked to join the team %>
+    <% 
+      @join_team_requests = JoinTeamRequest.where(team_id: result[:team_id])
+      @join_team_requests.each do |join_team_request|
+        if join_team_request.status=='P'
+          requestors_names << User.find(Participant.find(join_team_request.participant_id).user_id).name
+          requestors << {name: User.find(Participant.find(join_team_request.participant_id).user_id).name, request_id: join_team_request.id}
+        end
+      end 
+    %>
+    <% puts requestors %>
+
     <%
       team_members = []
       TeamsUser.where(team_id: result[:team_id]).each{|teamuser|
@@ -26,7 +40,7 @@
         <td align="center" width="500"><%= result[:name] %></td>
         <td align="center" width="500"><%= team_members.join(', ') %></td>
         <td align="center" width="500"><%= result[:comments_for_advertisement] %></td>
-        <% if  Participant.where(parent_id: result[:assignment_id], user_id: session[:user].id).first && !team_members.include?(session[:user].name) && ad_request.nil? %>
+        <% if  Participant.where(parent_id: result[:assignment_id], user_id: session[:user].id).first && !team_members.include?(session[:user].name) && !requestors_names.include?(session[:user].name) %>
           <td align="center"><%= link_to "Request invitation", :controller => 'join_team_requests', :action => 'new',
             :assignment_id=>result[:assignment_id],
             :topic_id=>result[:topic_id],
@@ -38,8 +52,16 @@
           <% if team_members.include?(session[:user].name) %>
             <td align="center"><img src="/assets/info.png" title="You're a member of this team and cannot request to join!"></td>
           <% else %>
+            <%
+              desired_id = -1
+              requestors.each do |requestor|
+                if requestor[:name] == session[:user].name
+                  desired_id = requestor[:request_id]
+                end
+              end
+            %>
             <td align="center"><%= link_to "Edit invitation", :controller => 'join_team_requests', :action => 'edit',
-                  :id=>ad_request.id
+                  :id=>desired_id
                 %>
               <img src="/assets/info.png" title="Edit your request to join this team">
             </td>

--- a/app/views/sign_up_sheet/show_team.html.erb
+++ b/app/views/sign_up_sheet/show_team.html.erb
@@ -10,7 +10,6 @@
     <th width="500">Action</th>
   </tr>
 
-  <% count = 0 %>
   <% requestors = [] %>
   <% requestors_names = [] %>
 

--- a/app/views/sign_up_sheet/show_team.html.erb
+++ b/app/views/sign_up_sheet/show_team.html.erb
@@ -27,7 +27,6 @@
         end
       end 
     %>
-    <% puts requestors %>
 
     <%
       team_members = []

--- a/app/views/sign_up_sheet/show_team.html.erb
+++ b/app/views/sign_up_sheet/show_team.html.erb
@@ -26,7 +26,7 @@
         <td align="center" width="500"><%= result[:name] %></td>
         <td align="center" width="500"><%= team_members.join(', ') %></td>
         <td align="center" width="500"><%= result[:comments_for_advertisement] %></td>
-        <% if  Participant.where(parent_id: result[:assignment_id], user_id: session[:user].id).first && ad_request.nil? %>
+        <% if  Participant.where(parent_id: result[:assignment_id], user_id: session[:user].id).first && !team_members.include?(session[:user].name) && ad_request.nil? %>
           <td align="center"><%= link_to "Request invitation", :controller => 'join_team_requests', :action => 'new',
             :assignment_id=>result[:assignment_id],
             :topic_id=>result[:topic_id],

--- a/app/views/sign_up_sheet/show_team.html.erb
+++ b/app/views/sign_up_sheet/show_team.html.erb
@@ -13,7 +13,7 @@
   <% count=0 %>
   <%# @results is the ad_info for an assignment's topic %>
   <% @results.each {|result| %>
-    <% ad_request = JoinTeamRequest.where(team_id: result[:team_id], participant_id: session[:user].id) %>
+    <% ad_request = JoinTeamRequest.where(team_id: result[:team_id], participant_id: session[:user].id).first %>
     <%
       team_members = []
       TeamsUser.where(team_id: result[:team_id]).each{|teamuser|

--- a/app/views/sign_up_sheet/show_team.html.erb
+++ b/app/views/sign_up_sheet/show_team.html.erb
@@ -13,7 +13,7 @@
   <% count=0 %>
   <%# @results is the ad_info for an assignment's topic %>
   <% @results.each {|result| %>
-
+    <% ad_request = JoinTeamRequest.where(team_id: result[:team_id], participant_id: session[:user].id) %>
     <%
       team_members = []
       TeamsUser.where(team_id: result[:team_id]).each{|teamuser|
@@ -25,7 +25,7 @@
         <td align="center" width="500"><%= result[:name] %></td>
         <td align="center" width="500"><%= team_members.join(', ') %></td>
         <td align="center" width="500"><%= result[:comments_for_advertisement] %></td>
-        <% if  Participant.where(parent_id: result[:assignment_id], user_id: session[:user].id).first && result[:request].nil? %>
+        <% if  Participant.where(parent_id: result[:assignment_id], user_id: session[:user].id).first && ad_request.nil? %>
           <td align="center"><%= link_to "Request invitation", :controller => 'join_team_requests', :action => 'new',
             :assignment_id=>result[:assignment_id],
             :topic_id=>result[:topic_id],
@@ -35,17 +35,18 @@
           </td>
       </tr>
     <% else %>
-      <% if !team_members.include?(session[:user].name) %>
-        <td align="center"><%= link_to "Edit invitation", :controller => 'join_team_requests', :action => 'edit',
-              :id=>result[:request].id
-            %>
-          <img src="/assets/info.png" title="Edit your request to join this team">
-        </td>
       <% else %>
-        <td align="center"><%= "You are part of this team and cannot request to join" %></td>
+        <% if team_members.include?(session[:user].name) %>
+          <td align="center"><img src="/assets/info.png" title="You're a member of this team and cannot request to join!"></td>
+        <% else %>
+          <td align="center"><%= link_to "Edit invitation", :controller => 'join_team_requests', :action => 'edit',
+                :id=>ad_request.id
+              %>
+            <img src="/assets/info.png" title="Edit your request to join this team">
+          </td>
+        <% end %>
       <% end %>
     <% end %>
-  <% end %>
   <% } %>
 
 </table>

--- a/app/views/sign_up_sheet/show_team.html.erb
+++ b/app/views/sign_up_sheet/show_team.html.erb
@@ -20,13 +20,13 @@
 TeamsUser.where(team_id: result[:team_id]).each{|teamuser|
   team_members+=User.find(teamuser.user_id).name+" "
 }
-      if result[:advertise_for_partner] == true || result[:advertise_for_partner] == 1
+      if result[:advertise_for_partner]|| result[:advertise_for_partner] == 1
       %>
     <tr>
       <td align="center" width="500"><%= result[:name] %></td>
       <td align="center" width="500"><%= team_members  %></td>
       <td align="center" width="500"><%= result[:comments_for_advertisement] %></td>
-      <% if  Participant.where(parent_id: result[:assignment_id], user_id: session[:user].id).first!=nil %>
+      <% if  Participant.where(parent_id: result[:assignment_id], user_id: session[:user].id).first && result[:request].nil? %>
         <td align="center"><%= link_to "Request invitation", :controller => 'join_team_requests', :action => 'new',
           :assignment_id=>result[:assignment_id],
           :topic_id=>result[:topic_id],
@@ -36,7 +36,11 @@ TeamsUser.where(team_id: result[:team_id]).each{|teamuser|
       <img src="/assets/info.png" title="Send request to join this team">
     </td>
   <%else%>
-    <td></td>
+     <td align="center"><%= link_to "Edit invitation", :controller => 'join_team_requests', :action => 'edit',
+          :id=>result[:request].id
+        %>
+      <img src="/assets/info.png" title="Send request to join this team">
+    </td>
   <% end
   end %>
 

--- a/spec/controllers/sign_up_sheet_controller_spec.rb
+++ b/spec/controllers/sign_up_sheet_controller_spec.rb
@@ -735,7 +735,7 @@ describe SignUpSheetController do
 
   describe '#show_team' do
     it 'renders show_team page' do
-      allow(SignedUpTeam).to receive(:where).with('topic_id = ?', '1').and_return([signed_up_team])
+      allow(SignedUpTeam).to receive(:where).with(topic_id: 1).and_return([signed_up_team])
       allow(TeamsUser).to receive(:where).with(team_id: 1).and_return([double('TeamsUser', user_id: 1)])
       allow(User).to receive(:find).with(1).and_return(student)
       params = { assignment_id: 1, id: 1 }


### PR DESCRIPTION
added checks for if you were already on a team.
allow editing of invite rather than just sending a duplicate
closes issue #311 