### PR TITLE
Fix Crash for No Team Submissions

### DIFF
--- a/app/models/assignment_participant.rb
+++ b/app/models/assignment_participant.rb
@@ -170,6 +170,8 @@ class AssignmentParticipant < Participant
   # zhewei: this is the file path for reviewer to upload files during peer review
   def review_file_path(response_map_id = nil, participant = nil)
     puts "START \n"
+    puts response_map_id
+    puts participant
     if response_map_id.nil?
       return if participant.nil?
       no_team_path = assignment.path + '/' + participant.name.parameterize(separator: '_') + '_review'

--- a/app/models/assignment_participant.rb
+++ b/app/models/assignment_participant.rb
@@ -170,8 +170,8 @@ class AssignmentParticipant < Participant
   # zhewei: this is the file path for reviewer to upload files during peer review
   def review_file_path(response_map_id = nil, participant = nil)
     puts "START \n"
-    puts response_map_id
-    puts participant
+    puts "RESPONSEMAPID: " + response_map_id
+    puts "PARTICIPANT: " + participant
     if response_map_id.nil?
       return if participant.nil?
       no_team_path = assignment.path + '/' + participant.name.parameterize(separator: '_') + '_review'

--- a/app/models/assignment_participant.rb
+++ b/app/models/assignment_participant.rb
@@ -172,7 +172,9 @@ class AssignmentParticipant < Participant
     if response_map_id.nil?
       return if participant.nil?
       no_team_path = assignment.path + '/' + participant.name.parameterize(separator: '_') + '_review'
+      puts "No team path: " + no_team_path
       return no_team_path if participant.team.nil?
+      puts participant.team.nil?
     end
 
     response_map = ResponseMap.find(response_map_id)

--- a/app/models/assignment_participant.rb
+++ b/app/models/assignment_participant.rb
@@ -168,7 +168,13 @@ class AssignmentParticipant < Participant
   end
 
   # zhewei: this is the file path for reviewer to upload files during peer review
-  def review_file_path(response_map_id)
+  def review_file_path(response_map_id = nil, participant = nil)
+    if response_map_id.nil?
+      return if participant.nil?
+      no_team_path = assignment.path + '/' + participant.name.parameterize(separator: '_') + '_review'
+      return no_team_path if participant.team.nil?
+    end
+
     response_map = ResponseMap.find(response_map_id)
     first_user_id = TeamsUser.find_by(team_id: response_map.reviewee_id).user_id
     participant = Participant.find_by(parent_id: response_map.reviewed_object_id, user_id: first_user_id)

--- a/app/models/assignment_participant.rb
+++ b/app/models/assignment_participant.rb
@@ -169,6 +169,7 @@ class AssignmentParticipant < Participant
 
   # zhewei: this is the file path for reviewer to upload files during peer review
   def review_file_path(response_map_id = nil, participant = nil)
+    puts "START \n"
     if response_map_id.nil?
       return if participant.nil?
       no_team_path = assignment.path + '/' + participant.name.parameterize(separator: '_') + '_review'
@@ -177,6 +178,7 @@ class AssignmentParticipant < Participant
       puts participant.team.nil?
     end
 
+    puts "END \n"
     response_map = ResponseMap.find(response_map_id)
     first_user_id = TeamsUser.find_by(team_id: response_map.reviewee_id).user_id
     participant = Participant.find_by(parent_id: response_map.reviewed_object_id, user_id: first_user_id)

--- a/app/models/assignment_participant.rb
+++ b/app/models/assignment_participant.rb
@@ -169,20 +169,12 @@ class AssignmentParticipant < Participant
 
   # zhewei: this is the file path for reviewer to upload files during peer review
   def review_file_path(response_map_id = nil, participant = nil)
-    puts "START \n"
-    puts "RESPONSEMAPID: "
-    puts response_map_id
-    puts "PARTICIPANT: "
-    puts participant
     if response_map_id.nil?
       return if participant.nil?
       no_team_path = assignment.path + '/' + participant.name.parameterize(separator: '_') + '_review'
-      puts "No team path: " + no_team_path
       return no_team_path if participant.team.nil?
-      puts participant.team.nil?
     end
 
-    puts "END \n"
     response_map = ResponseMap.find(response_map_id)
     first_user_id = TeamsUser.find_by(team_id: response_map.reviewee_id).user_id
     participant = Participant.find_by(parent_id: response_map.reviewed_object_id, user_id: first_user_id)

--- a/app/models/assignment_participant.rb
+++ b/app/models/assignment_participant.rb
@@ -170,8 +170,10 @@ class AssignmentParticipant < Participant
   # zhewei: this is the file path for reviewer to upload files during peer review
   def review_file_path(response_map_id = nil, participant = nil)
     puts "START \n"
-    puts "RESPONSEMAPID: " + response_map_id
-    puts "PARTICIPANT: " + participant
+    puts "RESPONSEMAPID: "
+    puts response_map_id
+    puts "PARTICIPANT: "
+    puts participant
     if response_map_id.nil?
       return if participant.nil?
       no_team_path = assignment.path + '/' + participant.name.parameterize(separator: '_') + '_review'

--- a/app/views/submitted_content/_main.html.erb
+++ b/app/views/submitted_content/_main.html.erb
@@ -6,11 +6,6 @@
   <% end %>
 <% end %>
 <br/>
-<!-- 
-<% if participant.team.hyperlinks.try(:length) %>
-  <%= render :partial => 'submitted_content/hyperlink', :locals => {:participant => participant, stage: @stage} %>
-<% end %>
--->
 <%= render partial: 'submitted_content/submitted_files', locals: {participant: participant, stage: @stage, origin: ''} %>
 <% if @assignment.require_quiz? %>
   <!-- Setting the t_id for team assignments. The t_id should be not be nil because when the user does not have team, "your work" is unclickable-->

