### PR TITLE
Allowing any TA to update questionnaire created by other TA's(Issue #2635)

### DIFF
--- a/app/controllers/questionnaires_controller.rb
+++ b/app/controllers/questionnaires_controller.rb
@@ -18,7 +18,7 @@ class QuestionnairesController < ApplicationController
     when 'edit'
       @questionnaire = Questionnaire.find(params[:id])
       current_user_has_admin_privileges? ||
-      (current_user_is_a?('Teaching Assistant') && Ta.find(session[:user].id).courses_assisted_with.any? { |c| c.tas&.include?(Ta.find(@questionnaire.try(:instructor_id))) }) ||
+      (current_user_is_a?('Teaching Assistant') && Ta.find(session[:user].id).is_instructor_or_co_ta ||
       (current_user_is_a?('Instructor') && current_user_id?(@questionnaire.try(:instructor_id)))
     else
       current_user_has_student_privileges?

--- a/app/controllers/questionnaires_controller.rb
+++ b/app/controllers/questionnaires_controller.rb
@@ -18,7 +18,7 @@ class QuestionnairesController < ApplicationController
     when 'edit'
       @questionnaire = Questionnaire.find(params[:id])
       current_user_has_admin_privileges? ||
-      (current_user_is_a?('Teaching Assistant') && Ta.find(session[:user].id).is_instructor_or_co_ta? ||
+      (current_user_is_a?('Teaching Assistant') && Ta.find(session[:user].id).is_instructor_or_co_ta?(@questionnaire) ||
       (current_user_is_a?('Instructor') && current_user_id?(@questionnaire.try(:instructor_id)))
     else
       current_user_has_student_privileges?

--- a/app/controllers/questionnaires_controller.rb
+++ b/app/controllers/questionnaires_controller.rb
@@ -18,7 +18,7 @@ class QuestionnairesController < ApplicationController
     when 'edit'
       @questionnaire = Questionnaire.find(params[:id])
       current_user_has_admin_privileges? ||
-      (current_user_is_a?('Teaching Assistant') && Ta.find(session[:user].id).courses_assisted_with.any? { |c| c.tas&.include?(@questionnaire.try(:instructor_id)) }) ||
+      (current_user_is_a?('Teaching Assistant') && Ta.find(session[:user].id).courses_assisted_with.any? { |c| c.tas&.include?(Ta.find(@questionnaire.try(:instructor_id))) }) ||
       (current_user_is_a?('Instructor') && current_user_id?(@questionnaire.try(:instructor_id)))
     else
       current_user_has_student_privileges?

--- a/app/controllers/questionnaires_controller.rb
+++ b/app/controllers/questionnaires_controller.rb
@@ -18,7 +18,7 @@ class QuestionnairesController < ApplicationController
     when 'edit'
       @questionnaire = Questionnaire.find(params[:id])
       current_user_has_admin_privileges? ||
-      current_user_has_ta_privileges? ||
+      current_user_is_a?('Teaching Assistant') ||
       (current_user_is_a?('Instructor') && current_user_id?(@questionnaire.try(:instructor_id)))
     else
       current_user_has_student_privileges?

--- a/app/controllers/questionnaires_controller.rb
+++ b/app/controllers/questionnaires_controller.rb
@@ -18,7 +18,7 @@ class QuestionnairesController < ApplicationController
     when 'edit'
       @questionnaire = Questionnaire.find(params[:id])
       current_user_has_admin_privileges? ||
-      (current_user_is_a?('Teaching Assistant') && Ta.find(session[:user].id).is_instructor_or_co_ta ||
+      (current_user_is_a?('Teaching Assistant') && Ta.find(session[:user].id).is_instructor_or_co_ta? ||
       (current_user_is_a?('Instructor') && current_user_id?(@questionnaire.try(:instructor_id)))
     else
       current_user_has_student_privileges?

--- a/app/controllers/questionnaires_controller.rb
+++ b/app/controllers/questionnaires_controller.rb
@@ -14,15 +14,11 @@ class QuestionnairesController < ApplicationController
 
   # Check role access for edit questionnaire
   def action_allowed?
-    ta = Ta.find(id)
-    if ta.courses_assisted_with.any? do |c|
-      c.tas&.include?(@questionnaire.try(:instructor_id))
-    end
     case params[:action]
     when 'edit'
       @questionnaire = Questionnaire.find(params[:id])
       current_user_has_admin_privileges? ||
-      (current_user_is_a?('Teaching Assistant') && Ta.find(session[:user].id).courses_assisted_with.any? { |c| c.tas&.include?(@questionnaire.try(:instructor_id)) })
+      (current_user_is_a?('Teaching Assistant') && Ta.find(session[:user].id).courses_assisted_with.any? { |c| c.tas&.include?(@questionnaire.try(:instructor_id)) }) ||
       (current_user_is_a?('Instructor') && current_user_id?(@questionnaire.try(:instructor_id)))
     else
       current_user_has_student_privileges?

--- a/app/controllers/questionnaires_controller.rb
+++ b/app/controllers/questionnaires_controller.rb
@@ -18,7 +18,7 @@ class QuestionnairesController < ApplicationController
     when 'edit'
       @questionnaire = Questionnaire.find(params[:id])
       current_user_has_admin_privileges? ||
-      (current_user_is_a?('Teaching Assistant') && Ta.find(session[:user].id).is_instructor_or_co_ta?(@questionnaire) ||
+      (current_user_is_a?('Teaching Assistant') && Ta.find(session[:user].id).is_instructor_or_co_ta?(@questionnaire)) ||
       (current_user_is_a?('Instructor') && current_user_id?(@questionnaire.try(:instructor_id)))
     else
       current_user_has_student_privileges?

--- a/app/controllers/questionnaires_controller.rb
+++ b/app/controllers/questionnaires_controller.rb
@@ -18,8 +18,8 @@ class QuestionnairesController < ApplicationController
     when 'edit'
       @questionnaire = Questionnaire.find(params[:id])
       current_user_has_admin_privileges? ||
-        (current_user_is_a?('Instructor') && current_user_id?(@questionnaire.try(:instructor_id))) ||
-        (current_user_is_a?('Teaching Assistant') && session[:user].instructor_id == @questionnaire.try(:instructor_id))
+      current_user_has_ta_privileges? ||
+      (current_user_is_a?('Instructor') && current_user_id?(@questionnaire.try(:instructor_id)))
     else
       current_user_has_student_privileges?
     end

--- a/app/controllers/questionnaires_controller.rb
+++ b/app/controllers/questionnaires_controller.rb
@@ -14,11 +14,15 @@ class QuestionnairesController < ApplicationController
 
   # Check role access for edit questionnaire
   def action_allowed?
+    ta = Ta.find(id)
+    if ta.courses_assisted_with.any? do |c|
+      c.tas&.include?(@questionnaire.try(:instructor_id))
+    end
     case params[:action]
     when 'edit'
       @questionnaire = Questionnaire.find(params[:id])
       current_user_has_admin_privileges? ||
-      current_user_is_a?('Teaching Assistant') ||
+      (current_user_is_a?('Teaching Assistant') && Ta.find(session[:user].id).courses_assisted_with.any? { |c| c.tas&.include?(@questionnaire.try(:instructor_id)) })
       (current_user_is_a?('Instructor') && current_user_id?(@questionnaire.try(:instructor_id)))
     else
       current_user_has_student_privileges?

--- a/app/models/ta.rb
+++ b/app/models/ta.rb
@@ -15,6 +15,9 @@ class Ta < User
   def is_instructor_or_co_ta?(questionnaire)
     return false if questionnaire.nil?
     
+    # Check if is TA for any of the courses of a given questionnaire's instructor
+    return true if Ta.get_my_instructors(id).include?(questionnaire.try(:instructor_id))
+    
     ta = Ta.find(id)
     questionnaire_ta = Ta.find(questionnaire.try(:instructor_id))
     

--- a/app/models/ta.rb
+++ b/app/models/ta.rb
@@ -97,6 +97,19 @@ class Ta < User
     true
   end
 
+  def self.is_instructor_or_co_ta(questionnaire)
+    return false if session[:user].nil? || questionnaire.nil?
+    
+    ta = Ta.find(session[:user].id)
+    questionnaire_ta = Ta.find(questionnaire.try(:instructor_id))
+    
+    # Check if the TA is a co-TA for any of the courses of a given questionnaire's instructor
+    ta.courses_assisted_with.any? do |course|
+      course.tas&.include?(questionnaire_ta)
+    end
+  end
+
+  
   def self.get_user_list(user)
     courses = Ta.get_mapped_courses(user.id)
     participants = []

--- a/app/models/ta.rb
+++ b/app/models/ta.rb
@@ -11,7 +11,19 @@ class Ta < User
     courses = TaMapping.where(ta_id: id)
     courses.map { |c| Course.find(c.course_id) }
   end
-
+  
+  def is_instructor_or_co_ta(questionnaire)
+    return false if questionnaire.nil?
+    
+    ta = Ta.find(id)
+    questionnaire_ta = Ta.find(questionnaire.try(:instructor_id))
+    
+    # Check if the TA is a co-TA for any of the courses of a given questionnaire's instructor
+    ta.courses_assisted_with.any? do |course|
+      course.tas&.include?(questionnaire_ta)
+    end
+  end
+  
   def list_all(object_type, user_id)
     object_type.where(['instructor_id = ? OR private = 0', user_id])
   end
@@ -96,19 +108,6 @@ class Ta < User
   def teaching_assistant?
     true
   end
-
-  def is_instructor_or_co_ta(questionnaire)
-    return false if questionnaire.nil?
-    
-    ta = Ta.find(id)
-    questionnaire_ta = Ta.find(questionnaire.try(:instructor_id))
-    
-    # Check if the TA is a co-TA for any of the courses of a given questionnaire's instructor
-    ta.find.courses_assisted_with.any? do |course|
-      course.tas&.include?(questionnaire_ta)
-    end
-  end
-
   
   def self.get_user_list(user)
     courses = Ta.get_mapped_courses(user.id)

--- a/app/models/ta.rb
+++ b/app/models/ta.rb
@@ -97,14 +97,14 @@ class Ta < User
     true
   end
 
-  def self.is_instructor_or_co_ta(questionnaire)
-    return false if session[:user].nil? || questionnaire.nil?
+  def is_instructor_or_co_ta(questionnaire)
+    return false if questionnaire.nil?
     
-    ta = Ta.find(session[:user].id)
+    ta = Ta.find(id)
     questionnaire_ta = Ta.find(questionnaire.try(:instructor_id))
     
     # Check if the TA is a co-TA for any of the courses of a given questionnaire's instructor
-    ta.courses_assisted_with.any? do |course|
+    ta.find.courses_assisted_with.any? do |course|
       course.tas&.include?(questionnaire_ta)
     end
   end

--- a/app/models/ta.rb
+++ b/app/models/ta.rb
@@ -12,7 +12,7 @@ class Ta < User
     courses.map { |c| Course.find(c.course_id) }
   end
   
-  def is_instructor_or_co_ta(questionnaire)
+  def is_instructor_or_co_ta?(questionnaire)
     return false if questionnaire.nil?
     
     ta = Ta.find(id)


### PR DESCRIPTION
**What changed:** Changed code to allow any TA to update rubric created by any other TA. Earlier only the TA that had created the questionnaire could edit it but this change allows any TA to make necessary changes. Related to #2635 