### PR TITLE
Add a more descriptive name to the update button on questionnaire page (Issue #2734)

### DIFF
--- a/app/views/questionnaires/_questionnaire.html.erb
+++ b/app/views/questionnaires/_questionnaire.html.erb
@@ -23,7 +23,7 @@
     <%= submit_tag "Create", class: "btn btn-default" %>
   <% end %>
   <% if params[:action] == 'edit' %>
-    <%= submit_tag "Update questionnaire parameters", class: "btn btn-default" %>
+    <%= submit_tag "Update questionnaire name and parameters", class: "btn btn-default" %>
   <% end %>
 <% end %>
 


### PR DESCRIPTION
The issue https://github.com/expertiza/expertiza/issues/2734 requries a change in the name of the option "Update questionnaire parameters" to ""Update questionnaire name and parameters". 

This PR includes a change in the view to accommodate the change. The screenshot is attached below as a test on local system

<img width="636" alt="Screenshot 2024-02-26 at 4 04 42 PM" src="https://github.com/expertiza/expertiza/assets/71286830/bba5c897-55af-4b6c-a76e-cd70f26f2456">