### PR TITLE
Fixing bug where assignment created without teams shows create team option (Issue #2668)

### DIFF
--- a/app/views/student_task/view.html.erb
+++ b/app/views/student_task/view.html.erb
@@ -51,6 +51,7 @@ to display the label "Your team" in the student assignment tasks-->
   <!--Your work-->
   <% if @authorization == 'participant' || @can_submit == true %>
     <li>
+      <% if @assignment.max_team_size <= 1 || @team %>
         <% if @topics.size > 0 %>
           <% if @topic_id && @assignment.submission_allowed(@topic_id) %>
             <%= link_to t(".your_work"), :controller => 'submitted_content', :action => 'edit', :id => @participant.id %> <%=t ".submit_work" %>
@@ -65,6 +66,10 @@ to display the label "Your team" in the student assignment tasks-->
             <font color="gray"><%=t ".your_work" %></font> <%=t ".not_allowed" %>
           <% end %>
         <% end %>
+      <% else %>
+        <!-- Must be on a team to click "Your Work" -->
+        <font color="gray"><%=t ".your_work" %></font> <%=t ".not_allowed" %>
+      <% end%>
     </li>
   <% end %>
 

--- a/app/views/student_task/view.html.erb
+++ b/app/views/student_task/view.html.erb
@@ -39,7 +39,7 @@
 
 <!--ACS Here we need to know the size of the team to decide whether or not
 to display the label "Your team" in the student assignment tasks-->
-  <%if @assignment.max_team_size > 0 %>
+  <%if @assignment.max_team_size > 1 %>
     <% if @authorization == 'participant' %>
       <li>
         <%= link_to t('.your_team'), view_student_teams_path(student_id: @participant.id) %>
@@ -51,7 +51,6 @@ to display the label "Your team" in the student assignment tasks-->
   <!--Your work-->
   <% if @authorization == 'participant' || @can_submit == true %>
     <li>
-      <% if @team %>
         <% if @topics.size > 0 %>
           <% if @topic_id && @assignment.submission_allowed(@topic_id) %>
             <%= link_to t(".your_work"), :controller => 'submitted_content', :action => 'edit', :id => @participant.id %> <%=t ".submit_work" %>
@@ -66,10 +65,6 @@ to display the label "Your team" in the student assignment tasks-->
             <font color="gray"><%=t ".your_work" %></font> <%=t ".not_allowed" %>
           <% end %>
         <% end %>
-      <% else %>
-        <!-- Must be on a team to click "Your Work" -->
-        <font color="gray"><%=t ".your_work" %></font> <%=t ".not_allowed" %>
-      <% end%>
     </li>
   <% end %>
 


### PR DESCRIPTION
**What has been changed:** Creating an assignment without teams shows the your teams option and also a team needs to be created manually if the user does not have a team and this has now been fixed. (Issue #2668)