### PR TITLE
Importing teams bug fix (Issue #2634)

### DIFF
--- a/app/controllers/import_file_controller.rb
+++ b/app/controllers/import_file_controller.rb
@@ -74,7 +74,7 @@ class ImportFileController < ApplicationController
                      else
                        CourseTeam
                      end
-          options = eval(params[:options])
+          options = JSON.parse(params[:options])
           options[:has_teamname] = params[:has_teamname]
           Team.import(row_hash, params[:id], options, teamtype)
         end

--- a/app/views/import_file/_team.html.erb
+++ b/app/views/import_file/_team.html.erb
@@ -43,7 +43,7 @@
     <%= hidden_field_tag('has_teamname', @has_teamname) %>
     <%= hidden_field_tag('model', @model) %>
     <%= hidden_field_tag('id', @id) %>
-    <%= hidden_field_tag('options', @options)%>
+    <%= hidden_field_tag('options', @options.to_json)%>
 
     <div style="text-align:center">
           <button type="button" class="btn btn-primary" onclick="column_form.submit()">Import Teams</button>


### PR DESCRIPTION
**What Changed:** Fixed the bugs where teams could not be imported. This was happening because of incorrect serialization of the options being passed to the backend. This has been fixed by converting the hash object to JSON and then passing it to the controller. Related to Issue #2634 