### PR TITLE
Fixing search bar in manage users page (Issue #2626)

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -67,11 +67,11 @@ class UsersController < ApplicationController
     if letter.present? && search_by.present?
       case search_by.to_i
       when 1 # Search by username
-        @paginated_users = paginate_list.where('name LIKE ?', '%#{letter}%')
+        @paginated_users = paginate_list.where('name LIKE ?', "%#{letter}%")
       when 2 # Search by fullname
-        @paginated_users = paginate_list.where('fullname LIKE ?', '%#{letter}%')
+        @paginated_users = paginate_list.where('fullname LIKE ?', "%#{letter}%")
       when 3 # Search by email
-        @paginated_users = paginate_list.where('email LIKE ?', '%#{letter}%')
+        @paginated_users = paginate_list.where('email LIKE ?', "%#{letter}%")
       else
         @paginated_users = paginate_list
       end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -61,7 +61,23 @@ class UsersController < ApplicationController
 
   # for displaying the list of users
   def list
-    @paginated_users = paginate_list
+    letter = params[:letter]
+    search_by = params[:search_by]
+    # If search parameters present
+    if letter.present? && search_by.present?
+      case search_by.to_i
+      when 1 # Search by username
+        @paginated_users = paginate_list.where("name LIKE ?", "%#{letter}%")
+      when 2 # Search by fullname
+        @paginated_users = paginate_list.where("fullname LIKE ?", "%#{letter}%")
+      when 3 # Search by email
+        @paginated_users = paginate_list.where("email LIKE ?", "%#{letter}%")
+      else
+        @paginated_users = paginate_list
+      end
+    else # Display all users if no search parameters present
+      @paginated_users = paginate_list
+    end  
   end
 
   # for displaying users which are being searched for editing purposes after checking whether current user is authorized to do so

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -67,17 +67,17 @@ class UsersController < ApplicationController
     if letter.present? && search_by.present?
       case search_by.to_i
       when 1 # Search by username
-        @paginated_users = paginate_list.where("name LIKE ?", "%#{letter}%")
+        @paginated_users = paginate_list.where('name LIKE ?', '%#{letter}%')
       when 2 # Search by fullname
-        @paginated_users = paginate_list.where("fullname LIKE ?", "%#{letter}%")
+        @paginated_users = paginate_list.where('fullname LIKE ?', '%#{letter}%')
       when 3 # Search by email
-        @paginated_users = paginate_list.where("email LIKE ?", "%#{letter}%")
+        @paginated_users = paginate_list.where('email LIKE ?', '%#{letter}%')
       else
         @paginated_users = paginate_list
       end
     else # Display all users if no search parameters present
       @paginated_users = paginate_list
-    end  
+    end
   end
 
   # for displaying users which are being searched for editing purposes after checking whether current user is authorized to do so


### PR DESCRIPTION
**What has been changed:** Fixed the search bar in the manage users page. The page now correctly displays the user when searched by email, full name or username. Related to Issue #2626 