### PR TITLE
Fixing bug task not started even after submission (Issue #2633)

### DIFF
--- a/app/models/student_task.rb
+++ b/app/models/student_task.rb
@@ -43,13 +43,17 @@ class StudentTask
   end
 
   def content_submitted_in_current_stage?
-    current_stage == 'submission' && hyperlinks.present?
+    current_stage == 'submission' && (hyperlinks.present? || recent_submission.present?) 
   end
 
   delegate :course, to: :assignment
 
   def hyperlinks
     @hyperlinks ||= participant.team.nil? ? [] : participant.team.hyperlinks
+  end
+
+  def recent_submission
+    participant.team&.most_recent_submission
   end
 
   def incomplete?


### PR DESCRIPTION
** What has been changed: ** Fixed the bug where the students would see task not started even after submitting content. Added a new method recent_submission which checks for the most recent submission. If there exists a recent submission then the task has been started and moves to the revision list.  Related to Issue #2633 