### PR TITLE
Changin lint.yml to ignore files that do not need to be spell checked

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,7 +21,11 @@ jobs:
           pip install codespell
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
       - name: Check spelling with codespell
-        run: codespell --ignore-words=.github/config/codespell.txt --exclude-file=.github/config/codespell.txt
+        run: |
+          codespell --ignore-words=.github/config/codespell.txt \
+                    --exclude-file=.github/config/codespell.txt \
+                    --exclude=./db/migrate \
+                    --exclude=./rspec/fixtures
 
   misspell:
     name: Check spelling all files in commit with misspell


### PR DESCRIPTION
**What has been changed:** Ignored a pdf file as well as the db/migrate folder in the lint.yml workflow to fix the lint runner.