### PR TITLE
Adding checkboxes to delete selected topics (#2637)

### DIFF
--- a/app/views/sign_up_sheet/_table_header.html.erb
+++ b/app/views/sign_up_sheet/_table_header.html.erb
@@ -1,3 +1,4 @@
+<th width="5%"><%=t ".checkbox"%></th>
 <th width="5%"><%=t ".topic_id"%></th>
 <% if @assignment.vary_by_topic? %>
   <th width="25%"><%=t ".topic_name"%></th>

--- a/app/views/sign_up_sheet/_table_line.html.erb
+++ b/app/views/sign_up_sheet/_table_line.html.erb
@@ -35,6 +35,7 @@
 </script>
 
 <input name="hidden_topic_id" type="hidden" value=<%=topic.id %> >
+<td><input type="checkbox" class="topic-checkbox" name="selected_topics[]" value="<%= topic.id %>"></td>
 
 <td id='topic_id'><%= topic.topic_identifier %></td>
 <td><%= render :partial => '/sign_up_sheet/topic_names', :locals => {:i => i, :topic=>topic} %></td>


### PR DESCRIPTION
Related to #2637: Added a checkbox option to select and delete as many topics as the instructor wants along with the delete all topics button.