### PR TITLE
E2403. Mentor-meeting management [Emails Notifications]

### DIFF
--- a/app/helpers/mailer_helper.rb
+++ b/app/helpers/mailer_helper.rb
@@ -29,6 +29,7 @@ module MailerHelper
       }
     )
   end
+
   def self.send_mail_to_all_super_users(super_user, user, subject)
     Mailer.request_user_message(
       to: super_user.email,

--- a/app/helpers/mailer_helper.rb
+++ b/app/helpers/mailer_helper.rb
@@ -14,6 +14,18 @@ module MailerHelper
     )
   end
 
+  def self.send_team_confirmation_mail_to_user(user, subject, partial_name)
+    #  This function serves as a helper to send emails to users letting them know they have added to a team
+    Mailer.generic_message(
+      to: user.email,
+      subject: subject,
+      body: {
+        user: user,
+        first_name: ApplicationHelper.get_user_first_name(user),
+        partial_name: partial_name
+      }
+    )
+  end
   def self.send_mail_to_all_super_users(super_user, user, subject)
     Mailer.request_user_message(
       to: super_user.email,

--- a/app/helpers/mailer_helper.rb
+++ b/app/helpers/mailer_helper.rb
@@ -24,8 +24,8 @@ module MailerHelper
         user: user,
         first_name: ApplicationHelper.get_user_first_name(user),
         partial_name: partial_name,
-        team_name: team_name,
-        assignment_name: assignment_name
+        team: team_name,
+        assignment: assignment_name
       }
     )
   end

--- a/app/helpers/mailer_helper.rb
+++ b/app/helpers/mailer_helper.rb
@@ -14,15 +14,18 @@ module MailerHelper
     )
   end
 
-  def self.send_team_confirmation_mail_to_user(user, subject, partial_name)
+  def self.send_team_confirmation_mail_to_user(user, subject, partial_name, team_name, assignment_name)
     #  This function serves as a helper to send emails to users letting them know they have added to a team
+    # note that the below hash is sent to a view html that has the partial_name
     Mailer.generic_message(
       to: user.email,
       subject: subject,
       body: {
         user: user,
         first_name: ApplicationHelper.get_user_first_name(user),
-        partial_name: partial_name
+        partial_name: partial_name,
+        team_name: team_name,
+        assignment_name: assignment_name
       }
     )
   end

--- a/app/mailers/mailer.rb
+++ b/app/mailers/mailer.rb
@@ -24,7 +24,7 @@ class Mailer < ActionMailer::Base
     @avg_pct = defn[:body][:avg_pct]
     @assignment = defn[:body][:assignment]
     @conference_variable = defn[:body][:conference_variable]
-    @team = defn[:body][:team]  # team name
+    @team = defn[:body][:team] # team name
 
     if Rails.env.development? || Rails.env.test?
       defn[:to] = 'expertiza.mailer@gmail.com'

--- a/app/mailers/mailer.rb
+++ b/app/mailers/mailer.rb
@@ -27,8 +27,7 @@ class Mailer < ActionMailer::Base
     @team = defn[:body][:team]  # team name
 
     if Rails.env.development? || Rails.env.test?
