### PR TITLE
Fixing bug where instructors were unable to see all assignment teams when viewing scores.

### DIFF
--- a/app/controllers/grades_controller.rb
+++ b/app/controllers/grades_controller.rb
@@ -47,6 +47,7 @@ class GradesController < ApplicationController
       end
     end
     @scores = review_grades(@assignment, @questions)
+    @original_length = @scores[:teams].length # After rejecting nil scores need original length to iterate over hash
     averages = vector(@scores)
     @average_chart = bar_chart(averages, 300, 100, 5)
     @avg_of_avg = mean(averages)

--- a/app/views/grades/_teams.html.erb
+++ b/app/views/grades/_teams.html.erb
@@ -32,7 +32,7 @@
 </thead>
 <!--E1877: tbody tag added to the table structure-->
 <tbody>
-<% 0.upto(@scores[:teams].length).each do |index| %>   
+<% 0.upto(@original_length).each do |index| %>   
      <%= render :partial => 'grades/team',
                 :locals => {:prefix => 'team'+index.to_s,
                             :tscore => @scores[:teams][index.to_s.to_sym],


### PR DESCRIPTION
**What has been changed:** 

When looking at participant scores under the view scores section, the instructors could not see all the participants in the assignment. This was occurring due to index of the hash not changing after rejecting nil scores. 

A new variable that keeps track of the original length of the scores before rejecting the nil scores has been added. This makes sure that all participants are iterated over when displaying the teams.

Also fixed bug where instructors where not being able to export grades to csv. This was because the code was calling the review_grades method in a class method. An instance of assignment had to be created to call it.