### PR TITLE
remove the condition to submit when a participant is only on a team

### DIFF
--- a/app/views/grades/view_team.html.erb
+++ b/app/views/grades/view_team.html.erb
@@ -295,10 +295,11 @@
     <%=t ".late_penalty"%>: <%= label_tag 'late_penalty', @penalties[:submission] %><br/>
   <% end %>
   <% if TaMapping.where(ta_id: @ta_id, course_id: @course_id).exists? || current_user == @assignment.instructor%>
-  <h4 style="font-weight:bold;display:inline-block;">TA Grade-Comment:</h4><br/>
+  <h4 style="font-weight:bold;display:inline-block;">Grade</h4><br/>
     <%= form_tag 'save_grade_and_comment_for_submission' do %>
       <%= hidden_field_tag :participant_id, params[:id] %>
       <%= number_field_tag 'grade_for_submission', @team.try(:grade_for_submission) ,min: 0, max: 100, maxlength: 3, size: 3, class: "form-control width-150", placeholder: t(".grade") %><br/>
+      <h4 style="font-weight:bold;display:inline-block;">Comments</h4><br/>
       <%= text_area_tag 'comment_for_submission', @team.try(:comment_for_submission), size: '75x10', placeholder: t(".Comment"), class: "form-control width-500" %><br>
       <%= submit_tag t(".save") ,class: "btn btn-default" %>
     <% end %>

--- a/app/views/student_task/view.html.erb
+++ b/app/views/student_task/view.html.erb
@@ -57,27 +57,23 @@ to display the label "Your team" in the student assignment tasks-->
  <!--Your work-->
   <% if @authorization == 'participant' || @can_submit == true %>
     <li>
-      <% if @assignment.max_team_size <= 1 || @team %>
-        <% if @topics.size > 0 %>
-          <% if @topic_id && @assignment.submission_allowed(@topic_id) %>
-            <%= link_to t(".your_work"), :controller => 'submitted_content', :action => 'edit', :id => @participant.id %> <%=t ".submit_work" %>
-          <% else %>
-            <!--if one team do not hold a topic (still in waitlist), they cannot submit their work.-->
-            <font color="gray"><%=t ".your_work" %></font> <%=t ".choose_topic" %>
-          <% end %>
+      <% if @topics.size > 0 %>
+        <% if @topic_id && @assignment.submission_allowed(@topic_id) %>
+          <%= link_to t(".your_work"), :controller => 'submitted_content', :action => 'edit', :id => @participant.id %> <%=t ".submit_work" %>
         <% else %>
-          <% if @assignment.submission_allowed(@topic_id) %>
-            <%= link_to t(".your_work"), :controller => 'submitted_content', :action => 'edit', :id => @participant.id %> <%=t ".submit_work" %>
-          <% else %>
-            <font color="gray"><%=t ".your_work" %></font> <%=t ".not_allowed" %>
-          <% end %>
+          <!--if one team do not hold a topic (still in waitlist), they cannot submit their work.-->
+          <font color="gray"><%=t ".your_work" %></font> <%=t ".choose_topic" %>
         <% end %>
       <% else %>
-        <!-- Must be on a team to click "Your Work" -->
-        <font color="gray"><%=t ".your_work" %></font> <%=t ".not_allowed" %>
-      <% end%>
+        <% if @assignment.submission_allowed(@topic_id) %>
+          <%= link_to t(".your_work"), :controller => 'submitted_content', :action => 'edit', :id => @participant.id %> <%=t ".submit_work" %>
+        <% else %>
+          <font color="gray"><%=t ".your_work" %></font> <%=t ".not_allowed" %>
+        <% end %>
+      <% end %>
     </li>
   <% end %>
+
 
   <% if @authorization == 'participant' or @can_review == true %>
     <li>

--- a/app/views/student_task/view.html.erb
+++ b/app/views/student_task/view.html.erb
@@ -74,7 +74,6 @@ to display the label "Your team" in the student assignment tasks-->
     </li>
   <% end %>
 
-
   <% if @authorization == 'participant' or @can_review == true %>
     <li>
       <!--alias_name means if one participant is a reader, it will show 'Your readings' to see others' work; if one participant is not a reader, it will show 'Others' work' on the screen.-->

--- a/app/views/student_task/view.html.erb
+++ b/app/views/student_task/view.html.erb
@@ -54,7 +54,7 @@ to display the label "Your team" in the student assignment tasks-->
         <%=t ".view_team" %>
   <% end %>
 
-  <!--Your work-->
+ <!--Your work-->
   <% if @authorization == 'participant' || @can_submit == true %>
     <li>
       <% if @assignment.max_team_size <= 1 || @team %>


### PR DESCRIPTION
The view has a condition where the "your work" option is only enabled when a particpant is on a team or when max team size 1. This has been removed from the view. The tests performed were:

1. Now a participant can submit if he is not a part of a team and a team is automatically created when the submission is done.
2. If the participant is on a team and if they submit work it is submitted correctly.
3. If the participant has submitted work (individually ie he is in a team of 1 member) and decides to join another team, they are given a warning that their submission will be removed if they decide to change a team as the team has 0 members. 
