### PR TITLE
Fix Tag Prompts

### DIFF
--- a/app/controllers/tag_prompts_controller.rb
+++ b/app/controllers/tag_prompts_controller.rb
@@ -18,7 +18,7 @@ class TagPromptsController < ApplicationController
     @tagprompts = TagPrompt.all.order('prompt asc')
     @tagprompts.where!('prompt LIKE ?', "%#{params[:prompt]}%") if params.key?(:prompt) && (!params[:prompt] == '')
     @tagprompts.where!('desc LIKE ?', "%#{params[:desc]}%") if params.key?(:desc) && (!params[:desc] == '')
-    @tagprompts.where!('control_type LIKE ?', "%#{parasms[:control_type]}%") if params.key?(:control_type) && (!params[:control_type] == '')
+    @tagprompts.where!('control_type LIKE ?', "%#{params[:control_type]}%") if params.key?(:control_type) && (!params[:control_type] == '')
     render json: @tagprompts
   end
 

--- a/app/controllers/tag_prompts_controller.rb
+++ b/app/controllers/tag_prompts_controller.rb
@@ -43,4 +43,6 @@ class TagPromptsController < ApplicationController
   private
   def tag_prompts_params
     params.permit(:prompt, :desc, :control_type)
+  end
+  
 end


### PR DESCRIPTION
From issue #2359 
Can add tag prompts again, and also changes the spelling for the tag prompt toggle button to be clearer.

