### PR TITLE
E2411. Fix "Back" link on “New Late Policy” page

### DIFF
--- a/app/models/assignment_form.rb
+++ b/app/models/assignment_form.rb
@@ -80,7 +80,8 @@ class AssignmentForm
   # Code to update values of assignment
   def update_assignment(attributes)
     unless @assignment.update_attributes(attributes)
-      @errors = @assignment.errors.to_s
+      # calling the full_messages method instead of to_s method
+      @errors = @assignment.errors.full_messages
       @has_errors = true
     end
     @assignment.num_review_of_reviews = @assignment.num_metareviews_allowed
@@ -93,7 +94,8 @@ class AssignmentForm
 
     if attributes[0].key?(:questionnaire_weight)
       validate_assignment_questionnaires_weights(attributes)
-      @errors = @assignment.errors.to_s
+      # calling the full_messages method instead of to_s method
+      @errors = @assignment.errors.full_messages
       topic_id = nil
     end
     unless @has_errors
@@ -107,13 +109,15 @@ class AssignmentForm
         aq = assignment_questionnaire(questionnaire_type, attr[:used_in_round], topic_id, duty_id)
         if aq.id.nil?
           unless aq.save
-            @errors = @assignment.errors.to_s
+            # calling the full_messages method instead of to_s method
+            @errors = @assignment.errors.full_messages
             @has_errors = true
             next
           end
         end
         unless aq.update_attributes(attr)
-          @errors = @assignment.errors.to_s
+          # calling the full_messages method instead of to_s method
+          @errors = @assignment.errors.full_messages
           @has_errors = true
         end
       end
@@ -190,7 +194,8 @@ class AssignmentForm
         # get deadline for review
         @has_errors = true unless dd.update_attributes(due_date)
       end
-      @errors += @assignment.errors.to_s if @has_errors
+      # calling the full_messages method instead of to_s method
+      @errors += @assignment.errors.full_messages if @has_errors
     end
   end
 

--- a/app/views/assignments/edit.html.erb
+++ b/app/views/assignments/edit.html.erb
@@ -126,6 +126,13 @@
       $('#go_to_tabs2').click(function(){
         $('#Rubrics').click();
       });
+      // Redirect to Due Date Tab  on Back link from late policy
+      jQuery(document).ready(function() {
+        var referrer =  document.referrer;
+        if(referrer.includes("late_policies")){                     
+          $('#DueDates').click();
+        }  
+      }); 
     </script>
   <% end %>
 

--- a/app/views/late_policies/index.html.erb
+++ b/app/views/late_policies/index.html.erb
@@ -39,4 +39,4 @@ end
 <br />
 
 <%= link_to 'New late policy', :action => 'new'%><br />
-<%= link_to 'Back', :controller=> 'assignments', :action => 'edit', :id=>session[:assignment]%>
+<%= link_to 'Back', :controller=> 'assignments', :action => 'edit', :id=>session[:assignment_id]%>

--- a/app/views/late_policies/index.html.erb
+++ b/app/views/late_policies/index.html.erb
@@ -39,4 +39,4 @@ end
 <br />
 
 <%= link_to 'New late policy', :action => 'new'%><br />
-<%= link_to 'Back', :controller=> 'assignments', :action => 'edit', :id=>session[:assignment_id]%>
+<%= link_to 'Back', :controller=> 'assignments', :action => 'edit', :id=>session[:assignment]%>

--- a/app/views/late_policies/new.html.erb
+++ b/app/views/late_policies/new.html.erb
@@ -10,4 +10,4 @@
 
 <br>
 <br>
-<%= link_to 'Back', :controller=> 'assignments', :action => 'edit', :id=>session[:assignment]%>
+<%= link_to 'Back', :controller=> 'assignments', :action => 'edit', :id=>session[:assignment_id]%>

--- a/app/views/late_policies/new.html.erb
+++ b/app/views/late_policies/new.html.erb
@@ -10,4 +10,4 @@
 
 <br>
 <br>
-<%= link_to 'Back', :controller=> 'assignments', :action => 'edit', :id=>session[:assignment_id]%>
+<%= link_to 'Back', :controller=> 'assignments', :action => 'edit', :id=>session[:assignment]%>

--- a/spec/features/late_policy_features.rb
+++ b/spec/features/late_policy_features.rb
@@ -20,8 +20,8 @@ describe 'Assignment creation topics tab', js: true do
     visit "/assignments/#{assignment.id}/edit"
     click_link 'Due Dates'
     click_link 'New Late Policy'
-    fails if 
-      expect(flash[:error]).to be('Failed to save the assignment: ') 
+    fails if
+      expect(flash[:error]).to be('Failed to save the assignment: ')
     end
   end
 

--- a/spec/features/late_policy_features.rb
+++ b/spec/features/late_policy_features.rb
@@ -1,0 +1,27 @@
+require_relative 'features/helpers/assignment_creation_helper'
+
+describe 'Assignment creation topics tab', js: true do
+  include AssignmentCreationHelper
+  before(:each) do
+    create_deadline_types
+    (1..3).each do |i|
+      create(:course, name: "Course #{i}")
+    end
+    assignment = create(:assignment, name: 'assignment for late policy test')
+    login_as('instructor6')
+    visit "/assignments/#{assignment.id}/edit"
+    check('assignment_has_due_dates')
+    click_link 'Due Dates'
+  end
+
+  it 'Flash Error Message on New Late Policy Page', js: true do
+    assignment = Assignment.where(name: 'assignment for late policy test').first
+    create(:topic, assignment_id: assignment.id)
+    visit "/assignments/#{assignment.id}/edit"
+    click_link 'Due Dates'
+    click_link 'New Late Policy'
+    fails if 
+      expect(flash[:error]).to be('Failed to save the assignment: ') 
+    end
+  end
+end

--- a/spec/features/late_policy_features.rb
+++ b/spec/features/late_policy_features.rb
@@ -24,4 +24,29 @@ describe 'Assignment creation topics tab', js: true do
       expect(flash[:error]).to be('Failed to save the assignment: ') 
     end
   end
+
+it 'Back Button Interation on New Late Policy Page', js: true do
+    assignment = Assignment.where(name: 'assignment for late policy test').first
+    create(:topic, assignment_id: assignment.id)
+    visit "/assignments/#{assignment.id}/edit"
+    click_link 'Due Dates'
+    click_button 'New Late Policy'
+    click_button 'Back'
+    expect(page).to route_to("/assignments/#{assignment.id}/edit")
+  end
+
+  it 'Back Button Interation on New Late Policy Page while creating', js: true do
+    assignment = Assignment.where(name: 'assignment for late policy test').first
+    create(:topic, assignment_id: assignment.id)
+    visit "/assignments/#{assignment.id}/edit"
+    click_link 'Due Dates'
+    click_button 'New Late Policy'
+    fill_in "policy_name", with: 'Test Late Policy'
+    fill_in "penalty_per_unit", with: '15'
+    fill_in "max_penalty", with: '20'
+    click_button 'Create'
+    visit "/late_policies"
+    click_button 'Back'
+    expect(page).to route_to("/assignments/#{assignment.id}/edit")
+  end
 end


### PR DESCRIPTION
We have fixed the following issues mentioned in the project documentation in this PR:

Issue 1: Fixed the issue so that it doesn’t show error message "Failed to save the assignment: #" when clicking on New Late Policy in Due Date tab. 
Issue 2: The Back link on the New late policy page now directs the user to Due dates tab so that they can continue to edit the assignment instead of showing an error.
