### PR TITLE
Force team creation

### DIFF
--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -60,7 +60,9 @@ class Assignment < ApplicationRecord
 
   # TODO app breaks when max team size is set as > 1 and team has only one member
   def team_assignment?
-    max_team_size > 1
+    # All assignments should be team assignments
+    # max_team_size > 1
+    true
   end
   alias team_assignment team_assignment?
 

--- a/app/views/assignments/edit/_general.html.erb
+++ b/app/views/assignments/edit/_general.html.erb
@@ -94,9 +94,6 @@ function autogenerate_submission(){
     <td style='padding:5px' id='assignment_team_assignment_field'>
 
       <div class="form-inline">
-        <% @assignment_form.assignment.max_team_size %>
-        <%= label_tag('team_assignment', 'Has teams?') %>
-
         <span style='padding:5px' class="form-inline" id='assignment_team_count_field' <%= 'hidden' unless @assignment_form.assignment.team_assignment?%>>
           <!--Teammate reviews fields-->
           <input name="assignment_form[assignment][show_teammate_reviews]" type="hidden" value="false"/>

--- a/app/views/assignments/edit/_general.html.erb
+++ b/app/views/assignments/edit/_general.html.erb
@@ -94,7 +94,7 @@ function autogenerate_submission(){
     <td style='padding:5px' id='assignment_team_assignment_field'>
 
       <div class="form-inline">
-        <%= check_box_tag('team_assignment', 'true', @assignment_form.assignment.team_assignment?, {:onChange => 'hasTeamsChanged()'}) %>
+        <%= check_box_tag('team_assignment', 'true', @assignment_form.assignment.team_assignment?, {:onChange => 'hasTeamsChanged()'}, disabled=true) %>
         <% @assignment_form.assignment.max_team_size %>
         <%= label_tag('team_assignment', 'Has teams?') %>
 

--- a/app/views/assignments/edit/_general.html.erb
+++ b/app/views/assignments/edit/_general.html.erb
@@ -94,7 +94,6 @@ function autogenerate_submission(){
     <td style='padding:5px' id='assignment_team_assignment_field'>
 
       <div class="form-inline">
-        <%= check_box_tag('team_assignment', 'true', @assignment_form.assignment.team_assignment?, {:onChange => 'hasTeamsChanged()'}, disabled=true) %>
         <% @assignment_form.assignment.max_team_size %>
         <%= label_tag('team_assignment', 'Has teams?') %>
 

--- a/app/views/student_task/view.html.erb
+++ b/app/views/student_task/view.html.erb
@@ -34,7 +34,7 @@
 
 <!--ACS Here we need to know the size of the team to decide whether or not
 to display the label "Your team" in the student assignment tasks-->
-  <%if @assignment.max_team_size > 1 %>
+  <%if @assignment.max_team_size > 0 %>
     <% if @authorization == 'participant' %>
       <li>
         <%= link_to t('.your_team'), view_student_teams_path(student_id: @participant.id) %>

--- a/app/views/teams/new.html.erb
+++ b/app/views/teams/new.html.erb
@@ -9,7 +9,7 @@
     <% if @parent.is_a?(Course)%>
           Team Size:<%= select_tag 'team_size', options_for_select(2..4), size: 1 %>
     <% else %>
-          Team Size:<%= select_tag 'team_size', options_for_select(2..@parent.max_team_size), size: 1 %>
+          Team Size:<%= select_tag 'team_size', options_for_select(1..@parent.max_team_size), size: 1 %>
     <% end %>
 <%= hidden_field_tag 'id', @parent.id %>
 


### PR DESCRIPTION
Expertiza does not work when teams are disabled and students are by themselves. This forces team creation with a default of 1 person teams.

Tested submitting links and files, reviewing, and viewing scores/reports.

All seems to be fine, the two issues I found exist on beta for bigger teams as well I think.

Issue #2258 :
I submitted a review from two students on each other. The bar chart shows the scores, but only one team appears in the bottom table.
![image](https://user-images.githubusercontent.com/41524135/164052231-601dc656-38ff-43cf-a616-d41797d28065.png)

Issue 2:
Submitting a grade/comment does not save from Review Report. This one may be a new issue?
![image](https://user-images.githubusercontent.com/41524135/164052490-c0480a0e-4978-4b1c-8874-a37dc6448505.png)

