### PR TITLE
Fix forced team creation

### DIFF
--- a/app/views/assignments/edit/_general.html.erb
+++ b/app/views/assignments/edit/_general.html.erb
@@ -94,7 +94,7 @@ function autogenerate_submission(){
     <td style='padding:5px' id='assignment_team_assignment_field'>
 
       <div class="form-inline">
-        <span style='padding:5px' class="form-inline" id='assignment_team_count_field' onLoad='hasTeamsChanged()' <%= 'hidden' unless @assignment_form.assignment.team_assignment?%>>
+        <span style='padding:5px' class="form-inline" id='assignment_team_count_field' onload='hasTeamsChanged()' <%= 'hidden' unless @assignment_form.assignment.team_assignment?%>>
           <!--Teammate reviews fields-->
           <input name="assignment_form[assignment][show_teammate_reviews]" type="hidden" value="false"/>
           <%= label_tag('assignment_form[assignment][max_team_size]', 'Maximum number of members per team:') %>

--- a/app/views/assignments/edit/_general.html.erb
+++ b/app/views/assignments/edit/_general.html.erb
@@ -96,6 +96,7 @@ function autogenerate_submission(){
       <div class="form-inline">
         <span style='padding:5px' class="form-inline" id='assignment_team_count_field' <%= 'hidden' unless @assignment_form.assignment.team_assignment?%>>
           <!--Teammate reviews fields-->
+          <%= hasTeamsChanged() %>
           <input name="assignment_form[assignment][show_teammate_reviews]" type="hidden" value="false"/>
           <%= label_tag('assignment_form[assignment][max_team_size]', 'Maximum number of members per team:') %>
           <%= text_field_tag('assignment_form[assignment][max_team_size]', @assignment_form.assignment.max_team_size, {:style => 'width:50px;', class: 'form-control'}) %>
@@ -309,33 +310,16 @@ function autogenerate_submission(){
         var autoAssignMentorCheckbox = jQuery('#auto_assign_mentor_checkbox');
 
         jQuery("#questionnaire_table_TeammateReviewQuestionnaire").remove()
-        if (checkbox.is(':checked')) {
-            team_count_field.removeAttr('hidden');
-            team_formation_due_date_checkbox.removeAttr('hidden')
-            jQuery('#assignment_form_assignment_max_team_size').val('2');
-            teammate_reviews_field.removeAttr('hidden');
-            // E2115 hide auto assign mentor checkbox when an
-            // an assignment does not have teams
-            // what would the mentor be assigned to if there are no teams?
-            autoAssignMentorCheckbox.hide();
-            addDueDateTableElement(<%= @due_date_nameurl_not_empty==nil ? false:@due_date_nameurl_not_empty %>,'team_formation', 0,<%= due_date(@assignment_form.assignment, 'team_formation').to_json.html_safe %>);
-        } else {
-            if (confirm(msg)) {
-              team_count_field.attr('hidden', true);
-              team_formation_due_date_checkbox.attr('hidden', true)
-              teammate_reviews_field.attr('hidden', true);
-              // E2115 show auto assign mentor checkbox when an
-              // an assignment has teams
-              autoAssignMentorCheckbox.show();
-              document.getElementById('assignment_form_assignment_max_team_size').value = '1';
-              removeDueDateTableElement('team_formation', 0);
-            } else {
-              checkbox.prop('checked', true);
-            }
-            if (<%= !@assignment_form.assignment.team_assignment?%>){
-              team_count_field.attr('hidden', true);
-            }
-          } 
+
+        team_count_field.removeAttr('hidden');
+        team_formation_due_date_checkbox.removeAttr('hidden')
+        jQuery('#assignment_form_assignment_max_team_size').val('2');
+        teammate_reviews_field.removeAttr('hidden');
+        // E2115 hide auto assign mentor checkbox when an
+        // an assignment does not have teams
+        // what would the mentor be assigned to if there are no teams?
+        autoAssignMentorCheckbox.hide();
+        addDueDateTableElement(<%= @due_date_nameurl_not_empty==nil ? false:@due_date_nameurl_not_empty %>,'team_formation', 0,<%= due_date(@assignment_form.assignment, 'team_formation').to_json.html_safe %>);
     }
 
     function staggeredDeadlineChanged() {

--- a/app/views/assignments/edit/_general.html.erb
+++ b/app/views/assignments/edit/_general.html.erb
@@ -107,7 +107,7 @@ function autogenerate_submission(){
       &nbsp;&nbsp;&nbsp;&nbsp;
       <!--Maximum number of members per team-->
   </tr>
-
+  <%= puts("adding due date table now \n")%>
   <body onload="addDueDateTableElement(<%= @due_date_nameurl_not_empty==nil ? false:@due_date_nameurl_not_empty %>,'team_formation', 0,<%= due_date(@assignment_form.assignment, 'team_formation').to_json.html_safe %>);">
 
   <!-- E2115 Mentor Management -->

--- a/app/views/assignments/edit/_general.html.erb
+++ b/app/views/assignments/edit/_general.html.erb
@@ -107,8 +107,6 @@ function autogenerate_submission(){
       &nbsp;&nbsp;&nbsp;&nbsp;
       <!--Maximum number of members per team-->
   </tr>
-  <%= puts("adding due date table now \n")%>
-  <body onload="addDueDateTableElement(<%= @due_date_nameurl_not_empty==nil ? false:@due_date_nameurl_not_empty %>,'team_formation', 0,<%= due_date(@assignment_form.assignment, 'team_formation').to_json.html_safe %>);">
 
   <!-- E2115 Mentor Management -->
   <tr>
@@ -300,28 +298,6 @@ function autogenerate_submission(){
     }
     <% end %>
 
-    <!-- Violation of DRY principle, adds input field and handles checkboxes hidden states in other views -->
-    function hasTeamsChanged() {
-        var msg = 'Warning! Unchecking this box will hide teams that already exist.';
-        var checkbox = jQuery('#team_assignment');
-        var team_count_field = jQuery('#assignment_team_count_field');
-        var teammate_reviews_field = jQuery('#assignment_show_teammate_reviews');
-        var team_formation_due_date_checkbox = jQuery('#team_formation_due_date_checkbox');
-        var autoAssignMentorCheckbox = jQuery('#auto_assign_mentor_checkbox');
-
-        jQuery("#questionnaire_table_TeammateReviewQuestionnaire").remove()
-
-        team_count_field.removeAttr('hidden');
-        team_formation_due_date_checkbox.removeAttr('hidden')
-        jQuery('#assignment_form_assignment_max_team_size').val('2');
-        teammate_reviews_field.removeAttr('hidden');
-        // E2115 hide auto assign mentor checkbox when an
-        // an assignment does not have teams
-        // what would the mentor be assigned to if there are no teams?
-        autoAssignMentorCheckbox.hide();
-        addDueDateTableElement(<%= @due_date_nameurl_not_empty==nil ? false:@due_date_nameurl_not_empty %>,'team_formation', 0,<%= due_date(@assignment_form.assignment, 'team_formation').to_json.html_safe %>);
-    }
-
     function staggeredDeadlineChanged() {
       var msg = 'Warning! Unchecking all topics for this assignment will now have the same deadline.'
       if (!jQuery('#assignment_staggered_deadline').is(':checked')) {
@@ -362,6 +338,7 @@ function autogenerate_submission(){
     }
 
     jQuery(document).ready(function() {
+      addDueDateTableElement(<%= @due_date_nameurl_not_empty==nil ? false:@due_date_nameurl_not_empty %>,'team_formation', 0,<%= due_date(@assignment_form.assignment, 'team_formation').to_json.html_safe %>);
       jQuery('input[type=radio][name=num_reviews]').change(function(){
         if (this.value == 'student'){
           jQuery('#num_reviews_per_student_threshold').removeAttr('hidden');

--- a/app/views/assignments/edit/_general.html.erb
+++ b/app/views/assignments/edit/_general.html.erb
@@ -92,9 +92,8 @@ function autogenerate_submission(){
 
   <tr>
     <td style='padding:5px' id='assignment_team_assignment_field'>
-
       <div class="form-inline">
-        <span style='padding:5px' class="form-inline" id='assignment_team_count_field' <%= 'hidden' %>>
+        <span style='padding:5px' class="form-inline" id='assignment_team_count_field' <%= 'hidden' unless @assignment_form.assignment.team_assignment?%>>
           <!--Teammate reviews fields-->
           <input name="assignment_form[assignment][show_teammate_reviews]" type="hidden" value="false"/>
           <%= label_tag('assignment_form[assignment][max_team_size]', 'Maximum number of members per team:') %>
@@ -109,9 +108,11 @@ function autogenerate_submission(){
       <!--Maximum number of members per team-->
   </tr>
 
+  <body onload="addDueDateTableElement(<%= @due_date_nameurl_not_empty==nil ? false:@due_date_nameurl_not_empty %>,'team_formation', 0,<%= due_date(@assignment_form.assignment, 'team_formation').to_json.html_safe %>);">
+
   <!-- E2115 Mentor Management -->
   <tr>
-    <td style='padding:5px' id='assignment_auto_assign_mentor_field' onload="hasTeamsChanged()">
+    <td style='padding:5px' id='assignment_auto_assign_mentor_field'>
       <input name="assignment_form[assignment][auto_assign_mentor]" type="hidden" value="false"/>
       <%= check_box_tag(
             'assignment_form[assignment][auto_assign_mentor]',

--- a/app/views/assignments/edit/_general.html.erb
+++ b/app/views/assignments/edit/_general.html.erb
@@ -94,13 +94,14 @@ function autogenerate_submission(){
     <td style='padding:5px' id='assignment_team_assignment_field'>
 
       <div class="form-inline">
-        <span style='padding:5px' class="form-inline" id='assignment_team_count_field' onload='hasTeamsChanged()' <%= 'hidden' unless @assignment_form.assignment.team_assignment?%>>
+        <span style='padding:5px' class="form-inline" id='assignment_team_count_field' <%= 'hidden' %>>
           <!--Teammate reviews fields-->
           <input name="assignment_form[assignment][show_teammate_reviews]" type="hidden" value="false"/>
           <%= label_tag('assignment_form[assignment][max_team_size]', 'Maximum number of members per team:') %>
           <%= text_field_tag('assignment_form[assignment][max_team_size]', @assignment_form.assignment.max_team_size, {:style => 'width:50px;', class: 'form-control'}) %>
         </span>
       </div>
+      <%= onload='hasTeamsChanged()' %>
       <span id='assignment_show_teammate_reviews' class="form-inline"  <%= 'hidden' unless @assignment_form.assignment.team_assignment?%>>
         <%= check_box_tag('assignment_form[assignment][show_teammate_reviews]', 'true', @assignment_form.assignment.show_teammate_reviews) %>
         <%= label_tag('assignment_form[assignment][show_teammate_reviews]', 'Show teammate reviews?') %>

--- a/app/views/assignments/edit/_general.html.erb
+++ b/app/views/assignments/edit/_general.html.erb
@@ -94,9 +94,8 @@ function autogenerate_submission(){
     <td style='padding:5px' id='assignment_team_assignment_field'>
 
       <div class="form-inline">
-        <span style='padding:5px' class="form-inline" id='assignment_team_count_field' <%= 'hidden' unless @assignment_form.assignment.team_assignment?%>>
+        <span style='padding:5px' class="form-inline" id='assignment_team_count_field' onLoad='hasTeamsChanged()' <%= 'hidden' unless @assignment_form.assignment.team_assignment?%>>
           <!--Teammate reviews fields-->
-          <%= hasTeamsChanged() %>
           <input name="assignment_form[assignment][show_teammate_reviews]" type="hidden" value="false"/>
           <%= label_tag('assignment_form[assignment][max_team_size]', 'Maximum number of members per team:') %>
           <%= text_field_tag('assignment_form[assignment][max_team_size]', @assignment_form.assignment.max_team_size, {:style => 'width:50px;', class: 'form-control'}) %>

--- a/app/views/assignments/edit/_general.html.erb
+++ b/app/views/assignments/edit/_general.html.erb
@@ -101,8 +101,7 @@ function autogenerate_submission(){
           <%= text_field_tag('assignment_form[assignment][max_team_size]', @assignment_form.assignment.max_team_size, {:style => 'width:50px;', class: 'form-control'}) %>
         </span>
       </div>
-      <%= onload='hasTeamsChanged()' %>
-      <span id='assignment_show_teammate_reviews' class="form-inline"  <%= 'hidden' unless @assignment_form.assignment.team_assignment?%>>
+      <span id='assignment_show_teammate_reviews' class="form-inline" onload="hasTeamsChanged()" <%= 'hidden' unless @assignment_form.assignment.team_assignment?%>>
         <%= check_box_tag('assignment_form[assignment][show_teammate_reviews]', 'true', @assignment_form.assignment.show_teammate_reviews) %>
         <%= label_tag('assignment_form[assignment][show_teammate_reviews]', 'Show teammate reviews?') %>
       </span>

--- a/app/views/assignments/edit/_general.html.erb
+++ b/app/views/assignments/edit/_general.html.erb
@@ -101,7 +101,7 @@ function autogenerate_submission(){
           <%= text_field_tag('assignment_form[assignment][max_team_size]', @assignment_form.assignment.max_team_size, {:style => 'width:50px;', class: 'form-control'}) %>
         </span>
       </div>
-      <span id='assignment_show_teammate_reviews' class="form-inline" onload="hasTeamsChanged()" <%= 'hidden' unless @assignment_form.assignment.team_assignment?%>>
+      <span id='assignment_show_teammate_reviews' class="form-inline" <%= 'hidden' unless @assignment_form.assignment.team_assignment?%>>
         <%= check_box_tag('assignment_form[assignment][show_teammate_reviews]', 'true', @assignment_form.assignment.show_teammate_reviews) %>
         <%= label_tag('assignment_form[assignment][show_teammate_reviews]', 'Show teammate reviews?') %>
       </span>
@@ -111,7 +111,7 @@ function autogenerate_submission(){
 
   <!-- E2115 Mentor Management -->
   <tr>
-    <td style='padding:5px' id='assignment_auto_assign_mentor_field'>
+    <td style='padding:5px' id='assignment_auto_assign_mentor_field' onload="hasTeamsChanged()">
       <input name="assignment_form[assignment][auto_assign_mentor]" type="hidden" value="false"/>
       <%= check_box_tag(
             'assignment_form[assignment][auto_assign_mentor]',

--- a/app/views/student_task/view.html.erb
+++ b/app/views/student_task/view.html.erb
@@ -44,22 +44,27 @@ to display the label "Your team" in the student assignment tasks-->
   <%end%>
 
   <!--Your work-->
-  <% if @team && (@authorization == 'participant' || @can_submit == true) %>
+  <% if @authorization == 'participant' || @can_submit == true %>
     <li>
-      <% if @topics.size > 0 %>
-        <% if @topic_id and @assignment.submission_allowed(@topic_id) %>
-          <%= link_to t(".your_work"), :controller => 'submitted_content', :action => 'edit', :id => @participant.id %> <%=t ".submit_work" %>
+      <% if @team %>
+        <% if @topics.size > 0 %>
+          <% if @topic_id and @assignment.submission_allowed(@topic_id) %>
+            <%= link_to t(".your_work"), :controller => 'submitted_content', :action => 'edit', :id => @participant.id %> <%=t ".submit_work" %>
+          <% else %>
+            <!--if one team do not hold a topic (still in waitlist), they cannot submit their work.-->
+            <font color="gray"><%=t ".your_work" %></font> <%=t ".choose_topic" %>
+          <% end %>
         <% else %>
-          <!--if one team do not hold a topic (still in waitlist), they cannot submit their work.-->
-          <font color="gray"><%=t ".your_work" %></font> <%=t ".choose_topic" %>
+          <% if @assignment.submission_allowed(@topic_id) %>
+            <%= link_to t(".your_work"), :controller => 'submitted_content', :action => 'edit', :id => @participant.id %> <%=t ".submit_work" %>
+          <% else %>
+            <font color="gray"><%=t ".your_work" %></font> <%=t ".not_allowed" %>
+          <% end %>
         <% end %>
       <% else %>
-        <% if @assignment.submission_allowed(@topic_id) %>
-          <%= link_to t(".your_work"), :controller => 'submitted_content', :action => 'edit', :id => @participant.id %> <%=t ".submit_work" %>
-        <% else %>
-          <font color="gray"><%=t ".your_work" %></font> <%=t ".not_allowed" %>
-        <% end %>
-      <% end %>
+        <!-- Must be on a team to click "Your Work" -->
+        <font color="gray"><%=t ".your_work" %></font> <%=t ".not_allowed" %>
+      <% end%>
     </li>
   <% end %>
 

--- a/app/views/student_task/view.html.erb
+++ b/app/views/student_task/view.html.erb
@@ -44,7 +44,7 @@ to display the label "Your team" in the student assignment tasks-->
   <%end%>
 
   <!--Your work-->
-  <% if @authorization == 'participant' or @can_submit == true %>
+  <% if @team && (@authorization == 'participant' || @can_submit == true) %>
     <li>
       <% if @topics.size > 0 %>
         <% if @topic_id and @assignment.submission_allowed(@topic_id) %>


### PR DESCRIPTION
When making an assignment with more than 1 person teams, the teammate review row in rubrics is not added.

The hasTeamsChanged() method used to call a function to do this. I removed hasTeamsChanged though because it used to be called on checkbox change, and all of its other functionality besides calling addDueDateTableElement() is useless now.

I tried adding the call to addDueDateTableElement() at the bottom in the jQuery(document).ready(function() {} section, like how it is in other files, but it doesn't seem to work still