### PR TITLE
Add participant_id to teams_users table

### DIFF
--- a/db/migrate/20221128192313_add_participant_id_to_teams_users.rb
+++ b/db/migrate/20221128192313_add_participant_id_to_teams_users.rb
@@ -1,0 +1,22 @@
+class AddParticipantIdToTeamsUsers < ActiveRecord::Migration[5.1]
+  def change
+    add_column :teams_users, :participant_id, :integer, index: true
+    # add_reference :teams_users, :participants
+    add_foreign_key :teams_users, :participants
+
+    teams_users = TeamsUser.all
+    teams_users.each do |teams_user|
+      if !teams_user.team_id.nil?
+        team = Team.find(teams_user.team_id)
+        if !team.nil?
+          participant = Participant.find_by(user_id: teams_user["user_id"], parent_id: team["parent_id"])
+          if !participant.nil?
+            teams_user.participant_id = participant["id"]
+            teams_user.save
+          end
+        end
+      end
+      next unless teams_user.participant_id
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20220405222420) do
+ActiveRecord::Schema.define(version: 20221128192313) do
 
   create_table "account_requests", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
     t.string "name"
@@ -718,7 +718,9 @@ ActiveRecord::Schema.define(version: 20220405222420) do
     t.integer "user_id"
     t.integer "duty_id"
     t.string "pair_programming_status", limit: 1
+    t.integer "participant_id"
     t.index ["duty_id"], name: "index_teams_users_on_duty_id"
+    t.index ["participant_id"], name: "fk_rails_7192605c92"
     t.index ["team_id"], name: "fk_users_teams"
     t.index ["user_id"], name: "fk_teams_users"
   end
@@ -832,6 +834,7 @@ ActiveRecord::Schema.define(version: 20220405222420) do
   add_foreign_key "tag_prompt_deployments", "questionnaires"
   add_foreign_key "tag_prompt_deployments", "tag_prompts"
   add_foreign_key "teams_users", "duties"
+  add_foreign_key "teams_users", "participants"
   add_foreign_key "teams_users", "teams", name: "fk_users_teams"
   add_foreign_key "teams_users", "users", name: "fk_teams_users"
 end


### PR DESCRIPTION
### E2283. Refactor student_teams functionality

- Created a column that would be called “participant_id”, which will be a foreign key that references participants table.
- Created a migration that fetches the assignment_id for each tuple from the teams table. We would find the participant with the help of the assignment_id we just got from the teams table and the user_id that is already present in the current table, and store its “id” in the participant_id column we created in the last step. You have to come with optimal migration strategy that reliably calculates the participant_id

@rjain09
@namanshrimali 


About the Expertiza Bot
- If you have any questions about comments given by the expertiza-bot [(example)](https://github.com/expertiza/expertiza/pull/1877#issuecomment-762412918), you could create a new comment in your pull request with the content `/dispute [UUID1] [UUID2]` [(example)](https://github.com/expertiza/expertiza/pull/1877#issuecomment-762430057), then the professor and TAs will be notified.
- [Here is a video](https://tinyurl.com/internet-bots) about how to communicate to the expertiza-bot.