--- a/app/views/submitted_content/_main.html.erb
+++ b/app/views/submitted_content/_main.html.erb
@@ -6,9 +6,11 @@
   <% end %>
 <% end %>
 <br/>
+<!-- 
 <% if participant.team.hyperlinks.try(:length) %>
   <%= render :partial => 'submitted_content/hyperlink', :locals => {:participant => participant, stage: @stage} %>
 <% end %>
+-->
 <%= render partial: 'submitted_content/submitted_files', locals: {participant: participant, stage: @stage, origin: ''} %>
 <% if @assignment.require_quiz? %>
   <!-- Setting the t_id for team assignments. The t_id should be not be nil because when the user does not have team, "your work" is unclickable-->

--- a/app/views/submitted_content/_main.html.erb
+++ b/app/views/submitted_content/_main.html.erb
@@ -7,7 +7,7 @@
 <% end %>
 <br/>
 <% if participant.team.nil? %>
-  <%= flash[:warn] = 'Submitted content while not on a team is not supported by Expertiza currently.'%>
+  <% flash[:warn] = 'Submitting content while not on a team is not supported by Expertiza currently.' %>
 <% elsif participant.team.hyperlinks.try(:length) %>
   <%= render :partial => 'submitted_content/hyperlink', :locals => {:participant => participant, stage: @stage} %>
 <% end %>

--- a/app/views/submitted_content/_main.html.erb
+++ b/app/views/submitted_content/_main.html.erb
@@ -6,6 +6,11 @@
   <% end %>
 <% end %>
 <br/>
+<% if participant.team.nil? %>
+  <%= flash[:warn] = 'Submitted content while not on a team is not supported by Expertiza currently.'%>
+<% elsif participant.team.hyperlinks.try(:length) %>
+  <%= render :partial => 'submitted_content/hyperlink', :locals => {:participant => participant, stage: @stage} %>
+<% end %>
 <%= render partial: 'submitted_content/submitted_files', locals: {participant: participant, stage: @stage, origin: ''} %>
 <% if @assignment.require_quiz? %>
   <!-- Setting the t_id for team assignments. The t_id should be not be nil because when the user does not have team, "your work" is unclickable-->

--- a/app/views/submitted_content/_submitted_files.html.erb
+++ b/app/views/submitted_content/_submitted_files.html.erb
@@ -4,7 +4,7 @@
   <% files = participant.files(participant.review_file_path(response_map_id).to_s + current_folder.name) %>
 <% else %>
   <% if participant.team.nil? %>
-    <% files = participant.files(participant.review_file_path(participant: participant).to_s + current_folder.name) %>
+    <% files = participant.files(participant.review_file_path(nil, participant).to_s + current_folder.name) %>
   <% else %>
     <% files = participant.team.files(participant.team.path.to_s + current_folder.name) %>
   <% end %>

--- a/app/views/submitted_content/_submitted_files.html.erb
+++ b/app/views/submitted_content/_submitted_files.html.erb
@@ -4,7 +4,7 @@
   <% files = participant.files(participant.review_file_path(response_map_id).to_s + current_folder.name) %>
 <% else %>
   <% if participant.team.nil? %>
-    <% files = participant.files(participant.review_file_path(response_map_id).to_s + current_folder.name) %>
+    <% files = participant.files(participant.review_file_path(response_map_id: nil, participant: participant).to_s + current_folder.name) %>
   <% else %>
     <% files = participant.team.files(participant.team.path.to_s + current_folder.name) %>
   <% end %>

--- a/app/views/submitted_content/_submitted_files.html.erb
+++ b/app/views/submitted_content/_submitted_files.html.erb
@@ -3,7 +3,11 @@
 <% if origin == 'review' %>
   <% files = participant.files(participant.review_file_path(response_map_id).to_s + current_folder.name) %>
 <% else %>
-  <% files = participant.team.files(participant.team.path.to_s + current_folder.name) %>
+  <% if participant.team.nil? %>
+    <% files = participant.files(participant.review_file_path(response_map_id).to_s + current_folder.name) %>
+  <% else %>
+    <% files = participant.team.files(participant.team.path.to_s + current_folder.name) %>
+  <% end %>
 <%end%>
 
 <%session_participant = AssignmentParticipant.where(parent_id: @assignment.id, user_id: session[:user].id).first%>

--- a/app/views/submitted_content/_submitted_files.html.erb
+++ b/app/views/submitted_content/_submitted_files.html.erb
@@ -4,7 +4,7 @@
   <% files = participant.files(participant.review_file_path(response_map_id).to_s + current_folder.name) %>
 <% else %>
   <% if participant.team.nil? %>
-    <% files = participant.files(participant.review_file_path(response_map_id: nil, participant: participant).to_s + current_folder.name) %>
+    <% files = participant.files(participant.review_file_path(participant: participant).to_s + current_folder.name) %>
   <% else %>
     <% files = participant.team.files(participant.team.path.to_s + current_folder.name) %>
   <% end %>


### PR DESCRIPTION
Just a temporary fix for the crash when submitting something on an assignment without teams. So many functions need the participant to be on a team, and submitting content when not on a team is literally not possible with how Expertiza is setup. 

I think we eventually need to replace the option to enable teams with a forced box that defaults to 2 members per team. If you decrease it to one, that would accomplish what we want while not breaking everything. 

![image](https://user-images.githubusercontent.com/41524135/163471763-a3c544a0-a42e-428a-842d-30b5886d799d.png)

![image](https://user-images.githubusercontent.com/41524135/163471727-19d039d6-93ad-4964-992a-a629fb2bbc5c.png)
