### PR TITLE
Changing back link to point to response controller (Issue #2645)

### DIFF
--- a/app/views/popup/team_users_popup.html.haml
+++ b/app/views/popup/team_users_popup.html.haml
@@ -60,4 +60,4 @@
       %hr/
   %br/
   .footer
-    = link_to 'Back', :controller=> 'review_mapping', :action=>'response_report', :id=>params[:assignment_id]
+    = link_to 'Back', controller: 'reports', action: 'response_report', id: params[:assignment_id]


### PR DESCRIPTION
**What changed:** Made a small bugfix where the controller method had been moved out to the response_controller but the back link had not been updated to reflect the same. 