### PR TITLE
E2305. Grading audit trail

### DIFF
--- a/app/controllers/grades_controller.rb
+++ b/app/controllers/grades_controller.rb
@@ -162,6 +162,8 @@ class GradesController < ApplicationController
     @team = participant.team
     @team.grade_for_submission = params[:grade_for_submission]
     @team.comment_for_submission = params[:comment_for_submission]
+    # create a grading history entry for this assignment
+    # save the grade, comment, receiver, and instructor
     begin
       @team.save
       flash[:success] = 'Grade and comment for submission successfully saved.'


### PR DESCRIPTION
Changes made for implementing Grading Audit Trail as per Project E2305.

Problem: Any instructor can assign/edit a grade freely. There is no way of tracking who did it.
Web pages:  
1. Review grade: Log in as instructor -> Manage -> Assignments -> View Review Report 
2. Submission grade: Log in as instructor -> Manage -> Assignments -> View submissions

In this pull request, a grading audit trail will be created with the following information: 
- When a grade is assigned by an instructor, an indication of who did it and when it was done. 
- Comments previously provided by other instructors.
- This information will be stored every time an instructor edits a grade/comment and clicks the save button.

The grading log entry will include the instructor id, assignment id, student id, grade, comment, and timestamp.


Note: The review Report page has been broken by someone else in earlier commits which needs to be fixed before adding history for review grades.
