### PR TITLE
Reduce load time for 'View Submission' when no team is created 

### DIFF
--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -180,13 +180,10 @@ class Team < ApplicationRecord
 
   # Generate the team name
   def self.generate_team_name(_team_name_prefix = '')
-    counter = 1
-    loop do
-      team_name = "Team_#{counter}"
-      return team_name unless Team.find_by(name: team_name)
-
-      counter += 1
-    end
+    last_team = Team.where('name LIKE ?', "#{_team_name_prefix} Team_%").order(name: :desc).first
+    counter = last_team ? last_team.name.scan(/\d+/).first.to_i + 1 : 1
+    team_name = "#{_team_name_prefix} Team_#{counter}"
+    team_name
   end
 
   # Extract team members from the csv and push to DB,  changed to hash by E1776

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -156,10 +156,10 @@ describe Team do
 
   describe '.generate_team_name' do
     it 'generates the unused team name' do
-      allow(Team).to receive(:find_by).with(name: 'Team_1').and_return(team)
+      allow(Team).to receive(:find_by).with(name: 'Assignment Team_1').and_return(team)
 
-      allow(Team).to receive(:find_by).with(name: 'Team_2').and_return(nil)
-      expect(Team.generate_team_name()).to eq('Team_2')
+      allow(Team).to receive(:find_by).with(name: 'Assignment Team_2').and_return(nil)
+      expect(Team.generate_team_name('Assignment')).to eq('Assignment Team_2')
     end
   end
 

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -156,7 +156,7 @@ describe Team do
 
   describe '.generate_team_name' do
     it 'generates the unused team name' do
-      allow(Team).to receive(:where).with('name LIKE ?', 'Assignment Team_%').and_return(team)
+      allow(Team).to receive(:where).with('name LIKE ?', 'Assignment Team_%').and_return([team])
       expect(Team.generate_team_name('Assignment')).to eq('Assignment Team_1')
     end
   end

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -156,7 +156,6 @@ describe Team do
 
   describe '.generate_team_name' do
     it 'generates the unused team name' do
-      allow(Team).to receive(:where).with('name LIKE ?', 'Assignment Team_%').and_return([team])
       expect(Team.generate_team_name('Assignment')).to eq('Assignment Team_1')
     end
   end

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -275,8 +275,7 @@ describe Team do
     #   it 'handles duplicated teams and imports team members' do
     #     allow(Team).to receive(:find_by).with(name: 'no team', parent_id: 1).and_return(team)
     #     allow_any_instance_of(Team).to receive(:handle_duplicate)
-    #       .with(team, 'no team', 
-    1, 'rename', AssignmentTeam.new).and_return('new team name')
+    #       .with(team, 'no team', 1, 'rename', AssignmentTeam.new).and_return('new team name')
     #     allow(AssignmentTeam).to receive(:create_team_and_node).with(1).and_return(AssignmentTeam.new)
     #     allow_any_instance_of(Team).to receive(:import_team_members).with(1, ['no team', 'another field']).and_return(true)
     #     expect(Team.import(['no team', 'another field'], 1, {has_column_names: 'true'}, AssignmentTeam.new)).to be true

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -156,10 +156,8 @@ describe Team do
 
   describe '.generate_team_name' do
     it 'generates the unused team name' do
-      allow(Team).to receive(:find_by).with(name: 'Assignment Team_1').and_return(team)
-
-      allow(Team).to receive(:find_by).with(name: 'Assignment Team_2').and_return(nil)
-      expect(Team.generate_team_name('Assignment')).to eq('Assignment Team_2')
+      allow(Team).to receive(:where).with('name LIKE ?', 'Assignment Team_%').and_return(team)
+      expect(Team.generate_team_name('Assignment')).to eq('Assignment Team_1')
     end
   end
 
@@ -277,7 +275,8 @@ describe Team do
     #   it 'handles duplicated teams and imports team members' do
     #     allow(Team).to receive(:find_by).with(name: 'no team', parent_id: 1).and_return(team)
     #     allow_any_instance_of(Team).to receive(:handle_duplicate)
-    #       .with(team, 'no team', 1, 'rename', AssignmentTeam.new).and_return('new team name')
+    #       .with(team, 'no team', 
+    1, 'rename', AssignmentTeam.new).and_return('new team name')
     #     allow(AssignmentTeam).to receive(:create_team_and_node).with(1).and_return(AssignmentTeam.new)
     #     allow_any_instance_of(Team).to receive(:import_team_members).with(1, ['no team', 'another field']).and_return(true)
     #     expect(Team.import(['no team', 'another field'], 1, {has_column_names: 'true'}, AssignmentTeam.new)).to be true

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -159,7 +159,7 @@ describe Team do
       allow(Team).to receive(:find_by).with(name: 'Team_1').and_return(team)
 
       allow(Team).to receive(:find_by).with(name: 'Team_2').and_return(nil)
-      expect(Team.generate_team_name('no name')).to eq('Team_2')
+      expect(Team.generate_team_name()).to eq('Team_2')
     end
   end
 


### PR DESCRIPTION
**What has been changed:** Made changes to the generate_team_name method in the team.rb model to make it more efficient. Earlier the system had to go through all the team names in the db before creating a new team name. The new method looks for team names with the specified prefix and gets the last team with that name to then create a new one. 