### PR TITLE
Adding a button to delete all topics (#2637)

### DIFF
--- a/app/views/sign_up_sheet/_add_topics.html.erb
+++ b/app/views/sign_up_sheet/_add_topics.html.erb
@@ -57,7 +57,7 @@
                     'Topic Link <em>(optional)</em>' %> |
 
     <input type="button" value="Delete selected topics" onclick="deleteTopics()" />|
-    <input id='select_all' type="checkbox" onClick="selectAll(this)" />Select All |
+    <input type="button" value="Delete all topics" onclick="deleteAllTopics()" />|
 <% end %>
 
 <script>
@@ -71,7 +71,29 @@
                 topic_identifiers.push(topic_id);
                 
             });
-            
+            jQuery.ajax({
+                url: '/sign_up_sheet/delete_all_selected_topics',
+                method: 'POST',
+                data: {
+                    topic_ids: topic_identifiers,
+                    assignment_id: <%= @assignment.id %>  
+                },
+                success: function() {
+                    location.reload();
+                }
+            });
+        } else {
+            window.location.href = '<%= edit_assignment_path(@assignment.id) + "#tabs-2" %>';
+        }
+    }
+    function deleteAllTopics() {
+        var msg = 'Are you sure? It will delete all topics';
+        if (confirm(msg)) {
+            var topic_identifiers = []
+            $("#topics tr").each(function(topic) {
+                var topic_id = $(this).closest('tr').find('#topic_id').text();
+                topic_identifiers.push(topic_id);
+            });
             jQuery.ajax({
                 url: '/sign_up_sheet/delete_all_selected_topics',
                 method: 'POST',


### PR DESCRIPTION
Related to #2637: Added a temporary fix to the code by adding a delete all button which will remove all the topics from an assignment. Doing this takes you back to the assignment page but now you have the option 'has topics' available which can be selected to add new topics to the assignment.