-      #defn[:to] = 'expertiza.mailer@gmail.com'
-      defn[:to] = 'slkwiatk@ncsu.edu'
+      defn[:to] = 'expertiza.mailer@gmail.com'
     end
     mail(subject: defn[:subject],
          to: defn[:to],

--- a/app/mailers/mailer.rb
+++ b/app/mailers/mailer.rb
@@ -24,9 +24,11 @@ class Mailer < ActionMailer::Base
     @avg_pct = defn[:body][:avg_pct]
     @assignment = defn[:body][:assignment]
     @conference_variable = defn[:body][:conference_variable]
+    @team = defn[:body][:team]  # team name
 
     if Rails.env.development? || Rails.env.test?
-      defn[:to] = 'expertiza.mailer@gmail.com'
+      #defn[:to] = 'expertiza.mailer@gmail.com'
+      defn[:to] = 'slkwiatk@ncsu.edu'
     end
     mail(subject: defn[:subject],
          to: defn[:to],

--- a/app/models/mentor_management.rb
+++ b/app/models/mentor_management.rb
@@ -83,6 +83,12 @@ class MentorManagement
     Mailer.delayed_message(bcc: emails,
                            subject: '[Expertiza]: New Mentor Assignment',
                            body: message).deliver_now
+
+    # Send a different message to the Mentor letting them know they have been assigned to a team
+    mentor_message = "You have been assigned as a mentor for assignment #{Assignment.find(team.parent_id).name} for team #{team.name} <br>Current members:<br> #{members_info.join('<br>')}"
+    Mailer.delayed_message(bcc: mentor.email,
+                           subject: '[Expertiza]: New Mentoring Assignment',
+                           body: mentor_message).deliver_now
   end
 
   # Returns true if [user] is a mentor, and false if not.

--- a/app/models/mentor_management.rb
+++ b/app/models/mentor_management.rb
@@ -83,7 +83,6 @@ class MentorManagement
     Mailer.delayed_message(bcc: emails,
                            subject: '[Expertiza]: New Mentor Assignment',
                            body: message).deliver_now
-
   end
 
   # Returns true if [user] is a mentor, and false if not.

--- a/app/models/mentor_management.rb
+++ b/app/models/mentor_management.rb
@@ -84,11 +84,6 @@ class MentorManagement
                            subject: '[Expertiza]: New Mentor Assignment',
                            body: message).deliver_now
 
-    # Send a different message to the Mentor letting them know they have been assigned to a team
-    mentor_message = "You have been assigned as a mentor for assignment #{Assignment.find(team.parent_id).name} for team #{team.name} <br>Current members:<br> #{members_info.join('<br>')}"
-    Mailer.delayed_message(bcc: mentor.email,
-                           subject: '[Expertiza]: New Mentoring Assignment',
-                           body: mentor_message).deliver_now
   end
 
   # Returns true if [user] is a mentor, and false if not.

--- a/app/models/mentored_team.rb
+++ b/app/models/mentored_team.rb
@@ -12,6 +12,7 @@ class MentoredTeam < AssignmentTeam
           TeamUserNode.create(parent_id: parent.id, node_object_id: t_user.id)
           add_participant(parent_id, user)
           ExpertizaLogger.info LoggerMessage.new('Model:Team', user.name, "Added member to the team #{id}")
+          MailerHelper.send_team_confirmation_mail_to_user(user, "[Expertiza] Added to a Team", "user_added_to_team", "#{name}", Assignment.find(_assignment_id).name.to_s).deliver
         end
         if can_add_member
             MentorManagement.assign_mentor(_assignment_id, id)

--- a/app/models/mentored_team.rb
+++ b/app/models/mentored_team.rb
@@ -1,7 +1,7 @@
 class MentoredTeam < AssignmentTeam
     # Class created during refactoring of E2351
     # Overridden method to include the MentorManagement workflow
-    def add_member(user, _assignment_id = nil)
+    def add_member(user, assignment_id = nil)
         raise "The user #{user.name} is already a member of the team #{name}" if user?(user)
     
         can_add_member = false
@@ -12,15 +12,15 @@ class MentoredTeam < AssignmentTeam
           TeamUserNode.create(parent_id: parent.id, node_object_id: t_user.id)
           add_participant(parent_id, user)
           ExpertizaLogger.info LoggerMessage.new('Model:Team', user.name, "Added member to the team #{id}")
-          assignment_name = _assignment_id ? Assignment.find(_assignment_id).name.to_s : ""
+          assignment_name = assignment_id ? Assignment.find(assignment_id).name.to_s : ''
           if MentorManagement.user_a_mentor?(user)
-            MailerHelper.send_team_confirmation_mail_to_user(user, "[Expertiza] Added to a Team", "mentor_added_to_team", "#{name}", assignment_name).deliver
+            MailerHelper.send_team_confirmation_mail_to_user(user, '[Expertiza] Added to a Team', 'mentor_added_to_team', name.to_s, assignment_name).deliver
           elsif !user.is_a?(Participant)
-            MailerHelper.send_team_confirmation_mail_to_user(user, "[Expertiza] Added to a Team", "user_added_to_team", "#{name}", assignment_name).deliver
+            MailerHelper.send_team_confirmation_mail_to_user(user, '[Expertiza] Added to a Team', 'user_added_to_team', name.to_s, assignment_name).deliver
           end
         end
         if can_add_member
-            MentorManagement.assign_mentor(_assignment_id, id)
+            MentorManagement.assign_mentor(assignment_id, id)
         end
         can_add_member
     end

--- a/app/models/mentored_team.rb
+++ b/app/models/mentored_team.rb
@@ -12,7 +12,11 @@ class MentoredTeam < AssignmentTeam
           TeamUserNode.create(parent_id: parent.id, node_object_id: t_user.id)
           add_participant(parent_id, user)
           ExpertizaLogger.info LoggerMessage.new('Model:Team', user.name, "Added member to the team #{id}")
-          MailerHelper.send_team_confirmation_mail_to_user(user, "[Expertiza] Added to a Team", "user_added_to_team", "#{name}", Assignment.find(_assignment_id).name.to_s).deliver
+          if MentorManagement.user_a_mentor?(user)
+            MailerHelper.send_team_confirmation_mail_to_user(user, "[Expertiza] Added to a Team", "mentor_added_to_team", "#{name}", Assignment.find(_assignment_id).name.to_s).deliver
+          else
+            MailerHelper.send_team_confirmation_mail_to_user(user, "[Expertiza] Added to a Team", "user_added_to_team", "#{name}", Assignment.find(_assignment_id).name.to_s).deliver
+          end
         end
         if can_add_member
             MentorManagement.assign_mentor(_assignment_id, id)

--- a/app/models/mentored_team.rb
+++ b/app/models/mentored_team.rb
@@ -12,10 +12,11 @@ class MentoredTeam < AssignmentTeam
           TeamUserNode.create(parent_id: parent.id, node_object_id: t_user.id)
           add_participant(parent_id, user)
           ExpertizaLogger.info LoggerMessage.new('Model:Team', user.name, "Added member to the team #{id}")
+          assignment_name = _assignment_id ? Assignment.find(_assignment_id).name.to_s : ""
           if MentorManagement.user_a_mentor?(user)
-            MailerHelper.send_team_confirmation_mail_to_user(user, "[Expertiza] Added to a Team", "mentor_added_to_team", "#{name}", Assignment.find(_assignment_id).name.to_s).deliver
-          else
-            MailerHelper.send_team_confirmation_mail_to_user(user, "[Expertiza] Added to a Team", "user_added_to_team", "#{name}", Assignment.find(_assignment_id).name.to_s).deliver
+            MailerHelper.send_team_confirmation_mail_to_user(user, "[Expertiza] Added to a Team", "mentor_added_to_team", "#{name}", assignment_name).deliver
+          elsif !user.is_a?(Participant)
+            MailerHelper.send_team_confirmation_mail_to_user(user, "[Expertiza] Added to a Team", "user_added_to_team", "#{name}", assignment_name).deliver
           end
         end
         if can_add_member

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -89,7 +89,10 @@ class Team < ApplicationRecord
       add_participant(parent_id, user)
       ExpertizaLogger.info LoggerMessage.new('Model:Team', user.name, "Added member to the team #{id}")
       # Now that a new team member has been added to a team, send an email to them letting them know
-      MailerHelper.send_team_confirmation_mail_to_user(user, "You have been added to the team #{name}.", "team_welcome").deliver
+      MailerHelper.send_team_confirmation_mail_to_user(user, "[Expertiza] Added to a Team", "user_added_to_team", "#{name}", Assignment.find(_assignment_id).name.to_s).deliver
+      #Mailer.generic_message(to: user,
+      #                       subject: '[Expertiza]: New Mentor Assignment',
+      #                       body: message).deliver_now
     end
     can_add_member
   end

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -88,11 +88,15 @@ class Team < ApplicationRecord
       TeamUserNode.create(parent_id: parent.id, node_object_id: t_user.id)
       add_participant(parent_id, user)
       ExpertizaLogger.info LoggerMessage.new('Model:Team', user.name, "Added member to the team #{id}")
+      # if assignment_id is nil, then don't send an assignment name
+      assignment_name = _assignment_id ? Assignment.find(_assignment_id).name.to_s : ""
       # Now that a new team member has been added to a team, send an email to them letting them know
       if MentorManagement.user_a_mentor?(user)
-        MailerHelper.send_team_confirmation_mail_to_user(user, "[Expertiza] Added to a Team", "mentor_added_to_team", "#{name}", Assignment.find(_assignment_id).name.to_s).deliver
-      else
-        MailerHelper.send_team_confirmation_mail_to_user(user, "[Expertiza] Added to a Team", "user_added_to_team", "#{name}", Assignment.find(_assignment_id).name.to_s).deliver
+        MailerHelper.send_team_confirmation_mail_to_user(user, "[Expertiza] Added to a Team", "mentor_added_to_team", "#{name}", assignment_name).deliver
+      elsif !user.is_a?(Participant)
+        # If the user is a participant, then we don't went to send them emails since that class is something
+        # completely out of the scope of this project
+        MailerHelper.send_team_confirmation_mail_to_user(user, "[Expertiza] Added to a Team", "user_added_to_team", "#{name}", assignment_name).deliver
       end
 
     end

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -92,11 +92,11 @@ class Team < ApplicationRecord
       assignment_name = assignment_id ? Assignment.find(assignment_id).name.to_s : ''
       # Now that a new team member has been added to a team, send an email to them letting them know
       if MentorManagement.user_a_mentor?(user)
-        MailerHelper.send_team_confirmation_mail_to_user(user, '[Expertiza] Added to a Team', 'mentor_added_to_team', "#{name}", assignment_name).deliver
+        MailerHelper.send_team_confirmation_mail_to_user(user, '[Expertiza] Added to a Team', 'mentor_added_to_team', name.to_s, assignment_name).deliver
       elsif !user.is_a?(Participant)
         # If the user is a participant, then we don't went to send them emails since that class is something
         # completely out of the scope of this project
-        MailerHelper.send_team_confirmation_mail_to_user(user, '[Expertiza] Added to a Team', 'user_added_to_team', "#{name}", assignment_name).deliver
+        MailerHelper.send_team_confirmation_mail_to_user(user, '[Expertiza] Added to a Team', 'user_added_to_team', name.to_s, assignment_name).deliver
       end
 
     end
@@ -110,7 +110,7 @@ class Team < ApplicationRecord
     members = TeamsUser.where(team_id: team_id)
     members.each do |member|
       member_name = member.name
-      unless member_name.include?(' (Mentor)') 
+      unless member_name.include?(' (Mentor)')
         count = count + 1
       end
     end

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -77,7 +77,7 @@ class Team < ApplicationRecord
   end
 
   # Add member to the team, changed to hash by E1776
-  def add_member(user, _assignment_id = nil)
+  def add_member(user, assignment_id = nil)
     raise "The user #{user.name} is already a member of the team #{name}" if user?(user)
 
     can_add_member = false
@@ -89,14 +89,14 @@ class Team < ApplicationRecord
       add_participant(parent_id, user)
       ExpertizaLogger.info LoggerMessage.new('Model:Team', user.name, "Added member to the team #{id}")
       # if assignment_id is nil, then don't send an assignment name
-      assignment_name = _assignment_id ? Assignment.find(_assignment_id).name.to_s : ""
+      assignment_name = assignment_id ? Assignment.find(assignment_id).name.to_s : ''
       # Now that a new team member has been added to a team, send an email to them letting them know
       if MentorManagement.user_a_mentor?(user)
-        MailerHelper.send_team_confirmation_mail_to_user(user, "[Expertiza] Added to a Team", "mentor_added_to_team", "#{name}", assignment_name).deliver
+        MailerHelper.send_team_confirmation_mail_to_user(user, '[Expertiza] Added to a Team', 'mentor_added_to_team', "#{name}", assignment_name).deliver
       elsif !user.is_a?(Participant)
         # If the user is a participant, then we don't went to send them emails since that class is something
         # completely out of the scope of this project
-        MailerHelper.send_team_confirmation_mail_to_user(user, "[Expertiza] Added to a Team", "user_added_to_team", "#{name}", assignment_name).deliver
+        MailerHelper.send_team_confirmation_mail_to_user(user, '[Expertiza] Added to a Team', 'user_added_to_team', "#{name}", assignment_name).deliver
       end
 
     end

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -89,10 +89,12 @@ class Team < ApplicationRecord
       add_participant(parent_id, user)
       ExpertizaLogger.info LoggerMessage.new('Model:Team', user.name, "Added member to the team #{id}")
       # Now that a new team member has been added to a team, send an email to them letting them know
-      MailerHelper.send_team_confirmation_mail_to_user(user, "[Expertiza] Added to a Team", "user_added_to_team", "#{name}", Assignment.find(_assignment_id).name.to_s).deliver
-      #Mailer.generic_message(to: user,
-      #                       subject: '[Expertiza]: New Mentor Assignment',
-      #                       body: message).deliver_now
+      if MentorManagement.user_a_mentor?(user)
+        MailerHelper.send_team_confirmation_mail_to_user(user, "[Expertiza] Added to a Team", "mentor_added_to_team", "#{name}", Assignment.find(_assignment_id).name.to_s).deliver
+      else
+        MailerHelper.send_team_confirmation_mail_to_user(user, "[Expertiza] Added to a Team", "user_added_to_team", "#{name}", Assignment.find(_assignment_id).name.to_s).deliver
+      end
+
     end
     can_add_member
   end

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -88,6 +88,8 @@ class Team < ApplicationRecord
       TeamUserNode.create(parent_id: parent.id, node_object_id: t_user.id)
       add_participant(parent_id, user)
       ExpertizaLogger.info LoggerMessage.new('Model:Team', user.name, "Added member to the team #{id}")
+      # Now that a new team member has been added to a team, send an email to them letting them know
+      MailerHelper.send_team_confirmation_mail_to_user(user, "You have been added to the team #{name}.", "team_welcome").deliver
     end
     can_add_member
   end

--- a/app/views/mailer/partials/_mentor_added_to_team_html.html.erb
+++ b/app/views/mailer/partials/_mentor_added_to_team_html.html.erb
@@ -1,0 +1,8 @@
+Hi <%= @first_name %>,
+<BR>
+<p>
+  You are now mentoring Team '<%= @team %>' for the Assignment '<%= @assignment %>' on Expertiza.
+</p>
+<p>
+  Expertiza Team
+</p>

--- a/app/views/mailer/partials/_mentor_added_to_team_plain.html.erb
+++ b/app/views/mailer/partials/_mentor_added_to_team_plain.html.erb
@@ -1,0 +1,5 @@
+Hi <%= @first_name %>,
+
+You are now mentoring Team '<%= @team %>' for the Assignment '<%= @assignment %>' on Expertiza.
+
+Expertiza Team

--- a/app/views/mailer/partials/_user_added_to_team_html.html.erb
+++ b/app/views/mailer/partials/_user_added_to_team_html.html.erb
@@ -1,7 +1,7 @@
 Hi <%= @first_name %>,
 <BR>
 <p>
-  You have been added to Team <%= @team_name %> for the Assignment '<%= @assignment_name %>' on Expertiza.
+  You have been added to Team '<%= @team %>' for the Assignment '<%= @assignment %>' on Expertiza.
 </p>
 <p>
   Expertiza Team

--- a/app/views/mailer/partials/_user_added_to_team_html.html.erb
+++ b/app/views/mailer/partials/_user_added_to_team_html.html.erb
@@ -1,0 +1,8 @@
+Hi <%= @first_name %>,
+<BR>
+<p>
+  You have been added to Team <%= @team_name %> for the Assignment '<%= @assignment_name %>' on Expertiza.
+</p>
+<p>
+  Expertiza Team
+</p>

--- a/app/views/mailer/partials/_user_added_to_team_plain.html.erb
+++ b/app/views/mailer/partials/_user_added_to_team_plain.html.erb
@@ -1,0 +1,5 @@
+Hi <%= @first_name %>,
+
+You have been added to Team '<%= @team_name %>' for the Assignment '<%= @assignment_name %>' on Expertiza.
+
+Expertiza Team

--- a/app/views/mailer/partials/_user_added_to_team_plain.html.erb
+++ b/app/views/mailer/partials/_user_added_to_team_plain.html.erb
@@ -1,5 +1,5 @@
 Hi <%= @first_name %>,
 
-You have been added to Team '<%= @team_name %>' for the Assignment '<%= @assignment_name %>' on Expertiza.
+You have been added to Team '<%= @team %>' for the Assignment '<%= @assignment %>' on Expertiza.
 
 Expertiza Team

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -105,29 +105,27 @@ describe Team do
           allow_any_instance_of(Team).to receive(:add_participant).with(1, user).and_return(double('Participant'))
         end
         it 'sends mail to mentor if user is a mentor' do
-            allow(MentorManagement).to receive(:user_a_mentor?).with(user).and_return(true)
-            allow(Assignment).to receive(:find).with(1).and_return(assignment)
-            allow(MailerHelper).to receive(:send_team_confirmation_mail_to_user).and_return(double('Mail', deliver: true))
+          allow(MentorManagement).to receive(:user_a_mentor?).with(user).and_return(true)
+          allow(Assignment).to receive(:find).with(1).and_return(assignment)
+          allow(MailerHelper).to receive(:send_team_confirmation_mail_to_user).and_return(double('Mail', deliver: true))
 
-            expect(MailerHelper).to receive(:send_team_confirmation_mail_to_user).with(user, "[Expertiza] Added to a Team", "mentor_added_to_team", "#{team.name}", "").and_return(double('Mail', deliver: true))
+          expect(MailerHelper).to receive(:send_team_confirmation_mail_to_user).with(user, '[Expertiza] Added to a Team', 'mentor_added_to_team', team.name.to_s, '').and_return(double('Mail', deliver: true))
 
-            expect(team.add_member(user)).to be true
+          expect(team.add_member(user)).to be true
         end
 
         it 'sends mail to user if user is a user' do
-            allow(MentorManagement).to receive(:user_a_mentor?).with(user).and_return(false)
-            allow(Assignment).to receive(:find).with(1).and_return(assignment)
-            allow(MailerHelper).to receive(:send_team_confirmation_mail_to_user).and_return(double('Mail', deliver: true))
+          allow(MentorManagement).to receive(:user_a_mentor?).with(user).and_return(false)
+          allow(Assignment).to receive(:find).with(1).and_return(assignment)
+          allow(MailerHelper).to receive(:send_team_confirmation_mail_to_user).and_return(double('Mail', deliver: true))
 
-            expect(MailerHelper).to receive(:send_team_confirmation_mail_to_user).with(user, "[Expertiza] Added to a Team", "user_added_to_team", "#{team.name}", "").and_return(double('Mail', deliver: true))
+          expect(MailerHelper).to receive(:send_team_confirmation_mail_to_user).with(user, '[Expertiza] Added to a Team', 'user_added_to_team', team.name.to_s, '').and_return(double('Mail', deliver: true))
 
-            expect(team.add_member(user)).to be true
+          expect(team.add_member(user)).to be true
         end
       end
     end
   end
-
-
 
   describe '.size' do
     it 'returns the size of current team' do


### PR DESCRIPTION
Changes Proposed in Pull Request:

Added a new feature such that users are automatically emailed when they are added to a team. Also, mentors are automatically emailed a different email when they are added to a team. 
Added a new function to the mailer_helper class for mail specifically sent to user/mentors when added to a team. 
Added view partials to handle the HTML format of the new emails being sent. 
Slightly changed the generic_message function in the mailer class to handle more cases. 
Also added test cases to check that users/mentors are emailed when added to teams now. 

Mentions:
@efg 


