### PR TITLE
Assign grades option was missing from view (Issue #2714)

### DIFF
--- a/app/views/assignments/list_submissions.html.erb
+++ b/app/views/assignments/list_submissions.html.erb
@@ -55,7 +55,7 @@
           <td><p style = <%="color:#{team_name_color}"%>><%= team.name(session[:ip]) %></p>
           <% unless participants.empty? %>
             <!-- “Assign Grade” will show if the final deadline of this assignment pass -->
-            <% if @assignment.current_stage == "Finished" %>
+            <% if @assignment.current_stage(topic_identifier) == "Finished" %>
               <%= link_to 'Assign Grade', { controller: 'grades', action: 'view_team', id: participants.first.id}, target: '_blank' %></td>
             <!-- if current user(TA/instructor) is participant in assignment then the user can perform review -->
             <%elsif current_user_is_assignment_participant?(@assignment.id) %>


### PR DESCRIPTION
**What was changed:** The current_stage method of the assignment takes topic_id as a parameter but no argument was being passed in. The topic_id if not passed in, sets the topic stage to be 'Unknown'. The topic_id argument has been added to set the assignment stage correctly. 