### PR TITLE
Changing mime file content check to extension check

### DIFF
--- a/app/controllers/submitted_content_controller.rb
+++ b/app/controllers/submitted_content_controller.rb
@@ -207,7 +207,7 @@ class SubmittedContentController < ApplicationController
   def check_extension_integrity(original_filename)
     
   allowed_extensions = ['pdf', 'png', 'jpeg', 'zip', 'tar', 'gz', '7z', 'odt', 'docx','md','rb','mp4','txt']
-  file_extension = original_filename.split('.')[-1].downcase
+  file_extension = original_filename&.split('.')&.last&.downcase
   allowed_extensions.include?(file_extension)
 end
 

--- a/app/controllers/submitted_content_controller.rb
+++ b/app/controllers/submitted_content_controller.rb
@@ -120,11 +120,14 @@ class SubmittedContentController < ApplicationController
     file_content = file.read
 
     # check file type
-    unless check_content_type_integrity(file_content) || file.original_filename.split('.')[-1] == 'rb'
-      flash[:error] = 'File type error'
+    unless check_extension_integrity(file.original_filename)
+      flash[:error] = "File extension does not match. "\
+                      "Please upload one of the following: "\
+                      "pdf, png, jpeg, zip, tar, gz, 7z, odt, docx, md, rb, mp4, txt"
       redirect_to action: 'edit', id: participant.id
       return
     end
+
 
     participant.team.set_student_directory_num
     @current_folder = DisplayOption.new
@@ -198,14 +201,16 @@ class SubmittedContentController < ApplicationController
 
   private
 
-  # Verify the integrity of uploaded files.
-  # @param file_content [Object] the content of uploaded file
+  # Verify the extension name of uploaded files.
+  # @param filename [String] the name of uploaded file
   # @return [Boolean] the result of verification
-  def check_content_type_integrity(file_content)
-    limited_types = %w[application/pdf image/png image/jpeg application/zip application/x-tar application/x-gzip-compressed application/x-7z-compressed application/vnd.oasis.opendocument.text application/vnd.openxmlformats-officedocument.wordprocessingml.document]
-    mime = MimeMagic.by_magic(file_content)
-    limited_types.include? mime.to_s
-  end
+  def check_extension_integrity(original_filename)
+    
+  allowed_extensions = ['pdf', 'png', 'jpeg', 'zip', 'tar', 'gz', '7z', 'odt', 'docx','md','rb','mp4','txt']
+  file_extension = original_filename.split('.')[-1].downcase
+  allowed_extensions.include?(file_extension)
+end
+
 
   # Verify the size of uploaded file is under specific value.
   # @param file [Object] uploaded file

--- a/spec/controllers/submitted_content_controller_spec.rb
+++ b/spec/controllers/submitted_content_controller_spec.rb
@@ -127,8 +127,7 @@ describe SubmittedContentController do
         expect(flash[:error]).to be_present # not checking message content since it uses variable size limit
       end
       it 'flashes error for file of unexpected type' do
-        allow(SubmittedContentController).to receive(:check_content_type_integrity).and_return(false)
-        allow(MimeMagic).to receive(:by_magic).and_return("not valid")
+        allow(SubmittedContentController).to receive(:check_extension_integrity).and_return(false)
         allow_any_instance_of(Rack::Test::UploadedFile::String).to receive(:read).and_return("")
         allow_any_instance_of(Rack::Test::UploadedFile::String).to receive(:original_filename).and_return("")
         file = Rack::Test::UploadedFile.new("#{Rails.root}/spec/fixtures/files/helloworld.c")
@@ -136,7 +135,9 @@ describe SubmittedContentController do
                   id: 1}
         response = get :submit_file, params: params
         expect(response).to redirect_to(action: :edit, id: 1)
-        expect(flash[:error]).to eq 'File type error'
+        expect(flash[:error]).to eq "File extension does not match. "\
+                                    "Please upload one of the following: "\
+                                    "pdf, png, jpeg, zip, tar, gz, 7z, odt, docx, md, rb, mp4, txt"
       end
       # we could test that file is written and submission record is created, but we could have to
       # make assumptions about how path is formed and user input for path/filename is sanitized.  We don't want
@@ -209,8 +210,7 @@ describe SubmittedContentController do
         expect(flash[:error]).to be_present # not checking message content since it uses variable size limit
       end
       it 'flashes error for file of unexpected type' do
-        allow(SubmittedContentController).to receive(:check_content_type_integrity).and_return(false)
-        allow(MimeMagic).to receive(:by_magic).and_return("not valid")
+        allow(SubmittedContentController).to receive(:check_extension_integrity).and_return(false)
         allow_any_instance_of(Rack::Test::UploadedFile::String).to receive(:read).and_return("")
         allow_any_instance_of(Rack::Test::UploadedFile::String).to receive(:original_filename).and_return("")
         file = Rack::Test::UploadedFile.new("#{Rails.root}/spec/fixtures/files/helloworld.c")
@@ -218,7 +218,9 @@ describe SubmittedContentController do
                   id: 1}
         response = get :submit_file, params: params
         expect(response).to redirect_to(action: :edit, id: 1)
-        expect(flash[:error]).to eq 'File type error'
+        expect(flash[:error]).to eq "File extension does not match. "\
+                                    "Please upload one of the following: "\
+                                    "pdf, png, jpeg, zip, tar, gz, 7z, odt, docx, md, rb, mp4, txt"
       end
       # we could test that file is written and submission record is created, but we could have to
       # make assumptions about how path is formed and user input for path/filename is sanitized.  We don't want
@@ -367,7 +369,7 @@ describe SubmittedContentController do
     end
   end
 
-  ### NEED TO DO check_content_type_integrity
+  ### NEED TO DO check_extension_integrity
 
   describe '#check_content_size' do
     it "file size 500 should succeed" do


### PR DESCRIPTION
**What has been changed:** Changing mime file content check to extension check since the mime gem was failing and could not detect the mime type.