### PR TITLE
Downgraded bootstrap-sass version to 3.4.1

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,7 +21,7 @@
   ],
   "dependencies": {
     "bootstrap": "latest",
-    "bootstrap-sass": "latest",
+    "bootstrap-sass": "3.4.1",
     "jquery": "latest",
     "react": "latest",
     "react-simpletabs": "latest",


### PR DESCRIPTION
Currently expertiza sass is breaking, which is due to recent changes in bootstrap-sass npm package. Downgrading to last stable version (3.4.1) so that app runs without breaking and maintains styling.