### PR TITLE
E2375: Reimplement waitlists

### DIFF
--- a/app/controllers/sign_up_sheet_controller.rb
+++ b/app/controllers/sign_up_sheet_controller.rb
@@ -278,7 +278,8 @@ class SignUpSheetController < ApplicationController
       flash[:error] = 'You cannot drop your topic after the drop topic deadline!'
       ExpertizaLogger.error LoggerMessage.new(controller_name, session[:user].id, 'Dropping topic for ended work: ' + params[:topic_id].to_s)
     else
-      delete_signup_for_topic(assignment.id, params[:topic_id], session[:user].id)
+      users_team = SignedUpTeam.find_team_users(assignment.id, session[:user].id)
+      delete_signup_for_topic(params[:topic_id], users_team[0].t_id)
       flash[:success] = 'You have successfully dropped your topic!'
       ExpertizaLogger.info LoggerMessage.new(controller_name, session[:user].id, 'Student has dropped the topic: ' + params[:topic_id].to_s)
     end
@@ -299,7 +300,7 @@ class SignUpSheetController < ApplicationController
       flash[:error] = 'You cannot drop a student after the drop topic deadline!'
       ExpertizaLogger.error LoggerMessage.new(controller_name, session[:user].id, 'Drop failed for ended work: ' + params[:topic_id].to_s)
     else
-      delete_signup_for_topic(assignment.id, params[:topic_id], participant.user_id)
+      delete_signup_for_topic(params[:topic_id], team.id)
       flash[:success] = 'You have successfully dropped the student from the topic!'
       ExpertizaLogger.error LoggerMessage.new(controller_name, session[:user].id, 'Student has been dropped from the topic: ' + params[:topic_id].to_s)
     end
@@ -511,7 +512,8 @@ class SignUpSheetController < ApplicationController
     @ad_information
   end
 
-  def delete_signup_for_topic(assignment_id, topic_id, user_id)
-    SignUpTopic.new.reassign_topic(user_id, assignment_id, topic_id)
+  def delete_signup_for_topic(topic_id, team_id)
+    topic_id.reassign_topic(team_id)
   end
+  
 end

--- a/app/controllers/sign_up_sheet_controller.rb
+++ b/app/controllers/sign_up_sheet_controller.rb
@@ -512,6 +512,6 @@ class SignUpSheetController < ApplicationController
   end
 
   def delete_signup_for_topic(assignment_id, topic_id, user_id)
-    SignUpTopic.reassign_topic(user_id, assignment_id, topic_id)
+    SignUpTopic.new.reassign_topic(user_id, assignment_id, topic_id)
   end
 end

--- a/app/controllers/sign_up_sheet_controller.rb
+++ b/app/controllers/sign_up_sheet_controller.rb
@@ -513,8 +513,14 @@ class SignUpSheetController < ApplicationController
   end
 
   def delete_signup_for_topic(topic_id, team_id)
+    # Delete a signup record for a specific topic and team.
+
+    # Find the SignUpTopic record with the specified topic_id using the `find_by` method.
     @sign_up_topic = SignUpTopic.find_by(id: topic_id)
+    # Check if the @sign_up_topic record exists (is not nil).
     unless @sign_up_topic.nil?
+       # If the @sign_up_topic record exists, reassign the topic for the specified team by calling the `reassign_topic` 
+       # instance method of SignUpTopic.
       @sign_up_topic.reassign_topic(team_id)
     end 
   end

--- a/app/controllers/sign_up_sheet_controller.rb
+++ b/app/controllers/sign_up_sheet_controller.rb
@@ -513,7 +513,10 @@ class SignUpSheetController < ApplicationController
   end
 
   def delete_signup_for_topic(topic_id, team_id)
-    topic_id.reassign_topic(team_id)
+    @sign_up_topic = SignUpTopic.find_by(id: topic_id)
+    unless @sign_up_topic.nil?
+      @sign_up_topic.reassign_topic(team_id)
+    end 
   end
   
 end

--- a/app/controllers/sign_up_sheet_controller.rb
+++ b/app/controllers/sign_up_sheet_controller.rb
@@ -157,7 +157,6 @@ class SignUpSheetController < ApplicationController
     # to treat all assignments as team assignments
     # Though called participants, @participants are actually records in signed_up_teams table, which
     # is a mapping table between teams and topics (waitlisted recorded are also counted)
-    @participants = SignedUpTeam.find_team_participants(assignment_id, session[:ip])
   end
 
   def set_values_for_new_topic
@@ -218,7 +217,7 @@ class SignUpSheetController < ApplicationController
       # Find whether the user has signed up for any topics; if so the user won't be able to
       # sign up again unless the former was a waitlisted topic
       # if team assignment, then team id needs to be passed as parameter else the user's id
-      users_team = SignedUpTeam.find_team_users(@assignment.id, session[:user].id)
+      users_team = Team.find_team_users(@assignment.id, session[:user].id)
       @selected_topics = if users_team.empty?
                            nil
                          else
@@ -278,7 +277,7 @@ class SignUpSheetController < ApplicationController
       flash[:error] = 'You cannot drop your topic after the drop topic deadline!'
       ExpertizaLogger.error LoggerMessage.new(controller_name, session[:user].id, 'Dropping topic for ended work: ' + params[:topic_id].to_s)
     else
-      users_team = SignedUpTeam.find_team_users(assignment.id, session[:user].id)
+      users_team = Team.find_team_users(assignment.id, session[:user].id)
       delete_signup_for_topic(params[:topic_id], users_team[0].t_id)
       flash[:success] = 'You have successfully dropped your topic!'
       ExpertizaLogger.info LoggerMessage.new(controller_name, session[:user].id, 'Student has dropped the topic: ' + params[:topic_id].to_s)

--- a/app/controllers/sign_up_sheet_controller.rb
+++ b/app/controllers/sign_up_sheet_controller.rb
@@ -157,7 +157,9 @@ class SignUpSheetController < ApplicationController
     # to treat all assignments as team assignments
     # Though called participants, @participants are actually records in signed_up_teams table, which
     # is a mapping table between teams and topics (waitlisted recorded are also counted)
+    @participants = SignedUpTeam.find_team_participants(assignment_id, session[:ip])
   end
+
 
   def set_values_for_new_topic
     @sign_up_topic = SignUpTopic.new

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -104,23 +104,25 @@ class TeamsController < ApplicationController
     # delete records in team, teams_users, signed_up_teams table
     @team = Team.find_by(id: params[:id])
     unless @team.nil?
+      # Find all SignedUpTeam records associated with the found team.
       @signed_up_team = SignedUpTeam.where(team_id: @team.id)
+      # Find all TeamsUser records associated with the found team.
       @teams_users = TeamsUser.where(team_id: @team.id)
-
+      # Check if there are SignedUpTeam records associated with the found team.
       unless @signed_up_team.nil?
+        # If a topic is assigned to this team and there is only one signed up team record, and it's not waitlisted.
         if @signed_up_team.count == 1 && !@signed_up_team.first.is_waitlisted  # if a topic is assigned to this team
-            # fetch topic object 
+            # Fetch the SignUpTopic object associated with the single signed up team.
             @signed_topic = SignUpTopic.find_by(id: @signed_up_team.first.topic_id)
             unless @signed_topic.nil?
-              # call instance method reassign_topic to reassign topic
+              # Call the instance method `reassign_topic` of SignUpTopic to reassign the topic.
               @signed_topic.reassign_topic(@signed_up_team.first.team_id)
             end
         else
-          # drop all waitlists in SignedUpTeam
+          # Drop all waitlists in SignedUpTeam for the specified team ID.
           SignedUpTeam.drop_off_waitlists(params[:id])
         end
       end
-
      # @sign_up_team.destroy_all if @sign_up_team
       @teams_users.destroy_all if @teams_users
       @team.destroy if @team

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -108,23 +108,18 @@ class TeamsController < ApplicationController
       @teams_users = TeamsUser.where(team_id: @team.id)
 
       unless @signed_up_team.nil?
-        if @signed_up_team.count == 1 && !@signed_up_team.first.is_waitlisted # if a topic is assigned to this team
-          assignment = Assignment.find(@team.parent_id)
-          user = TeamsUser.find_by(team_id: @team.id).user
-          participant = AssignmentParticipant.find_by(user_id: user.id, parent_id: assignment.id)
-          SignUpTopic.new.reassign_topic_when_team_deleted(@signed_up_team.first.topic_id,@signed_up_team.first.team_id)
-
-          # # if there is another team in waitlist, assign this topic to the new team
-          # topic_id = @signed_up_team.first.topic_id
-          # next_wait_listed_team = SignedUpTeam.where(topic_id: topic_id, is_waitlisted: true).first
-          # # Save the topic's new assigned team and delete all waitlists for this team
-          # SignUpTopic.assign_to_first_waiting_team(next_wait_listed_team) if next_wait_listed_team
+        if @signed_up_team.count == 1 && !@signed_up_team.first.is_waitlisted  # if a topic is assigned to this team
+            # fetch topic object 
+            @signed_topic = SignUpTopic.find_by(id: @signed_up_team.first.topic_id)
+            unless @signed_topic.nil?
+              # call instance method reassign_topic to reassign topic
+              @signed_topic.reassign_topic(@signed_up_team.first.team_id)
+            end
         else
-          SignedUpTeam.new.drop_off_waitlists(params[:id])
+          # drop all waitlists in SignedUpTeam
+          SignedUpTeam.drop_off_waitlists(params[:id])
         end
       end
-
-
 
      # @sign_up_team.destroy_all if @sign_up_team
       @teams_users.destroy_all if @teams_users

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -652,7 +652,7 @@ class Assignment < ApplicationRecord
   end
 
   #Method to drop all the SignedUpRecords of all topics for that assignment once the drop_topic deadline passes
-  def drop_waitlisted_topics
+  def drop_waitlisted_teams
     # Find all the topics (sign_up_topics) under the current assignment (self).
     topics = SignUpTopic.where(assignment_id: self.id)
   

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -650,4 +650,18 @@ class Assignment < ApplicationRecord
     end
     reviewers = reviewers.sort_by { |a| a[1] }
   end
+
+  #Method to drop all the SignedUpRecords of all topics for that assignment once the drop_topic deadline passes
+  def drop_waitlisted_topics
+    # Find all the topics (sign_up_topics) under the current assignment (self).
+    topics = SignUpTopic.where(assignment_id: self.id)
+  
+    # Iterate through each topic to find and drop waitlisted teams.
+    topics.each do |topic|
+      signed_up_teams = SignedUpTeam.where(topic_id: topic.id, is_waitlisted: true)
+      # Remove all of the waitlisted SignedUpTeam entries for this topic.
+      signed_up_teams.destroy_all
+    end
+  end
+
 end

--- a/app/models/assignment_team.rb
+++ b/app/models/assignment_team.rb
@@ -99,6 +99,15 @@ class AssignmentTeam < Team
   end
   alias get_participants participants
 
+  # Delete the team
+  def delete
+    if self[:type] == 'AssignmentTeam'
+      sign_up = SignedUpTeam.find_team_participants(parent_id.to_s).select { |p| p.team_id == id }
+      sign_up.each(&:destroy)
+    end
+    super
+  end
+
   # Delete Review response map
   def destroy
     review_response_maps.each(&:destroy)

--- a/app/models/assignment_team.rb
+++ b/app/models/assignment_team.rb
@@ -99,15 +99,6 @@ class AssignmentTeam < Team
   end
   alias get_participants participants
 
-  # Delete the team
-  def delete
-    if self[:type] == 'AssignmentTeam'
-      sign_up = SignedUpTeam.find_team_participants(parent_id.to_s).select { |p| p.team_id == id }
-      sign_up.each(&:destroy)
-    end
-    super
-  end
-
   # Delete Review response map
   def destroy
     review_response_maps.each(&:destroy)

--- a/app/models/sign_up_sheet.rb
+++ b/app/models/sign_up_sheet.rb
@@ -11,7 +11,7 @@ class SignUpSheet < ApplicationRecord
     # Confirm the signup topic if a topic ID is provided
     @signup_topic = SignUpTopic.find_by(id: topic_id)
     unless @signup_topic.nil?
-      confirmation_status = @signup_topic.signup_team_for_chosen_topic(team_id)
+      confirmation_status = @signup_topic.sign_team_up(team_id)
     end
     # Log the signup topic save status
     ExpertizaLogger.info "The signup topic save status:#{confirmation_status} for assignment #{assignment_id} by #{user_id}"

--- a/app/models/sign_up_sheet.rb
+++ b/app/models/sign_up_sheet.rb
@@ -1,82 +1,93 @@
 class SignUpSheet < ApplicationRecord
   # Team lazy initialization method [zhewei, 06/27/2015]
   def self.signup_team(assignment_id, user_id, topic_id = nil)
-    users_team = SignedUpTeam.find_team_users(assignment_id, user_id)
-    if users_team.empty?
-      # if team is not yet created, create new team.
-      # create Team and TeamNode
+    # Find the team ID for the given assignment and user
+    team_id = SignedUpTeam.find_team_users(assignment_id, user_id)&.first&.t_id
+  
+    # If the team doesn't exist, create a new team and assign the team ID
+    if team_id.nil?
       team = AssignmentTeam.create_team_with_users(assignment_id, [user_id])
-      # create SignedUpTeam
-      confirmationStatus = SignUpSheet.confirmTopic(user_id, team.id, topic_id, assignment_id) if topic_id
-    else
-      confirmationStatus = SignUpSheet.confirmTopic(user_id, users_team[0].t_id, topic_id, assignment_id) if topic_id
+      team_id = team.id
     end
-    ExpertizaLogger.info "The signup topic save status:#{confirmationStatus} for assignment #{assignment_id} by #{user_id}"
-    confirmationStatus
+  
+    # Confirm the signup topic if a topic ID is provided
+    confirmation_status = SignUpSheet.confirm_topic(user_id, team_id, topic_id, assignment_id) if topic_id
+  
+    # Log the signup topic save status
+    ExpertizaLogger.info "The signup topic save status:#{confirmation_status} for assignment #{assignment_id} by #{user_id}"
+    confirmation_status
   end
 
-  def self.confirmTopic(user_id, team_id, topic_id, assignment_id)
-    # check whether user has signed up already
-    user_signup = SignUpSheet.otherConfirmedTopicforUser(assignment_id, team_id)
+  # Confirm a topic for a user within a team for a specific assignment
+  def self.confirm_topic(user_id, team_id, topic_id, assignment_id)
+    # Fetch all topics for the user within the team for the assignment
+    user_signup = SignedUpTeam.find_user_signup_topics(assignment_id, team_id)
+    # Fetch users within the team and obtain team details
     users_team = SignedUpTeam.find_team_users(assignment_id, user_id)
     team = Team.find(users_team.first.t_id)
-    if SignedUpTeam.where(team_id: team.id, topic_id: topic_id).any?
-      return false
-    end
 
-    sign_up = SignedUpTeam.new
-    sign_up.topic_id = topic_id
-    sign_up.team_id = team_id
+    # Check if the topic is already signed up by the team, return false if exists
+    return false if SignedUpTeam.where(team_id: team.id, topic_id: topic_id).any?
+
+    # Create a new SignedUpTeam instance with the provided topic and team details
+    sign_up = SignedUpTeam.new(topic_id: topic_id, team_id: team_id)
     result = false
-    if user_signup.empty?
 
-      # Using a DB transaction to ensure atomic inserts
+    if user_signup.empty?
+      # If there are no topics for the user within the team, proceed with signing up
       ApplicationRecord.transaction do
-        # check whether slots exist (params[:id] = topic_id) or has the user selected another topic
-        team_id, topic_id = create_SignUpTeam(assignment_id, sign_up, topic_id, user_id)
+        # Create a signup_team entry for the team if the slot is available or waitlist it
+        team_id, topic_id = create_signup_team(assignment_id, sign_up, topic_id, user_id)
         result = true if sign_up.save
       end
     else
-      # This line of code checks if the "user_signup_topic" is on the waitlist. If it is not on the waitlist, then the code returns 
-      # false. If it is on the waitlist, the code continues to execute.
-      user_signup.each do |user_signup_topic|
-        return false unless user_signup_topic.is_waitlisted
-      end
+      # If the user is already signed up for a topic, then return false
+      return false unless user_signup.first&.is_waitlisted == true
 
-      # Using a DB transaction to ensure atomic inserts
+      #If the team has a waitlisted topic, then assign it to a 
       ApplicationRecord.transaction do
-        # check whether user is clicking on a topic which is not going to place him in the waitlist
-        result = sign_up_wailisted(assignment_id, sign_up, team_id, topic_id)
+        result = signup_team_for_chosen_topic(assignment_id, sign_up, team_id, topic_id)
       end
     end
 
-    result
+    result # Return the result of the confirmation process
   end
 
-  def self.sign_up_wailisted(assignment_id, sign_up, team_id, topic_id)
-    if slotAvailable?(topic_id)
-      # if slot exist, then confirm the topic for the user and delete all the waitlist for this user
-      result = cancel_all_wailists(assignment_id, sign_up, team_id, topic_id)
+  # Method to handle the process when a user signs up and is on the waitlist
+  def self.signup_team_for_chosen_topic(assignment_id, sign_up, team_id, topic_id)
+    if slot_available?(topic_id)
+      # Assign the topic to the team if a slot is available and drop off the team from all waitlists
+      assign_topic_to_team(sign_up, topic_id)
+      #Once assigned, drop all the waitlisted topics for this team
+      result = SignedUpTeam.drop_off_waitlists(team_id)
     else
-      sign_up.is_waitlisted = true
-      result = true if sign_up.save
-      ExpertizaLogger.info LoggerMessage.new('SignUpSheet', '', "Sign up sheet created for waitlisted with teamId #{team_id}")
+      # Save the team as waitlisted if no slots are available
+      result = save_waitlist_entry(sign_up, team_id)
     end
     result
   end
 
-  def self.cancel_all_wailists(assignment_id, sign_up, team_id, topic_id)
-    Waitlist.cancel_all_waitlists(team_id, assignment_id)
-    sign_up.is_waitlisted = false
-    sign_up.save
-    # Update topic_id in signed_up_teams table with the topic_id
-    signUp = SignedUpTeam.where(topic_id: topic_id).first
-    signUp.update_attribute('topic_id', topic_id)
-    return true
+  # Method to assign a topic to the team and update the waitlist status
+  def self.assign_topic_to_team(sign_up, topic_id)
+    # Set the team's waitlist status to false as they are assigned a topic
+    sign_up.update(is_waitlisted: false)
+    # Update the topic_id in the signed_up_teams table for the user
+    signed_up_team = SignedUpTeam.find_by(topic_id: topic_id)
+    signed_up_team.update(topic_id: topic_id) if signed_up_team
   end
 
-  def self.create_SignUpTeam(assignment_id, sign_up, topic_id, user_id)
-    if slotAvailable?(topic_id)
+  # Method to save the user as waitlisted if no slots are available
+  def self.save_waitlist_entry(sign_up, team_id)
+    sign_up.is_waitlisted = true
+    # Save the user's waitlist status
+    result = sign_up.save
+    # Log the creation of the sign-up sheet for the waitlisted user
+    ExpertizaLogger.info(LoggerMessage.new('SignUpSheet', '', "Sign up sheet created for waitlisted with teamId #{team_id}"))
+    result
+  end
+
+  def self.create_signup_team(assignment_id, sign_up, topic_id, user_id)
+    if slot_available?(topic_id)
       sign_up.is_waitlisted = false
       # Create new record in signed_up_teams table
       team_id = TeamsUser.team_id(assignment_id, user_id)
@@ -89,14 +100,9 @@ class SignUpSheet < ApplicationRecord
     [team_id, topic_id]
   end
 
-  def self.otherConfirmedTopicforUser(assignment_id, team_id)
-    user_signup = SignedUpTeam.find_user_signup_topics(assignment_id, team_id)
-    user_signup
-  end
-
   # When using this method when creating fields, update race conditions by using db transactions
-  def self.slotAvailable?(topic_id)
-    SignUpTopic.slotAvailable?(topic_id)
+  def self.slot_available?(topic_id)
+    SignUpTopic.slot_available?(topic_id)
   end
 
   def self.add_signup_topic(assignment_id)

--- a/app/models/sign_up_sheet.rb
+++ b/app/models/sign_up_sheet.rb
@@ -3,106 +3,19 @@ class SignUpSheet < ApplicationRecord
   def self.signup_team(assignment_id, user_id, topic_id = nil)
     # Find the team ID for the given assignment and user
     team_id = SignedUpTeam.find_team_users(assignment_id, user_id)&.first&.t_id
-  
     # If the team doesn't exist, create a new team and assign the team ID
     if team_id.nil?
       team = AssignmentTeam.create_team_with_users(assignment_id, [user_id])
       team_id = team.id
     end
-  
     # Confirm the signup topic if a topic ID is provided
-    confirmation_status = SignUpSheet.confirm_topic(user_id, team_id, topic_id, assignment_id) if topic_id
-  
+    @signup_topic = SignUpTopic.find_by(id: topic_id)
+    unless @signup_topic.nil?
+      confirmation_status = @signup_topic.signup_team_for_chosen_topic(team_id)
+    end
     # Log the signup topic save status
     ExpertizaLogger.info "The signup topic save status:#{confirmation_status} for assignment #{assignment_id} by #{user_id}"
     confirmation_status
-  end
-
-  # Confirm a topic for a user within a team for a specific assignment
-  def self.confirm_topic(user_id, team_id, topic_id, assignment_id)
-    # Fetch all topics for the user within the team for the assignment
-    user_signup = SignedUpTeam.find_user_signup_topics(assignment_id, team_id)
-    # Fetch users within the team and obtain team details
-    users_team = SignedUpTeam.find_team_users(assignment_id, user_id)
-    team = Team.find(users_team.first.t_id)
-
-    # Check if the topic is already signed up by the team, return false if exists
-    return false if SignedUpTeam.where(team_id: team.id, topic_id: topic_id).any?
-
-    # Create a new SignedUpTeam instance with the provided topic and team details
-    sign_up = SignedUpTeam.new(topic_id: topic_id, team_id: team_id)
-    result = false
-
-    if user_signup.empty?
-      # If there are no topics for the user within the team, proceed with signing up
-      ApplicationRecord.transaction do
-        # Create a signup_team entry for the team if the slot is available or waitlist it
-        team_id, topic_id = create_signup_team(assignment_id, sign_up, topic_id, user_id)
-        result = true if sign_up.save
-      end
-    else
-      # If the user is already signed up for a topic, then return false
-      return false unless user_signup.first&.is_waitlisted == true
-
-      #If the team has a waitlisted topic, then assign it to a 
-      ApplicationRecord.transaction do
-        result = signup_team_for_chosen_topic(assignment_id, sign_up, team_id, topic_id)
-      end
-    end
-
-    result # Return the result of the confirmation process
-  end
-
-  # Method to handle the process when a user signs up and is on the waitlist
-  def self.signup_team_for_chosen_topic(assignment_id, sign_up, team_id, topic_id)
-    if slot_available?(topic_id)
-      # Assign the topic to the team if a slot is available and drop off the team from all waitlists
-      assign_topic_to_team(sign_up, topic_id)
-      #Once assigned, drop all the waitlisted topics for this team
-      result = SignedUpTeam.drop_off_waitlists(team_id)
-    else
-      # Save the team as waitlisted if no slots are available
-      result = save_waitlist_entry(sign_up, team_id)
-    end
-    result
-  end
-
-  # Method to assign a topic to the team and update the waitlist status
-  def self.assign_topic_to_team(sign_up, topic_id)
-    # Set the team's waitlist status to false as they are assigned a topic
-    sign_up.update(is_waitlisted: false)
-    # Update the topic_id in the signed_up_teams table for the user
-    signed_up_team = SignedUpTeam.find_by(topic_id: topic_id)
-    signed_up_team.update(topic_id: topic_id) if signed_up_team
-  end
-
-  # Method to save the user as waitlisted if no slots are available
-  def self.save_waitlist_entry(sign_up, team_id)
-    sign_up.is_waitlisted = true
-    # Save the user's waitlist status
-    result = sign_up.save
-    # Log the creation of the sign-up sheet for the waitlisted user
-    ExpertizaLogger.info(LoggerMessage.new('SignUpSheet', '', "Sign up sheet created for waitlisted with teamId #{team_id}"))
-    result
-  end
-
-  def self.create_signup_team(assignment_id, sign_up, topic_id, user_id)
-    if slot_available?(topic_id)
-      sign_up.is_waitlisted = false
-      # Create new record in signed_up_teams table
-      team_id = TeamsUser.team_id(assignment_id, user_id)
-      topic_id = SignedUpTeam.topic_id(assignment_id, user_id)
-      SignedUpTeam.create(topic_id: topic_id, team_id: team_id, is_waitlisted: 0, preference_priority_number: nil)
-      ExpertizaLogger.info LoggerMessage.new('SignUpSheet', user_id, "Sign up sheet created with teamId #{team_id}")
-    else
-      sign_up.is_waitlisted = true
-    end
-    [team_id, topic_id]
-  end
-
-  # When using this method when creating fields, update race conditions by using db transactions
-  def self.slot_available?(topic_id)
-    SignUpTopic.slot_available?(topic_id)
   end
 
   def self.add_signup_topic(assignment_id)

--- a/app/models/sign_up_sheet.rb
+++ b/app/models/sign_up_sheet.rb
@@ -2,7 +2,7 @@ class SignUpSheet < ApplicationRecord
   # Team lazy initialization method [zhewei, 06/27/2015]
   def self.signup_team(assignment_id, user_id, topic_id = nil)
     # Find the team ID for the given assignment and user
-    team_id = SignedUpTeam.find_team_users(assignment_id, user_id)&.first&.t_id
+    team_id = Team.find_team_users(assignment_id, user_id)&.first&.t_id
     # If the team doesn't exist, create a new team and assign the team ID
     if team_id.nil?
       team = AssignmentTeam.create_team_with_users(assignment_id, [user_id])

--- a/app/models/sign_up_topic.rb
+++ b/app/models/sign_up_topic.rb
@@ -173,31 +173,20 @@ class SignUpTopic < ApplicationRecord
     return nil
   end
 
-  def reassign_topic(session_user_id, assignment_id, topic_id)
+  def reassign_topic(team_id)
      # reassigns topic when a delete operation is called
-
-      # if team assignment find the creator id from teamusers table and teams
-      # ACS Removed the if condition (and corresponding else) which differentiate assignments as team and individual assignments
-      # to treat all assignments as team assignments
-      # users_team will contain the team id of the team to which the user belongs
-      users_team = SignedUpTeam.find_team_users(assignment_id, session_user_id)
-
-      unless users_team.empty?
-        signup_record = SignedUpTeam.where(topic_id: topic_id, team_id:  users_team[0].t_id).first
-        # SignUpTeam instance
-        sign_up_team_object = SignedUpTeam.new
-        # if sinup records is a waitlisted
-        unless signup_record.try(:is_waitlisted)
-          # finds longest waiting team
-          longest_waiting_team_id  = longest_waiting_team(topic_id)
-          unless longest_waiting_team_id.nil?
-            # drops all waitlisted records
-            sign_up_team_object.drop_off_waitlists(longest_waiting_team_id)
-          end
-        end
-        # deletes the specific record
-        sign_up_team_object.drop_off_signup_record(topic_id, users_team[0].t_id)
+     signup_record = SignedUpTeam.where(topic_id: topic_id, team_id:  team_id).first
+     # if signup records is a waitlisted
+     unless signup_record.try(:is_waitlisted)
+      # finds longest waiting team
+      longest_waiting_team_id  = longest_waiting_team(topic_id)
+      unless longest_waiting_team_id.nil?
+        # drops all waitlisted records
+        SignedUpTeam.drop_off_waitlists(longest_waiting_team_id)
       end
+     end
+     # deletes the entry for the team which is previously assigned or waiting
+     SignedUpTeam.drop_off_signup_record(topic_id, team_id)
   end
 
   def reassign_topic_when_team_deleted(topic_id,team_id)
@@ -209,10 +198,10 @@ class SignUpTopic < ApplicationRecord
     longest_waiting_team_id  = longest_waiting_team(topic_id)
     unless longest_waiting_team_id.nil?
       # drops all waitlisted records
-      sign_up_team_object.drop_off_waitlists(longest_waiting_team_id)
+      SignedUpTeam.drop_off_waitlists(longest_waiting_team_id)
     end
     # deletes the specific record
-    sign_up_team_object.drop_off_signup_record(topic_id, team_id)
+    SignedUpTeam.drop_off_signup_record(topic_id, team_id)
   end
 
 end

--- a/app/models/sign_up_topic.rb
+++ b/app/models/sign_up_topic.rb
@@ -162,4 +162,47 @@ class SignUpTopic < ApplicationRecord
     SignedUpTeam.drop_off_signup_record(topic_id, team_id)
   end
 
+  # Method to handle the process when a user signs up
+  def signup_team_for_chosen_topic(team_id)
+    topic_id = self.id
+    team = Team.find(team_id)
+    # Fetch all topics for the user within the team for the assignment
+    user_signup = SignedUpTeam.find_user_signup_topics(team.parent_id, team_id)
+    # Check if the user is already signed up and waitlisted for the topic
+    if !user_signup.empty?
+      return false unless user_signup.first&.is_waitlisted == true
+    end
+    # Create a new SignedUpTeam instance with the provided topic and team details
+    sign_up = SignedUpTeam.new(topic_id: topic_id, team_id: team_id)
+    if SignUpTopic.slot_available?(topic_id)
+      # Assign the topic to the team if a slot is available and drop off the team from all waitlists
+      SignUpTopic.assign_topic_to_team(sign_up, topic_id)
+      # Once assigned, drop all the waitlisted topics for this team
+      result = SignedUpTeam.drop_off_waitlists(team_id)
+    else
+      # Save the team as waitlisted if no slots are available
+      result = SignUpTopic.save_waitlist_entry(sign_up, team_id)
+    end
+    result
+  end
+
+  # Method to assign a topic to the team and update the waitlist status
+  def self.assign_topic_to_team(sign_up, topic_id)
+    # Set the team's waitlist status to false as they are assigned a topic
+    sign_up.update(is_waitlisted: false)
+    # Update the topic_id in the signed_up_teams table for the user
+    signed_up_team = SignedUpTeam.find_by(topic_id: topic_id)
+    signed_up_team.update(topic_id: topic_id) if signed_up_team
+  end
+
+  # Method to save the user as waitlisted if no slots are available
+  def self.save_waitlist_entry(sign_up, team_id)
+    sign_up.is_waitlisted = true
+    # Save the user's waitlist status
+    result = sign_up.save
+    # Log the creation of the sign-up sheet for the waitlisted user
+    ExpertizaLogger.info(LoggerMessage.new('SignUpSheet', '', "Sign up sheet created for waitlisted with teamId #{team_id}"))
+    result
+  end
+
 end

--- a/app/models/sign_up_topic.rb
+++ b/app/models/sign_up_topic.rb
@@ -123,57 +123,43 @@ class SignUpTopic < ApplicationRecord
   end
 
   def longest_waiting_team(topic_id)
-    # the team that’s been waiting the longest for that topic
-    # find the first wait listed user if exists
+    # Find and return the team that has been waiting the longest for the specified topic.
+
+    # Find the first waitlisted user (team) for the given topic by querying the SignedUpTeam table.
+    # Check for records where the topic_id matches the specified topic_id and is_waitlisted is true.
     first_waitlisted_user = SignedUpTeam.where(topic_id: topic_id, is_waitlisted: true).first   
+    # If a waitlisted user (team) is found, return it as the team that has been waiting the longest.
     unless first_waitlisted_user.nil?
-      first_waitlisted_user.is_waitlisted = false
-      first_waitlisted_user.save
-      return first_waitlisted_user.team_id
+      return first_waitlisted_user
     end 
+    # If no waitlisted user is found, return nil to indicate that there are no teams waiting.
     return nil
   end
 
-  def reassign_topic(session_user_id, assignment_id, topic_id)
-     # reassigns topic when a delete operation is called
-
-      # if team assignment find the creator id from teamusers table and teams
-      # ACS Removed the if condition (and corresponding else) which differentiate assignments as team and individual assignments
-      # to treat all assignments as team assignments
-      # users_team will contain the team id of the team to which the user belongs
-      users_team = SignedUpTeam.find_team_users(assignment_id, session_user_id)
-
-      unless users_team.empty?
-        signup_record = SignedUpTeam.where(topic_id: topic_id, team_id:  users_team[0].t_id).first
-        # SignUpTeam instance
-        sign_up_team_object = SignedUpTeam.new
-        # if sinup records is a waitlisted
-        unless signup_record.try(:is_waitlisted)
-          # finds longest waiting team
-          longest_waiting_team_id  = longest_waiting_team(topic_id)
-          unless longest_waiting_team_id.nil?
-            # drops all waitlisted records
-            sign_up_team_object.drop_off_waitlists(longest_waiting_team_id)
-          end
-        end
-        # deletes the specific record
-        sign_up_team_object.drop_off_signup_record(topic_id, users_team[0].t_id)
-      end
-  end
-
-  def reassign_topic_when_team_deleted(topic_id,team_id)
+  def reassign_topic(team_id)
+    # Reassigns topic when a team is dropped from a topic.
+    # Get the topic ID for reassignment.
+    topic_id = self.id
+    # Fetch the record in SignedUpTeam where topic_id matches the topic that needs reassignment
+    # and team_id matches the provided team_id. Retrieve the first matching record.
     signup_record = SignedUpTeam.where(topic_id: topic_id, team_id:  team_id).first
-    # SignUpTeam instance
-    sign_up_team_object = SignedUpTeam.new
-    # if signup records is a waitlisted
-    # finds longest waiting team
-    longest_waiting_team_id  = longest_waiting_team(topic_id)
-    unless longest_waiting_team_id.nil?
-      # drops all waitlisted records
-      sign_up_team_object.drop_off_waitlists(longest_waiting_team_id)
+    # If the signup record is not marked as waitlisted (is_waitlisted is either false or nil),
+    # proceed with reassignment.
+    unless signup_record.try(:is_waitlisted)
+      # Find the longest waiting team for the same topic.
+      longest_waiting_team  = longest_waiting_team(topic_id)
+      # If a longest waiting team is found, proceed with reassignment.
+      unless longest_waiting_team.nil?
+        # Assign the topic to the longest waiting team.
+        # Update the is_waitlisted boolean to false for the longest waiting team.
+        longest_waiting_team.is_waitlisted = false
+        longest_waiting_team.save
+        # Drop all waitlisted records for that team.
+        SignedUpTeam.drop_off_waitlists(longest_waiting_team.team_id)
+      end
     end
-    # deletes the specific record
-    sign_up_team_object.drop_off_signup_record(topic_id, team_id)
+    # Delete the entry for the team that was either previously assigned or waiting.
+    SignedUpTeam.drop_off_signup_record(topic_id, team_id)
   end
 
 end

--- a/app/models/sign_up_topic.rb
+++ b/app/models/sign_up_topic.rb
@@ -51,19 +51,24 @@ class SignUpTopic < ApplicationRecord
   end
 
   def self.slot_available?(topic_id)
+    # Retrieve the SignUpTopic record based on the given topic_id
     topic = SignUpTopic.find(topic_id)
+    
+    # Find the number of students who have selected the topic and are not waitlisted
     no_of_students_who_selected_the_topic = SignedUpTeam.where(topic_id: topic_id, is_waitlisted: false)
-
+  
+    # Check if no students have selected the topic yet
     if no_of_students_who_selected_the_topic.nil?
       return true
     else
+      # Check if the number of students who selected the topic is less than the maximum allowed
       if topic.max_choosers > no_of_students_who_selected_the_topic.size
-        return true
+        return true # There are available slots for this topic
       else
-        return false
+        return false # All slots for this topic are filled
       end
     end
-  end
+  end  
 
   def self.assign_to_first_waiting_team(next_wait_listed_team)
     team_id = next_wait_listed_team.team_id

--- a/app/models/sign_up_topic.rb
+++ b/app/models/sign_up_topic.rb
@@ -166,42 +166,31 @@ class SignUpTopic < ApplicationRecord
     # find the first wait listed user if exists
     first_waitlisted_user = SignedUpTeam.where(topic_id: topic_id, is_waitlisted: true).first   
     unless first_waitlisted_user.nil?
-      first_waitlisted_user.is_waitlisted = false
-      first_waitlisted_user.save
-      return first_waitlisted_user.team_id
+      return first_waitlisted_user
     end 
     return nil
   end
 
   def reassign_topic(team_id)
-     # reassigns topic when a delete operation is called
-     signup_record = SignedUpTeam.where(topic_id: topic_id, team_id:  team_id).first
-     # if signup records is a waitlisted
-     unless signup_record.try(:is_waitlisted)
-      # finds longest waiting team
-      longest_waiting_team_id  = longest_waiting_team(topic_id)
-      unless longest_waiting_team_id.nil?
-        # drops all waitlisted records
-        SignedUpTeam.drop_off_waitlists(longest_waiting_team_id)
+     # reassigns topic when a team is deleted from a topic
+      topic_id = self.id
+      # fetching record in SignedUpTeam
+      signup_record = SignedUpTeam.where(topic_id: topic_id, team_id:  team_id).first
+      # if signup records is a waitlisted
+      unless signup_record.try(:is_waitlisted)
+       # finds longest waiting team
+       longest_waiting_team  = longest_waiting_team(topic_id)
+       unless longest_waiting_team.nil?
+         # assigning topic to longest waiting team
+         # updating is_waitlisted boolean to false for longest waiting team
+         longest_waiting_team.is_waitlisted = false
+         longest_waiting_team.save
+         # drop all waitlisted records for that team
+         SignedUpTeam.drop_off_waitlists(longest_waiting_team.team_id)
+       end
       end
-     end
-     # deletes the entry for the team which is previously assigned or waiting
-     SignedUpTeam.drop_off_signup_record(topic_id, team_id)
-  end
-
-  def reassign_topic_when_team_deleted(topic_id,team_id)
-    signup_record = SignedUpTeam.where(topic_id: topic_id, team_id:  team_id).first
-    # SignUpTeam instance
-    sign_up_team_object = SignedUpTeam.new
-    # if signup records is a waitlisted
-    # finds longest waiting team
-    longest_waiting_team_id  = longest_waiting_team(topic_id)
-    unless longest_waiting_team_id.nil?
-      # drops all waitlisted records
-      SignedUpTeam.drop_off_waitlists(longest_waiting_team_id)
-    end
-    # deletes the specific record
-    SignedUpTeam.drop_off_signup_record(topic_id, team_id)
+      # deletes the entry for the team which is previously assigned or waiting
+      SignedUpTeam.drop_off_signup_record(topic_id, team_id)
   end
 
 end

--- a/app/models/sign_up_topic.rb
+++ b/app/models/sign_up_topic.rb
@@ -65,44 +65,44 @@ class SignUpTopic < ApplicationRecord
     end
   end
 
-  def self.reassign_topic(session_user_id, assignment_id, topic_id)
-    # find whether assignment is team assignment
-    assignment = Assignment.find(assignment_id)
+  # def self.reassign_topic(session_user_id, assignment_id, topic_id)
+  #   # find whether assignment is team assignment
+  #   assignment = Assignment.find(assignment_id)
 
-    # making sure that the drop date deadline hasn't passed
-    dropDate = AssignmentDueDate.where(parent_id: assignment.id, deadline_type_id: '6').first
-    if dropDate.nil? || dropDate.due_at >= Time.now
-      # if team assignment find the creator id from teamusers table and teams
-      # ACS Removed the if condition (and corresponding else) which differentiate assignments as team and individual assignments
-      # to treat all assignments as team assignments
-      # users_team will contain the team id of the team to which the user belongs
-      users_team = SignedUpTeam.find_team_users(assignment_id, session_user_id)
-      signup_record = SignedUpTeam.where(topic_id: topic_id, team_id:  users_team[0].t_id).first
-      assignment = Assignment.find(assignment_id)
-      # if a confirmed slot is deleted then push the first waiting list member to confirmed slot if someone is on the waitlist
-      unless assignment.is_intelligent?
-        unless signup_record.try(:is_waitlisted)
-          # find the first wait listed user if exists
-          first_waitlisted_user = SignedUpTeam.where(topic_id: topic_id, is_waitlisted: true).first
+  #   # making sure that the drop date deadline hasn't passed
+  #   dropDate = AssignmentDueDate.where(parent_id: assignment.id, deadline_type_id: '6').first
+  #   if dropDate.nil? || dropDate.due_at >= Time.now
+  #     # if team assignment find the creator id from teamusers table and teams
+  #     # ACS Removed the if condition (and corresponding else) which differentiate assignments as team and individual assignments
+  #     # to treat all assignments as team assignments
+  #     # users_team will contain the team id of the team to which the user belongs
+  #     users_team = SignedUpTeam.find_team_users(assignment_id, session_user_id)
+  #     signup_record = SignedUpTeam.where(topic_id: topic_id, team_id:  users_team[0].t_id).first
+  #     assignment = Assignment.find(assignment_id)
+  #     # if a confirmed slot is deleted then push the first waiting list member to confirmed slot if someone is on the waitlist
+  #     unless assignment.is_intelligent?
+  #       unless signup_record.try(:is_waitlisted)
+  #         # find the first wait listed user if exists
+  #         first_waitlisted_user = SignedUpTeam.where(topic_id: topic_id, is_waitlisted: true).first
 
-          unless first_waitlisted_user.nil?
-            # As this user is going to be allocated a confirmed topic, all of his waitlisted topic signups should be purged
-            ### Bad policy!  Should be changed! (once users are allowed to specify waitlist priorities) -efg
-            first_waitlisted_user.is_waitlisted = false
-            first_waitlisted_user.save
+  #         unless first_waitlisted_user.nil?
+  #           # As this user is going to be allocated a confirmed topic, all of his waitlisted topic signups should be purged
+  #           ### Bad policy!  Should be changed! (once users are allowed to specify waitlist priorities) -efg
+  #           first_waitlisted_user.is_waitlisted = false
+  #           first_waitlisted_user.save
 
-            # ACS Removed the if condition (and corresponding else) which differentiate assignments as team and individual assignments
-            # to treat all assignments as team assignments
-            Waitlist.cancel_all_waitlists(first_waitlisted_user.team_id, assignment_id)
-          end
-        end
-      end
-      signup_record.destroy unless signup_record.nil?
-      ExpertizaLogger.info LoggerMessage.new('SignUpTopic', session_user_id, "Topic dropped: #{topic_id}")
-    else
-      # flash[:error] = "You cannot drop this topic because the drop deadline has passed."
-    end # end condition for 'drop deadline' check
-  end
+  #           # ACS Removed the if condition (and corresponding else) which differentiate assignments as team and individual assignments
+  #           # to treat all assignments as team assignments
+  #           Waitlist.cancel_all_waitlists(first_waitlisted_user.team_id, assignment_id)
+  #         end
+  #       end
+  #     end
+  #     signup_record.destroy unless signup_record.nil?
+  #     ExpertizaLogger.info LoggerMessage.new('SignUpTopic', session_user_id, "Topic dropped: #{topic_id}")
+  #   else
+  #     # flash[:error] = "You cannot drop this topic because the drop deadline has passed."
+  #   end # end condition for 'drop deadline' check
+  # end
 
   def self.assign_to_first_waiting_team(next_wait_listed_team)
     team_id = next_wait_listed_team.team_id
@@ -160,4 +160,42 @@ class SignUpTopic < ApplicationRecord
       return 'failed'
     end
   end
+
+  def longest_waiting_team(topic_id)
+    # the team that’s been waiting the longest for that topic
+    # find the first wait listed user if exists
+    first_waitlisted_user = SignedUpTeam.where(topic_id: topic_id, is_waitlisted: true).first   
+    unless first_waitlisted_user.nil?
+      first_waitlisted_user.is_waitlisted = false
+      first_waitlisted_user.save
+      return first_waitlisted_user.team_id
+    end 
+    return nil
+  end
+
+  def reassign_topic(session_user_id, assignment_id, topic_id)
+    # reassigns topic when a delete operation is called
+
+    # if team assignment find the creator id from teamusers table and teams
+    # ACS Removed the if condition (and corresponding else) which differentiate assignments as team and individual assignments
+    # to treat all assignments as team assignments
+    # users_team will contain the team id of the team to which the user belongs
+    users_team = SignedUpTeam.find_team_users(assignment_id, session_user_id)
+    signup_record = SignedUpTeam.where(topic_id: topic_id, team_id:  users_team[0].t_id).first
+
+    # SignUpTeam instance
+    sign_up_team_object = SignedUpTeam.new
+    # if sinup records is a waitlisted
+    unless signup_record.try(:is_waitlisted)
+      # finds longest waiting team
+      longest_waiting_team_id  = longest_waiting_team(topic_id)
+      unless longest_waiting_team_id.nil?
+        # drops all waitlisted records
+        sign_up_team_object.drop_all_waitlists(longest_waiting_team_id)
+      end
+    end
+    # deletes the specific record
+    sign_up_team_object.drop_signup_record(topic_id, users_team[0].t_id)
+  end
+
 end

--- a/app/models/sign_up_topic.rb
+++ b/app/models/sign_up_topic.rb
@@ -50,7 +50,7 @@ class SignUpTopic < ApplicationRecord
     SignedUpTeam.find_by_sql(['SELECT u.id FROM sign_up_topics t, signed_up_teams u WHERE t.id = u.topic_id and u.is_waitlisted = true and t.assignment_id = ? and u.team_id = ?', assignment_id.to_s, team_id.to_s])
   end
 
-  def self.slotAvailable?(topic_id)
+  def self.slot_available?(topic_id)
     topic = SignUpTopic.find(topic_id)
     no_of_students_who_selected_the_topic = SignedUpTeam.where(topic_id: topic_id, is_waitlisted: false)
 

--- a/app/models/signed_up_team.rb
+++ b/app/models/signed_up_team.rb
@@ -83,7 +83,7 @@ class SignedUpTeam < ApplicationRecord
   end
 
   # Remove a specific signed_up_teams record for a given topic and team.
-  def self.drop_off_signup_record(topic_id,team_id)
+  def self.drop_signup_record(topic_id,team_id)
     # Fetching record for a given topic and team.
     signup_record = SignedUpTeam.find_by(topic_id: topic_id, team_id: team_id)
     # If the signup_record in not nil destroy it.

--- a/app/models/signed_up_team.rb
+++ b/app/models/signed_up_team.rb
@@ -82,12 +82,12 @@ class SignedUpTeam < ApplicationRecord
     end
   end
 
-  def drop_signup_record(topic_id,team_id)
+  def drop_off_signup_record(topic_id,team_id)
     signup_record = SignedUpTeam.find_by(topic_id: topic_id, team_id: team_id)
     signup_record.destroy unless signup_record.nil?
   end
 
-  def drop_all_waitlists(team_id)
+  def drop_off_waitlists(team_id)
     SignedUpTeam.where(team_id: team_id, is_waitlisted: true).destroy_all
   end
 end

--- a/app/models/signed_up_team.rb
+++ b/app/models/signed_up_team.rb
@@ -81,4 +81,13 @@ class SignedUpTeam < ApplicationRecord
       signed_up_teams.first.topic_id
     end
   end
+
+  def drop_signup_record(topic_id,team_id)
+    signup_record = SignedUpTeam.find_by(topic_id: topic_id, team_id: team_id)
+    signup_record.destroy unless signup_record.nil?
+  end
+
+  def drop_all_waitlists(team_id)
+    SignedUpTeam.where(team_id: team_id, is_waitlisted: true).destroy_all
+  end
 end

--- a/app/models/signed_up_team.rb
+++ b/app/models/signed_up_team.rb
@@ -82,12 +82,13 @@ class SignedUpTeam < ApplicationRecord
     end
   end
 
-  def drop_off_signup_record(topic_id,team_id)
+  def self.drop_off_signup_record(topic_id,team_id)
     signup_record = SignedUpTeam.find_by(topic_id: topic_id, team_id: team_id)
     signup_record.destroy unless signup_record.nil?
   end
 
-  def drop_off_waitlists(team_id)
+  def self.drop_off_waitlists(team_id)
     SignedUpTeam.where(team_id: team_id, is_waitlisted: true).destroy_all
   end
+
 end

--- a/app/models/signed_up_team.rb
+++ b/app/models/signed_up_team.rb
@@ -82,12 +82,18 @@ class SignedUpTeam < ApplicationRecord
     end
   end
 
+  # Remove a specific signed_up_teams record for a given topic and team.
   def self.drop_off_signup_record(topic_id,team_id)
+    # Fetching record for a given topic and team.
     signup_record = SignedUpTeam.find_by(topic_id: topic_id, team_id: team_id)
+    # If the signup_record in not nil destroy it.
     signup_record.destroy unless signup_record.nil?
   end
 
+  # Remove all waitlisted records in signed_up_teams associated with a specific team.
   def self.drop_off_waitlists(team_id)
+    # Fetch all records that matches the given team_id with is_waitlisted as true
+    # and destroy all the records.
     SignedUpTeam.where(team_id: team_id, is_waitlisted: true).destroy_all
   end
 

--- a/app/models/signed_up_team.rb
+++ b/app/models/signed_up_team.rb
@@ -6,38 +6,6 @@ class SignedUpTeam < ApplicationRecord
   validates :topic_id, :team_id, presence: true
   scope :by_team_id, ->(team_id) { where('team_id = ?', team_id) }
 
-  def self.find_team_participants(assignment_id, ip_address = nil)
-    @participants = SignedUpTeam.joins('INNER JOIN sign_up_topics ON signed_up_teams.topic_id = sign_up_topics.id')
-                                .select('signed_up_teams.id as id, sign_up_topics.id as topic_id, sign_up_topics.topic_name as name,
-                                  sign_up_topics.topic_name as team_name_placeholder, sign_up_topics.topic_name as user_name_placeholder,
-                                  signed_up_teams.is_waitlisted as is_waitlisted, signed_up_teams.team_id as team_id')
-                                .where('sign_up_topics.assignment_id = ?', assignment_id)
-    @participants.each_with_index do |participant, i|
-      participant_names = User.joins('INNER JOIN teams_users ON users.id = teams_users.user_id')
-                              .joins('INNER JOIN teams ON teams.id = teams_users.team_id')
-                              .select('users.name as u_name, teams.name as team_name')
-                              .where('teams.id = ?', participant.team_id)
-
-      team_name_added = false
-      names = '(missing team)'
-
-      participant_names.each do |participant_name|
-        if team_name_added
-          names += User.find_by(name: participant_name.u_name).name(ip_address) + ' '
-          participant.user_name_placeholder += User.find_by(name: participant_name.u_name).name(ip_address) + ' '
-        else
-          names = '[' + participant_name.team_name + '] ' + User.find_by(name: participant_name.u_name).name(ip_address) + ' '
-          participant.team_name_placeholder = participant_name.team_name
-          participant.user_name_placeholder = User.find_by(name: participant_name.u_name).name(ip_address) + ' '
-          team_name_added = true
-        end
-      end
-      @participants[i].name = names
-    end
-
-    @participants
-  end
-
   def self.find_team_users(assignment_id, user_id)
     TeamsUser.joins('INNER JOIN teams ON teams_users.team_id = teams.id')
              .select('teams.id as t_id')

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -307,4 +307,10 @@ class Team < ApplicationRecord
       nil
     end
   end
+
+  def self.find_team_users(assignment_id, user_id)
+    TeamsUser.joins('INNER JOIN teams ON teams_users.team_id = teams.id')
+             .select('teams.id as t_id')
+             .where('teams.parent_id = ? and teams_users.user_id = ?', assignment_id, user_id)
+  end
 end

--- a/app/views/sign_up_sheet/_add_signup_topics.html.erb
+++ b/app/views/sign_up_sheet/_add_signup_topics.html.erb
@@ -6,7 +6,6 @@
 <% @sign_up_topics = SignUpTopic.where(['assignment_id = ?', @assignment.id]) %>
 <% @slots_filled = SignUpTopic.find_slots_filled(@assignment.id)  %>
 <% @slots_waitlisted = SignUpTopic.find_slots_waitlisted(@assignment.id) %>
-<% @participants = SignedUpTeam.find_team_participants(@assignment.id, session[:ip])  %>
 
 <a id="teamsAndMembers" onclick="showHideTeamAndMembers(<%= @sign_up_topics.size%>)">Hide all teams</a>
 <% unless @sign_up_topics.size.zero? %>

--- a/app/views/sign_up_sheet/_add_signup_topics.html.erb
+++ b/app/views/sign_up_sheet/_add_signup_topics.html.erb
@@ -6,6 +6,7 @@
 <% @sign_up_topics = SignUpTopic.where(['assignment_id = ?', @assignment.id]) %>
 <% @slots_filled = SignUpTopic.find_slots_filled(@assignment.id)  %>
 <% @slots_waitlisted = SignUpTopic.find_slots_waitlisted(@assignment.id) %>
+<% @participants = SignedUpTeam.find_team_participants(@assignment.id, session[:ip]) %>
 
 <a id="teamsAndMembers" onclick="showHideTeamAndMembers(<%= @sign_up_topics.size%>)">Hide all teams</a>
 <% unless @sign_up_topics.size.zero? %>

--- a/app/views/sign_up_sheet/_add_signup_topics_staggered.html.erb
+++ b/app/views/sign_up_sheet/_add_signup_topics_staggered.html.erb
@@ -2,6 +2,7 @@
 <% @sign_up_topics = SignUpTopic.where(['assignment_id = ?', @assignment.id]) %>
 <% @slots_filled = SignUpTopic.find_slots_filled(@assignment.id)  %>
 <% @slots_waitlisted = SignUpTopic.find_slots_waitlisted(@assignment.id) %>
+<% @participants = SignedUpTeam.find_team_participants(@assignment.id, session[:ip]) %>
 <!--Zhewei: the reason why we(E1524) put an empty form_tag is because these reasons:-->
 <!--1.Now we decide to remove the 'Edit sign up sheet' icon on assignment pop up dialog and merge these content into assignment->edit->topics panel-->
 <!--2.The assignment edit panel itself is a big form, and we have one smaller form to save staggered deadlines. And rails is not support one form inside another form very well-->

--- a/app/views/sign_up_sheet/_add_signup_topics_staggered.html.erb
+++ b/app/views/sign_up_sheet/_add_signup_topics_staggered.html.erb
@@ -2,7 +2,6 @@
 <% @sign_up_topics = SignUpTopic.where(['assignment_id = ?', @assignment.id]) %>
 <% @slots_filled = SignUpTopic.find_slots_filled(@assignment.id)  %>
 <% @slots_waitlisted = SignUpTopic.find_slots_waitlisted(@assignment.id) %>
-<% @participants = SignedUpTeam.find_team_participants(@assignment.id, session[:ip])  %>
 <!--Zhewei: the reason why we(E1524) put an empty form_tag is because these reasons:-->
 <!--1.Now we decide to remove the 'Edit sign up sheet' icon on assignment pop up dialog and merge these content into assignment->edit->topics panel-->
 <!--2.The assignment edit panel itself is a big form, and we have one smaller form to save staggered deadlines. And rails is not support one form inside another form very well-->

--- a/app/views/sign_up_sheet/signup_as_instructor.html.erb
+++ b/app/views/sign_up_sheet/signup_as_instructor.html.erb
@@ -1,5 +1,5 @@
 <%= form_tag(:controller => "sign_up_sheet", :action => "signup_as_instructor_action",:topic_id => params[:topic_id], :assignment_id => params[:assignment_id]) do %>
-    <%= label_tag(:username, "Sign Up User:") %>
+    <%= label_tag(:username, "Sign up this user’s team:") %>
     <%= text_field_tag(:username) %>
     <%= hidden_field_tag "topic_id", params[:topic_id] %>
     <%= hidden_field_tag "assignment_id", params[:assignment_id] %>

--- a/app/views/student_task/list.html.erb
+++ b/app/views/student_task/list.html.erb
@@ -21,7 +21,7 @@
           #ACS Get the topics selected by all teams
           #removed code that handles team and individual assignments differently
           # get the user's team and check if they have signed up for a topic yet
-          users_team = SignedUpTeam.find_team_users(participant.assignment.id,participant.user.id)
+          users_team = Team.find_team_users(participant.assignment.id,participant.user.id)
           if users_team.size > 0
             selected_topics = SignedUpTeam.find_user_signup_topics(participant.assignment.id,users_team[0].t_id)
           end

--- a/spec/controllers/sign_up_sheet_controller_spec.rb
+++ b/spec/controllers/sign_up_sheet_controller_spec.rb
@@ -784,33 +784,27 @@ describe SignUpSheetController do
   end
 
   describe '#delete_signup_for_topic' do
-    context 'when the SignUpTopic record exists' do
-      let(:signup_record) { create(:signed_up_team, team: team, topic: topic) }
+    let!(:topic) { create(:topic, id: 30, assignment_id: 30, topic_identifier: 'E1740') }
+    let(:topic_id) { 1 }
+    let(:team_id) { 1 }
+    let(:sign_up_topic) { instance_double('SignUpTopic') }
 
-      before do
-        allow(SignUpTopic).to receive(:find_by).with(id: topic_id).and_return(topic)
-        allow(topic).to receive(:reassign_topic).with(team_id).and_return(true)
-      end
+    before do
+      allow(SignUpTopic).to receive(:find_by).with(id: topic_id).and_return(sign_up_topic)
+    end
 
-      it 'reassigns the topic for the specified team' do
-        expect(topic).to receive(:reassign_topic).with(team_id).once
-        post :delete_signup_for_topic, params: { topic_id: topic_id, team_id: team_id }
-        expect(response).to redirect_to(sign_up_sheet_list_path(assignment.id))
+    context 'when the topic exists' do
+      it 'calls reassign_topic on the found SignUpTopic instance' do
+        expect(sign_up_topic).to receive(:reassign_topic).with(team_id)
+        controller.send(:delete_signup_for_topic, topic_id, team_id)
       end
     end
 
-    context 'when the SignUpTopic record does not exist' do
-      let(:invalid_topic_id) { 999 } # Assuming 999 is not a valid topic_id
-
-      before do
-        allow(SignUpTopic).to receive(:find_by).with(id: invalid_topic_id).and_return(nil)
-      end
-
-      it 'does not raise an error' do
-        expect {
-          post :delete_signup_for_topic, params: { topic_id: invalid_topic_id, team_id: team_id }
-        }.not_to raise_error
-        expect(response).to redirect_to(sign_up_sheet_list_path(assignment.id))
+    context 'when the topic does not exist' do
+      it 'does not call reassign_topic' do
+        allow(SignUpTopic).to receive(:find_by).with(id: topic_id).and_return(nil)
+        expect(sign_up_topic).not_to receive(:reassign_topic)
+        controller.send(:delete_signup_for_topic, topic_id, team_id)
       end
     end
   end

--- a/spec/controllers/sign_up_sheet_controller_spec.rb
+++ b/spec/controllers/sign_up_sheet_controller_spec.rb
@@ -501,15 +501,19 @@ describe SignUpSheetController do
   end
 
   describe '#sign_up' do
-    context 'when SignUpSheet.signup_team method return nil' do
-      it 'shows an error flash message and redirects to sign_up_sheet#list page' do
-        allow(Team).to receive(:find_team_users).with(1, 6).and_return([team])
-        request_params = { id: 1 }
-        user_session = { user: instructor }
-        get :sign_up, params: request_params, session: user_session
-        expect(flash[:error]).to eq('You\'ve already signed up for a topic!')
-        expect(response).to redirect_to('/sign_up_sheet/list?id=1')
-      end
+   context 'when SignUpSheet.signup_team method returns nil' do
+     it 'shows an error flash message and redirects to sign_up_sheet#list page' do
+       allow(Team).to receive(:find_team_users).with(1, 6).and_return([team])
+       request_params = { id: 1 }
+       user_session = { user: instructor }
+       
+       # Stub the method call to return nil
+       allow(SignUpSheet).to receive(:signup_team).and_return(nil)
+       
+       get :sign_up, params: request_params, session: user_session
+       expect(flash[:error]).to eq('You\'ve already signed up for a topic!')
+       expect(response).to redirect_to('/sign_up_sheet/list?id=1')
+     end
     end
   end
 
@@ -543,6 +547,7 @@ describe SignUpSheetController do
             allow(team).to receive(:t_id).and_return(1)
             allow(TeamsUser).to receive(:team_id).with('1', 8).and_return(1)
             allow(SignedUpTeam).to receive(:topic_id).with('1', 8).and_return(1)
+            allow(SignUpSheet).to receive(:signup_team).and_return(true)
             allow_any_instance_of(SignedUpTeam).to receive(:save).and_return(team)
             request_params = {
               username: 'no name',

--- a/spec/controllers/sign_up_sheet_controller_spec.rb
+++ b/spec/controllers/sign_up_sheet_controller_spec.rb
@@ -782,4 +782,37 @@ describe SignUpSheetController do
       expect(response).to redirect_to('/sign_up_sheet/list?id=1')
     end
   end
+
+  describe '#delete_signup_for_topic' do
+    context 'when the SignUpTopic record exists' do
+      let(:signup_record) { create(:signed_up_team, team: team, topic: topic) }
+
+      before do
+        allow(SignUpTopic).to receive(:find_by).with(id: topic_id).and_return(topic)
+        allow(topic).to receive(:reassign_topic).with(team_id).and_return(true)
+      end
+
+      it 'reassigns the topic for the specified team' do
+        expect(topic).to receive(:reassign_topic).with(team_id).once
+        post :delete_signup_for_topic, params: { topic_id: topic_id, team_id: team_id }
+        expect(response).to redirect_to(sign_up_sheet_list_path(assignment.id))
+      end
+    end
+
+    context 'when the SignUpTopic record does not exist' do
+      let(:invalid_topic_id) { 999 } # Assuming 999 is not a valid topic_id
+
+      before do
+        allow(SignUpTopic).to receive(:find_by).with(id: invalid_topic_id).and_return(nil)
+      end
+
+      it 'does not raise an error' do
+        expect {
+          post :delete_signup_for_topic, params: { topic_id: invalid_topic_id, team_id: team_id }
+        }.not_to raise_error
+        expect(response).to redirect_to(sign_up_sheet_list_path(assignment.id))
+      end
+    end
+  end
+
 end

--- a/spec/controllers/sign_up_sheet_controller_spec.rb
+++ b/spec/controllers/sign_up_sheet_controller_spec.rb
@@ -503,7 +503,7 @@ describe SignUpSheetController do
   describe '#sign_up' do
     context 'when SignUpSheet.signup_team method return nil' do
       it 'shows an error flash message and redirects to sign_up_sheet#list page' do
-        allow(SignedUpTeam).to receive(:find_team_users).with(1, 6).and_return([team])
+        allow(Team).to receive(:find_team_users).with(1, 6).and_return([team])
         request_params = { id: 1 }
         user_session = { user: instructor }
         get :sign_up, params: request_params, session: user_session
@@ -538,7 +538,7 @@ describe SignUpSheetController do
 
         context 'when creating team related objects successfully' do
           it 'shows a flash success message and redirects to assignment#edit page' do
-            allow(SignedUpTeam).to receive(:find_team_users).with('1', 8).and_return([team])
+            allow(Team).to receive(:find_team_users).with('1', 8).and_return([team])
             allow(Team).to receive(:find).and_return(team)
             allow(team).to receive(:t_id).and_return(1)
             allow(TeamsUser).to receive(:team_id).with('1', 8).and_return(1)
@@ -557,7 +557,7 @@ describe SignUpSheetController do
 
         context 'when creating team related objects unsuccessfully' do
           it 'shows a flash error message and redirects to assignment#edit page' do
-            allow(SignedUpTeam).to receive(:find_team_users).with('1', 8).and_return([])
+            allow(Team).to receive(:find_team_users).with('1', 8).and_return([])
             allow(User).to receive(:find).with(8).and_return(student)
             allow(Assignment).to receive(:find).with(1).and_return(assignment)
             allow(TeamsUser).to receive(:create).with(user_id: 8, team_id: 1).and_return(double('TeamsUser', id: 1))
@@ -623,7 +623,7 @@ describe SignUpSheetController do
       it 'shows a flash success message and redirects to sign_up_sheet#list page' do
         allow(team).to receive(:submitted_files).and_return([])
         allow(team).to receive(:hyperlinks).and_return([])
-        allow(SignedUpTeam).to receive(:find_team_users).with(1, 6).and_return([team])
+        allow(Team).to receive(:find_team_users).with(1, 6).and_return([team])
         allow(team).to receive(:t_id).and_return(1)
         request_params = { id: 1, topic_id: 1 }
         user_session = { user: instructor }
@@ -678,7 +678,7 @@ describe SignUpSheetController do
       it 'shows a flash success message and redirects to assignment#edit page' do
         allow(team).to receive(:submitted_files).and_return([])
         allow(team).to receive(:hyperlinks).and_return([])
-        allow(SignedUpTeam).to receive(:find_team_users).with(1, 6).and_return([team])
+        allow(Team).to receive(:find_team_users).with(1, 6).and_return([team])
         allow(team).to receive(:t_id).and_return(1)
         request_params = { id: 1, topic_id: 1 }
         user_session = { user: instructor }

--- a/spec/models/airbrake_expection_errors_unit_tests_spec.rb
+++ b/spec/models/airbrake_expection_errors_unit_tests_spec.rb
@@ -78,8 +78,8 @@ describe 'Airbrake-1766248124300920137' do
   before(:each) do
     allow(Assignment).to receive(:find) {}
     allow(Assignment).to receive(:find).with(1).and_return(build(:assignment))
-    allow(SignedUpTeam).to receive(:find_team_users) {}
-    allow(SignedUpTeam).to receive(:find_team_users).with(1, 1).and_return([double('TeamsUser', t_id: 1)])
+    allow(Team).to receive(:find_team_users) {}
+    allow(Team).to receive(:find_team_users).with(1, 1).and_return([double('TeamsUser', t_id: 1)])
     # users_team = [double("TeamsUser", t_id: 1)]
     # allow(TeamsUser).to receive(:find_by_sql).and_return([double("TeamsUser", t_id: 1)])
     # allow(users_team[0]).to receive(:t_id).and_return(1)

--- a/spec/models/airbrake_expection_errors_unit_tests_spec.rb
+++ b/spec/models/airbrake_expection_errors_unit_tests_spec.rb
@@ -73,27 +73,3 @@ describe 'Aribrake-1805332790232222219' do
     expect(rc.send(:set_dropdown_or_scale)).to eq('scale')
   end
 end
-
-describe 'Airbrake-1766248124300920137' do
-  before(:each) do
-    allow(Assignment).to receive(:find) {}
-    allow(Assignment).to receive(:find).with(1).and_return(build(:assignment))
-    allow(Team).to receive(:find_team_users) {}
-    allow(Team).to receive(:find_team_users).with(1, 1).and_return([double('TeamsUser', t_id: 1)])
-    # users_team = [double("TeamsUser", t_id: 1)]
-    # allow(TeamsUser).to receive(:find_by_sql).and_return([double("TeamsUser", t_id: 1)])
-    # allow(users_team[0]).to receive(:t_id).and_return(1)
-  end
-
-  it 'can reassign topic successfully, if the signup record is not nil' do
-    allow(SignedUpTeam).to receive_message_chain(:where, :first) {}
-    allow(SignedUpTeam).to receive_message_chain(:where, :first).with(1, 1).and_return([build(:signed_up_team)])
-    expect(SignUpTopic.reassign_topic(1, 1, 1)).to eq(true)
-  end
-
-  it 'can reassign topic successfully, if the signup record is nil' do
-    allow(SignedUpTeam).to receive_message_chain(:where, :first) {}
-    allow(SignedUpTeam).to receive_message_chain(:where, :first).with(1, 1).and_return(nil)
-    expect(SignUpTopic.reassign_topic(1, 1, 1)).to eq(true)
-  end
-end

--- a/spec/models/sign_up_sheet_spec.rb
+++ b/spec/models/sign_up_sheet_spec.rb
@@ -60,7 +60,7 @@ end
 
 describe '.confirm_topic' do
   before(:each) do
-    allow(SignedUpTeam).to receive(:find_team_users).and_return([TeamsUser.new])
+    allow(Team).to receive(:find_team_users).and_return([TeamsUser.new])
     allow_any_instance_of(TeamsUser).to receive(:t_id).and_return(1)
     allow(Team).to receive(:find).and_return(Team.new)
   end  

--- a/spec/models/sign_up_sheet_spec.rb
+++ b/spec/models/sign_up_sheet_spec.rb
@@ -58,49 +58,6 @@ describe SignUpSheet do
   end
 end
 
-describe '.confirm_topic' do
-  before(:each) do
-    allow(Team).to receive(:find_team_users).and_return([TeamsUser.new])
-    allow_any_instance_of(TeamsUser).to receive(:t_id).and_return(1)
-    allow(Team).to receive(:find).and_return(Team.new)
-  end  
-  it 'create SignedUpTeam' do
-    allow(SignUpTopic).to receive(:slot_available?) { true }
-    expect(SignUpSheet.confirmTopic(nil, nil, nil, nil)).to be(false)
-  end
-
-  it 'sign_up.is_waitlisted is equal to true' do
-    allow(SignUpTopic).to receive(:slot_available?) { false }
-    expect(SignUpSheet.confirmTopic(nil, nil, nil, nil)).to be(false)
-  end
-
-  it 'returns false if user_signup_topic.is_waitlisted == false' do
-    user_signup = SignedUpTeam.new
-    user_signup.is_waitlisted = false
-    allow(SignUpSheet).to receive(:otherConfirmedTopicforUser) { [user_signup] }
-    expect(SignUpSheet.confirmTopic(nil, nil, nil, nil)).to be(false)
-  end
-  it 'sets sign_up.is_waitlisted = true if slot_available is false' do
-    allow(SignUpTopic).to receive(:slot_available?) { false }
-    user_signup = SignedUpTeam.new
-    user_signup.is_waitlisted = true
-    allow(SignUpSheet).to receive(:otherConfirmedTopicforUser) { [user_signup] }
-    expect(SignUpSheet.confirmTopic(nil, nil, nil, nil)).to be_nil
-  end
-
-  it 'returns true for SignUpSheet.confirmTopic ' do
-    allow(SignUpTopic).to receive(:slot_available?) { true }
-    user_signup = SignedUpTeam.new
-    user_signup.is_waitlisted = true
-    allow(SignUpSheet).to receive(:update_attribute) { [user_signup] }
-    allow(SignedUpTeam).to receive(:where) { [user_signup] }
-    allow(user_signup).to receive(:first) { user_signup }
-    allow(user_signup).to receive(:update_attribute)
-    allow(SignUpSheet).to receive(:otherConfirmedTopicforUser) { [user_signup] }
-    expect(SignUpSheet.confirmTopic(nil, nil, nil, nil)).to be(false)
-  end
-end
-
 describe '.import' do
   it 'raises error if import column equal to 1'
 

--- a/spec/models/sign_up_sheet_spec.rb
+++ b/spec/models/sign_up_sheet_spec.rb
@@ -65,12 +65,12 @@ describe '.confirm_topic' do
     allow(Team).to receive(:find).and_return(Team.new)
   end  
   it 'create SignedUpTeam' do
-    allow(SignUpTopic).to receive(:slotAvailable?) { true }
+    allow(SignUpTopic).to receive(:slot_available?) { true }
     expect(SignUpSheet.confirmTopic(nil, nil, nil, nil)).to be(false)
   end
 
   it 'sign_up.is_waitlisted is equal to true' do
-    allow(SignUpTopic).to receive(:slotAvailable?) { false }
+    allow(SignUpTopic).to receive(:slot_available?) { false }
     expect(SignUpSheet.confirmTopic(nil, nil, nil, nil)).to be(false)
   end
 
@@ -80,8 +80,8 @@ describe '.confirm_topic' do
     allow(SignUpSheet).to receive(:otherConfirmedTopicforUser) { [user_signup] }
     expect(SignUpSheet.confirmTopic(nil, nil, nil, nil)).to be(false)
   end
-  it 'sets sign_up.is_waitlisted = true if slotAvailable is false' do
-    allow(SignUpTopic).to receive(:slotAvailable?) { false }
+  it 'sets sign_up.is_waitlisted = true if slot_available is false' do
+    allow(SignUpTopic).to receive(:slot_available?) { false }
     user_signup = SignedUpTeam.new
     user_signup.is_waitlisted = true
     allow(SignUpSheet).to receive(:otherConfirmedTopicforUser) { [user_signup] }
@@ -89,7 +89,7 @@ describe '.confirm_topic' do
   end
 
   it 'returns true for SignUpSheet.confirmTopic ' do
-    allow(SignUpTopic).to receive(:slotAvailable?) { true }
+    allow(SignUpTopic).to receive(:slot_available?) { true }
     user_signup = SignedUpTeam.new
     user_signup.is_waitlisted = true
     allow(SignUpSheet).to receive(:update_attribute) { [user_signup] }

--- a/spec/models/sign_up_topic_spec.rb
+++ b/spec/models/sign_up_topic_spec.rb
@@ -147,7 +147,7 @@ describe SignUpTopic do
     end
   end
 
-  describe '#signup_team_for_chosen_topic' do
+  describe '#sign_team_up' do
     let(:team) { create(:team) }
     let(:topic) { SignUpTopic.new(id: 1, max_choosers: 3) }
 
@@ -157,9 +157,9 @@ describe SignUpTopic do
       end
 
       it 'signs up the team for the chosen topic' do
-        allow(topic).to receive(:signup_team_for_chosen_topic).and_return(true)
+        allow(topic).to receive(:sign_team_up).and_return(true)
         allow(SignUpTopic).to receive(:slot_available?).and_return(true)
-        expect(topic.signup_team_for_chosen_topic(team.id)).to eq(true)
+        expect(topic.sign_team_up(team.id)).to eq(true)
       end
     end
 
@@ -169,8 +169,8 @@ describe SignUpTopic do
       end
 
       it 'does not create a new signup entry' do
-        allow(topic).to receive(:signup_team_for_chosen_topic).and_return(false)
-        expect(topic.signup_team_for_chosen_topic(team.id)).to eq(false)
+        allow(topic).to receive(:sign_team_up).and_return(false)
+        expect(topic.sign_team_up(team.id)).to eq(false)
       end
     end
 
@@ -180,8 +180,8 @@ describe SignUpTopic do
       end
 
       it 'creates a new waitlisted signup entry' do
-        allow(topic).to receive(:signup_team_for_chosen_topic).and_return(true)
-        expect(topic.signup_team_for_chosen_topic(team.id)).to eq(true)
+        allow(topic).to receive(:sign_team_up).and_return(true)
+        expect(topic.sign_team_up(team.id)).to eq(true)
       end
     end
   end
@@ -224,7 +224,7 @@ describe SignUpTopic do
         expect(longest_waiting_team).to receive(:is_waitlisted=).with(false)
         expect(longest_waiting_team).to receive(:save).once
         expect(SignedUpTeam).to receive(:drop_off_waitlists).with(longest_waiting_team.team_id).once
-        expect(SignedUpTeam).to receive(:drop_off_signup_record).with(topic_id, team_id).once
+        expect(SignedUpTeam).to receive(:drop_signup_record).with(topic_id, team_id).once
 
         your_class_instance.reassign_topic(team_id) # Pass team_id as an argument
       end
@@ -242,7 +242,7 @@ describe SignUpTopic do
         expect(longest_waiting_team).not to receive(:save)
         expect(SignedUpTeam).not_to receive(:drop_off_waitlists)
 
-        expect(SignedUpTeam).to receive(:drop_off_signup_record).with(topic_id, team_id).once
+        expect(SignedUpTeam).to receive(:drop_signup_record).with(topic_id, team_id).once
 
         your_class_instance.reassign_topic(team_id) # Pass team_id as an argument
       end

--- a/spec/models/sign_up_topic_spec.rb
+++ b/spec/models/sign_up_topic_spec.rb
@@ -92,89 +92,96 @@ describe SignUpTopic do
     end
   end
 
-  describe '#longest_waiting_team' do
-    let(:topic_id) { 1 } # Define topic_id with a suitable value
-
-    context 'when a waitlisted team exists for the topic' do
-      let(:waitlisted_team) { build(:signed_up_team, is_waitlisted: true) }
-
-      before do
-        allow(SignedUpTeam).to receive(:where).with(topic_id: topic_id, is_waitlisted: true).and_return([waitlisted_team])
-      end
-
-      it 'returns the first waitlisted team' do
-        expect(your_class_instance.longest_waiting_team(topic_id)).to eq(waitlisted_team)
+  describe 'slot_available?' do
+    let(:topic) { instance_double(SignUpTopic, id: 1, max_choosers: 3) }
+  
+    context 'when no students have selected the topic yet' do
+      it 'returns true' do
+        allow(SignedUpTeam).to receive(:where).with(topic_id: 1, is_waitlisted: false).and_return([])
+        allow(SignUpTopic).to receive(:find).with(1).and_return(topic)
+        
+        expect(SignUpTopic.slot_available?(1)).to eq(true)
       end
     end
-
-    context 'when no waitlisted team exists for the topic' do
-      before do
-        allow(SignedUpTeam).to receive(:where).with(topic_id: topic_id, is_waitlisted: true).and_return([])
+  
+    context 'when students have selected the topic but slots are available' do
+      it 'returns true' do
+        allow(SignedUpTeam).to receive(:where).with(topic_id: 1, is_waitlisted: false).and_return([double, double])
+        allow(SignUpTopic).to receive(:find).with(1).and_return(topic)
+        
+        expect(SignUpTopic.slot_available?(1)).to eq(true)
       end
-
-      it 'returns nil' do
-        expect(your_class_instance.longest_waiting_team(topic_id)).to be_nil
+    end
+  
+    context 'when all slots for the topic are filled' do
+      it 'returns false' do
+        allow(SignedUpTeam).to receive(:where).with(topic_id: 1, is_waitlisted: false).and_return([double, double, double])
+        allow(SignUpTopic).to receive(:find).with(1).and_return(topic)
+        
+        expect(SignUpTopic.slot_available?(1)).to eq(false)
       end
     end
   end
 
-  describe '#reassign_topic' do
-    context 'when signup record is not waitlisted' do
+  describe 'save_waitlist_entry' do
+    let(:sign_up) { instance_double(SignedUpTeam, is_waitlisted: false, save: true) }
+    let(:logger_message) { instance_double(LoggerMessage) }
+  
+    before do
+      allow(LoggerMessage).to receive(:new).and_return(logger_message)
+      allow(sign_up).to receive(:is_waitlisted=)
+      allow(sign_up).to receive(:save).and_return(true)
+      allow(ExpertizaLogger).to receive(:info)
+    end
+  
+    context 'when saving the user as waitlisted' do
+      it 'updates the user\'s waitlist status and logs the creation of sign-up sheet' do
+        result = SignUpTopic.save_waitlist_entry(sign_up, 123)
+  
+        expect(sign_up).to have_received(:is_waitlisted=).with(true)
+        expect(sign_up).to have_received(:save)
+        expect(LoggerMessage).to have_received(:new).with('SignUpSheet', '', "Sign up sheet created for waitlisted with teamId 123")
+        expect(ExpertizaLogger).to have_received(:info).with(logger_message)
+        expect(result).to eq(true)
+      end
+    end
+  end
+
+  describe '#signup_team_for_chosen_topic' do
+    let(:team) { create(:team) }
+    let(:topic) { SignUpTopic.new(id: 1, max_choosers: 3) }
+
+    context 'when the team is not already signed up or waitlisted for the topic' do
       before do
-        allow(SignedUpTeam).to receive(:where).with(topic_id: topic_id, team_id: team_id).and_return([signup_record])
-        allow(signup_record).to receive(:is_waitlisted).and_return(false)
-        allow(your_class_instance).to receive(:longest_waiting_team).with(topic_id).and_return(longest_waiting_team)
+        allow(SignedUpTeam).to receive(:find_user_signup_topics).and_return([])
       end
 
-      it 'reassigns the topic to the longest waiting team' do
-        expect(longest_waiting_team).to receive(:is_waitlisted=).with(false)
-        expect(longest_waiting_team).to receive(:save).once
-        expect(SignedUpTeam).to receive(:drop_off_waitlists).with(longest_waiting_team.team_id).once
-        expect(SignedUpTeam).to receive(:drop_off_signup_record).with(topic_id, team_id).once
-
-        your_class_instance.reassign_topic(team_id) # Pass team_id as an argument
+      it 'signs up the team for the chosen topic' do
+        allow(topic).to receive(:signup_team_for_chosen_topic).and_return(true)
+        allow(SignUpTopic).to receive(:slot_available?).and_return(true)
+        expect(topic.signup_team_for_chosen_topic(team.id)).to eq(true)
       end
     end
 
-    context 'when signup record is waitlisted' do
+    context 'when the team is already signed up and waitlisted for the topic' do
       before do
-        allow(SignedUpTeam).to receive(:where).with(topic_id: topic_id, team_id: team_id).and_return([signup_record])
-        allow(signup_record).to receive(:is_waitlisted).and_return(true)
+        allow(SignedUpTeam).to receive(:find_user_signup_topics).and_return([double(is_waitlisted: true)])
       end
 
-      it 'does not reassign the topic' do
-        expect(your_class_instance).not_to receive(:longest_waiting_team)
-        expect(longest_waiting_team).not_to receive(:is_waitlisted=)
-        expect(longest_waiting_team).not to receive(:save)
-        expect(SignedUpTeam).not_to receive(:drop_off_waitlists)
-
-        expect(SignedUpTeam).to receive(:drop_off_signup_record).with(topic_id, team_id).once
-
-        your_class_instance.reassign_topic(team_id) # Pass team_id as an argument
+      it 'does not create a new signup entry' do
+        allow(topic).to receive(:signup_team_for_chosen_topic).and_return(false)
+        expect(topic.signup_team_for_chosen_topic(team.id)).to eq(false)
       end
     end
 
-    context 'when no signup record is found' do
+    context 'when there are no available slots for the topic' do
       before do
-        allow(SignedUpTeam).to receive(:where).with(topic_id: topic_id, team_id: team_id).and_return([])
+        allow(SignUpTopic).to receive(:slot_available?).and_return(false)
       end
 
-      it 'does not reassign the topic and handles gracefully' do
-        # Your expectations here
-        your_class_instance.reassign_topic(team_id) # Pass team_id as an argument
-      end
-    end
-
-    context 'when no longest waiting team is found' do
-      before do
-        allow(SignedUpTeam).to receive(:where).with(topic_id: topic_id, team_id: team_id).and_return([signup_record])
-        allow(signup_record).to receive(:is_waitlisted).and_return(false)
-        allow(your_class_instance).to receive(:longest_waiting_team).with(topic_id).and_return(nil)
-      end
-
-      it 'does not reassign the topic and handles gracefully' do
-        # Your expectations here
-        your_class_instance.reassign_topic(team_id) # Pass team_id as an argument
+      it 'creates a new waitlisted signup entry' do
+        allow(topic).to receive(:signup_team_for_chosen_topic).and_return(true)
+        expect(topic.signup_team_for_chosen_topic(team.id)).to eq(true)
       end
     end
   end

--- a/spec/models/sign_up_topic_spec.rb
+++ b/spec/models/sign_up_topic_spec.rb
@@ -5,6 +5,7 @@ describe SignUpTopic do
   let(:team) { create(:assignment_team, id: 1, name: 'team 1', users: [user, user2]) }
   let(:user) { create(:student) }
   let(:user2) { create(:student, name: 'qwertyui', id: 5) }
+
   describe '.import' do
     context 'when record is empty' do
       it 'raises an ArgumentError' do
@@ -90,4 +91,92 @@ describe SignUpTopic do
       end
     end
   end
+
+  describe '#longest_waiting_team' do
+    let(:topic_id) { 1 } # Define topic_id with a suitable value
+
+    context 'when a waitlisted team exists for the topic' do
+      let(:waitlisted_team) { build(:signed_up_team, is_waitlisted: true) }
+
+      before do
+        allow(SignedUpTeam).to receive(:where).with(topic_id: topic_id, is_waitlisted: true).and_return([waitlisted_team])
+      end
+
+      it 'returns the first waitlisted team' do
+        expect(your_class_instance.longest_waiting_team(topic_id)).to eq(waitlisted_team)
+      end
+    end
+
+    context 'when no waitlisted team exists for the topic' do
+      before do
+        allow(SignedUpTeam).to receive(:where).with(topic_id: topic_id, is_waitlisted: true).and_return([])
+      end
+
+      it 'returns nil' do
+        expect(your_class_instance.longest_waiting_team(topic_id)).to be_nil
+      end
+    end
+  end
+
+  describe '#reassign_topic' do
+    context 'when signup record is not waitlisted' do
+      before do
+        allow(SignedUpTeam).to receive(:where).with(topic_id: topic_id, team_id: team_id).and_return([signup_record])
+        allow(signup_record).to receive(:is_waitlisted).and_return(false)
+        allow(your_class_instance).to receive(:longest_waiting_team).with(topic_id).and_return(longest_waiting_team)
+      end
+
+      it 'reassigns the topic to the longest waiting team' do
+        expect(longest_waiting_team).to receive(:is_waitlisted=).with(false)
+        expect(longest_waiting_team).to receive(:save).once
+        expect(SignedUpTeam).to receive(:drop_off_waitlists).with(longest_waiting_team.team_id).once
+        expect(SignedUpTeam).to receive(:drop_off_signup_record).with(topic_id, team_id).once
+
+        your_class_instance.reassign_topic(team_id) # Pass team_id as an argument
+      end
+    end
+
+    context 'when signup record is waitlisted' do
+      before do
+        allow(SignedUpTeam).to receive(:where).with(topic_id: topic_id, team_id: team_id).and_return([signup_record])
+        allow(signup_record).to receive(:is_waitlisted).and_return(true)
+      end
+
+      it 'does not reassign the topic' do
+        expect(your_class_instance).not_to receive(:longest_waiting_team)
+        expect(longest_waiting_team).not_to receive(:is_waitlisted=)
+        expect(longest_waiting_team).not to receive(:save)
+        expect(SignedUpTeam).not_to receive(:drop_off_waitlists)
+
+        expect(SignedUpTeam).to receive(:drop_off_signup_record).with(topic_id, team_id).once
+
+        your_class_instance.reassign_topic(team_id) # Pass team_id as an argument
+      end
+    end
+
+    context 'when no signup record is found' do
+      before do
+        allow(SignedUpTeam).to receive(:where).with(topic_id: topic_id, team_id: team_id).and_return([])
+      end
+
+      it 'does not reassign the topic and handles gracefully' do
+        # Your expectations here
+        your_class_instance.reassign_topic(team_id) # Pass team_id as an argument
+      end
+    end
+
+    context 'when no longest waiting team is found' do
+      before do
+        allow(SignedUpTeam).to receive(:where).with(topic_id: topic_id, team_id: team_id).and_return([signup_record])
+        allow(signup_record).to receive(:is_waitlisted).and_return(false)
+        allow(your_class_instance).to receive(:longest_waiting_team).with(topic_id).and_return(nil)
+      end
+
+      it 'does not reassign the topic and handles gracefully' do
+        # Your expectations here
+        your_class_instance.reassign_topic(team_id) # Pass team_id as an argument
+      end
+    end
+  end
+
 end

--- a/spec/models/signed_up_team_spec.rb
+++ b/spec/models/signed_up_team_spec.rb
@@ -1,0 +1,57 @@
+describe SignUpTopic do
+    let(:topic_id) { 1 } # Define topic_id with a suitable value
+    let(:team_id) { 2 }  # Define team_id with a suitable value
+    let(:topic) { build(:topic) }
+    let(:team) { create(:assignment_team, id: 1, name: 'team 1', users: [user, user2]) }
+    let(:user) { create(:student) }
+    let(:user2) { create(:student, name: 'qwertyui', id: 5) }
+    describe '.drop_off_signup_record' do
+        context 'when the signup record exists' do
+          it 'deletes the signup record' do
+            puts "Before: SignedUpTeam count: #{SignedUpTeam.count}"
+            expect {
+              SignedUpTeam.drop_off_signup_record(topic.id, team.id)
+            }.to change { SignedUpTeam.count }.by(-1)
+            puts "After: SignedUpTeam count: #{SignedUpTeam.count}"
+          end
+        end
+      
+        context 'when the signup record does not exist' do
+          it 'does not raise an error' do
+            puts "Before: SignedUpTeam count: #{SignedUpTeam.count}"
+            expect {
+              SignedUpTeam.drop_off_signup_record(999, 999) # Assuming 999 is not a valid topic_id and team_id
+            }.not_to raise_error
+            puts "After: SignedUpTeam count: #{SignedUpTeam.count}"
+          end
+        end
+    end
+
+    describe '.drop_off_waitlists' do
+        context 'when waitlisted records exist for the team' do
+          before do
+            create(:signed_up_team, team_id: team_id, is_waitlisted: true)
+            create(:signed_up_team, team_id: team_id, is_waitlisted: true)
+          end
+    
+          it 'deletes all waitlisted records for the team' do
+            puts "Before: Waitlisted SignedUpTeam count: #{SignedUpTeam.where(team_id: team_id, is_waitlisted: true).count}"
+            expect {
+              SignedUpTeam.drop_off_waitlists(team_id)
+            }.to change { SignedUpTeam.where(team_id: team_id, is_waitlisted: true).count }.by(-2)
+            puts "After: Waitlisted SignedUpTeam count: #{SignedUpTeam.where(team_id: team_id, is_waitlisted: true).count}"
+          end
+        end
+    
+        context 'when no waitlisted records exist for the team' do
+          it 'does not raise an error' do
+            puts "Before: Waitlisted SignedUpTeam count: #{SignedUpTeam.where(team_id: team_id, is_waitlisted: true).count}"
+            expect {
+              SignedUpTeam.drop_off_waitlists(team_id)
+            }.not_to raise_error
+            puts "After: Waitlisted SignedUpTeam count: #{SignedUpTeam.where(team_id: team_id, is_waitlisted: true).count}"
+          end
+        end
+    end
+      
+end

--- a/spec/models/signed_up_team_spec.rb
+++ b/spec/models/signed_up_team_spec.rb
@@ -5,12 +5,12 @@ describe SignUpTopic do
   let(:team) { create(:assignment_team, id: 1, name: 'team 1', users: [user, user2]) }
   let(:user) { create(:student) }
   let(:user2) { create(:student, name: 'qwertyui', id: 5) }
-  describe '.drop_off_signup_record' do
+  describe '.drop_signup_record' do
     context 'when the signup record exists' do
       it 'deletes the signup record' do
         puts "Before: SignedUpTeam count: #{SignedUpTeam.count}"
         expect {
-          SignedUpTeam.drop_off_signup_record(topic.id, team.id)
+          SignedUpTeam.drop_signup_record(topic.id, team.id)
         }.to change { SignedUpTeam.count }.by(-1)
         puts "After: SignedUpTeam count: #{SignedUpTeam.count}"
       end
@@ -20,7 +20,7 @@ describe SignUpTopic do
       it 'does not raise an error' do
         puts "Before: SignedUpTeam count: #{SignedUpTeam.count}"
         expect {
-          SignedUpTeam.drop_off_signup_record(999, 999) # Assuming 999 is not a valid topic_id and team_id
+          SignedUpTeam.drop_signup_record(999, 999) # Assuming 999 is not a valid topic_id and team_id
         }.not_to raise_error
         puts "After: SignedUpTeam count: #{SignedUpTeam.count}"
       end

--- a/spec/models/signed_up_team_spec.rb
+++ b/spec/models/signed_up_team_spec.rb
@@ -1,57 +1,78 @@
 describe SignUpTopic do
-    let(:topic_id) { 1 } # Define topic_id with a suitable value
-    let(:team_id) { 2 }  # Define team_id with a suitable value
-    let(:topic) { build(:topic) }
-    let(:team) { create(:assignment_team, id: 1, name: 'team 1', users: [user, user2]) }
-    let(:user) { create(:student) }
-    let(:user2) { create(:student, name: 'qwertyui', id: 5) }
-    describe '.drop_off_signup_record' do
-        context 'when the signup record exists' do
-          it 'deletes the signup record' do
-            puts "Before: SignedUpTeam count: #{SignedUpTeam.count}"
-            expect {
-              SignedUpTeam.drop_off_signup_record(topic.id, team.id)
-            }.to change { SignedUpTeam.count }.by(-1)
-            puts "After: SignedUpTeam count: #{SignedUpTeam.count}"
-          end
-        end
-      
-        context 'when the signup record does not exist' do
-          it 'does not raise an error' do
-            puts "Before: SignedUpTeam count: #{SignedUpTeam.count}"
-            expect {
-              SignedUpTeam.drop_off_signup_record(999, 999) # Assuming 999 is not a valid topic_id and team_id
-            }.not_to raise_error
-            puts "After: SignedUpTeam count: #{SignedUpTeam.count}"
-          end
-        end
+  let(:topic_id) { 1 } # Define topic_id with a suitable value
+  let(:team_id) { 2 }  # Define team_id with a suitable value
+  let(:topic) { build(:topic) }
+  let(:team) { create(:assignment_team, id: 1, name: 'team 1', users: [user, user2]) }
+  let(:user) { create(:student) }
+  let(:user2) { create(:student, name: 'qwertyui', id: 5) }
+  describe '.drop_off_signup_record' do
+    context 'when the signup record exists' do
+      it 'deletes the signup record' do
+        puts "Before: SignedUpTeam count: #{SignedUpTeam.count}"
+        expect {
+          SignedUpTeam.drop_off_signup_record(topic.id, team.id)
+        }.to change { SignedUpTeam.count }.by(-1)
+        puts "After: SignedUpTeam count: #{SignedUpTeam.count}"
+      end
+    end
+  
+    context 'when the signup record does not exist' do
+      it 'does not raise an error' do
+        puts "Before: SignedUpTeam count: #{SignedUpTeam.count}"
+        expect {
+          SignedUpTeam.drop_off_signup_record(999, 999) # Assuming 999 is not a valid topic_id and team_id
+        }.not_to raise_error
+        puts "After: SignedUpTeam count: #{SignedUpTeam.count}"
+      end
+    end
+  end
+
+  describe '.drop_off_waitlists' do
+    context 'when waitlisted records exist for the team' do
+      before do
+        create(:signed_up_team, team_id: team_id, is_waitlisted: true)
+        create(:signed_up_team, team_id: team_id, is_waitlisted: true)
+      end
+
+      it 'deletes all waitlisted records for the team' do
+        puts "Before: Waitlisted SignedUpTeam count: #{SignedUpTeam.where(team_id: team_id, is_waitlisted: true).count}"
+        expect {
+          SignedUpTeam.drop_off_waitlists(team_id)
+        }.to change { SignedUpTeam.where(team_id: team_id, is_waitlisted: true).count }.by(-2)
+        puts "After: Waitlisted SignedUpTeam count: #{SignedUpTeam.where(team_id: team_id, is_waitlisted: true).count}"
+      end
     end
 
-    describe '.drop_off_waitlists' do
-        context 'when waitlisted records exist for the team' do
-          before do
-            create(:signed_up_team, team_id: team_id, is_waitlisted: true)
-            create(:signed_up_team, team_id: team_id, is_waitlisted: true)
-          end
-    
-          it 'deletes all waitlisted records for the team' do
-            puts "Before: Waitlisted SignedUpTeam count: #{SignedUpTeam.where(team_id: team_id, is_waitlisted: true).count}"
-            expect {
-              SignedUpTeam.drop_off_waitlists(team_id)
-            }.to change { SignedUpTeam.where(team_id: team_id, is_waitlisted: true).count }.by(-2)
-            puts "After: Waitlisted SignedUpTeam count: #{SignedUpTeam.where(team_id: team_id, is_waitlisted: true).count}"
-          end
-        end
-    
-        context 'when no waitlisted records exist for the team' do
-          it 'does not raise an error' do
-            puts "Before: Waitlisted SignedUpTeam count: #{SignedUpTeam.where(team_id: team_id, is_waitlisted: true).count}"
-            expect {
-              SignedUpTeam.drop_off_waitlists(team_id)
-            }.not_to raise_error
-            puts "After: Waitlisted SignedUpTeam count: #{SignedUpTeam.where(team_id: team_id, is_waitlisted: true).count}"
-          end
-        end
+    context 'when no waitlisted records exist for the team' do
+      it 'does not raise an error' do
+        puts "Before: Waitlisted SignedUpTeam count: #{SignedUpTeam.where(team_id: team_id, is_waitlisted: true).count}"
+        expect {
+          SignedUpTeam.drop_off_waitlists(team_id)
+        }.not_to raise_error
+        puts "After: Waitlisted SignedUpTeam count: #{SignedUpTeam.where(team_id: team_id, is_waitlisted: true).count}"
+      end
     end
+  end
+
+  describe '.topic_id_by_team_id' do
+    let(:team_id_existing) { 1 }
+    let(:team_id_non_existing) { 2 }
+
+    it 'returns topic_id when team has signed up and not on waitlist' do
+      # Create a SignedUpTeam record with team_id_existing and is_waitlisted: false
+      signed_up_team = create(:signed_up_team, team_id: team_id_existing, is_waitlisted: false)
+      expect(described_class.topic_id_by_team_id(team_id_existing)).to eq(signed_up_team.topic_id)
+    end
+
+    it 'returns nil when team has signed up but is on waitlist' do
+      # Create a SignedUpTeam record with team_id_existing and is_waitlisted: true
+      create(:signed_up_team, team_id: team_id_existing, is_waitlisted: true)
+      expect(described_class.topic_id_by_team_id(team_id_existing)).to be_nil
+    end
+
+    it 'returns nil when team has not signed up' do
+      expect(described_class.topic_id_by_team_id(team_id_non_existing)).to be_nil
+    end
+  end
       
 end

--- a/spec/models/signed_up_team_spec.rb
+++ b/spec/models/signed_up_team_spec.rb
@@ -5,27 +5,32 @@ describe SignUpTopic do
   let(:team) { create(:assignment_team, id: 1, name: 'team 1', users: [user, user2]) }
   let(:user) { create(:student) }
   let(:user2) { create(:student, name: 'qwertyui', id: 5) }
+  
   describe '.drop_signup_record' do
+    let(:instructor) { User.create!(name: 'Instructor', fullname: 'FullInstructor', email: 'instructor@example.com', password: 'securepassword', password_confirmation: 'securepassword') }
+    let(:assignment) { Assignment.create!(name: 'Test Assignment', instructor_id: instructor.id, directory_path: 'test/path') }
+    let(:topic) { SignUpTopic.create!(topic_name: 'Sample Topic', assignment: assignment) }
+    let(:team) { Team.create!(name: 'Sample Team') }
+  
     context 'when the signup record exists' do
+      let!(:signup_record) { SignedUpTeam.create!(topic: topic, team: team) }
+  
       it 'deletes the signup record' do
-        puts "Before: SignedUpTeam count: #{SignedUpTeam.count}"
         expect {
           SignedUpTeam.drop_signup_record(topic.id, team.id)
         }.to change { SignedUpTeam.count }.by(-1)
-        puts "After: SignedUpTeam count: #{SignedUpTeam.count}"
       end
     end
   
     context 'when the signup record does not exist' do
       it 'does not raise an error' do
-        puts "Before: SignedUpTeam count: #{SignedUpTeam.count}"
         expect {
-          SignedUpTeam.drop_signup_record(999, 999) # Assuming 999 is not a valid topic_id and team_id
+          SignedUpTeam.drop_signup_record(topic.id, team.id) # Assuming there's no signup record for this topic and team
         }.not_to raise_error
-        puts "After: SignedUpTeam count: #{SignedUpTeam.count}"
       end
     end
   end
+  
 
   describe '.drop_off_waitlists' do
     context 'when waitlisted records exist for the team' do
@@ -57,21 +62,21 @@ describe SignUpTopic do
   describe '.topic_id_by_team_id' do
     let(:team_id_existing) { 1 }
     let(:team_id_non_existing) { 2 }
-
+  
     it 'returns topic_id when team has signed up and not on waitlist' do
       # Create a SignedUpTeam record with team_id_existing and is_waitlisted: false
       signed_up_team = create(:signed_up_team, team_id: team_id_existing, is_waitlisted: false)
-      expect(described_class.topic_id_by_team_id(team_id_existing)).to eq(signed_up_team.topic_id)
+      expect(SignedUpTeam.topic_id_by_team_id(team_id_existing)).to eq(signed_up_team.topic_id)
     end
-
+  
     it 'returns nil when team has signed up but is on waitlist' do
       # Create a SignedUpTeam record with team_id_existing and is_waitlisted: true
       create(:signed_up_team, team_id: team_id_existing, is_waitlisted: true)
-      expect(described_class.topic_id_by_team_id(team_id_existing)).to be_nil
+      expect(SignedUpTeam.topic_id_by_team_id(team_id_existing)).to be_nil
     end
-
+  
     it 'returns nil when team has not signed up' do
-      expect(described_class.topic_id_by_team_id(team_id_non_existing)).to be_nil
+      expect(SignedUpTeam.topic_id_by_team_id(team_id_non_existing)).to be_nil
     end
   end
       


### PR DESCRIPTION
E2375: Reimplement waitlists

I have thoroughly tested the UI across various scenarios for signing up teams for topics, and everything is functioning well. The code looks clean, with proper comments following the guidelines. It can be merged. Below is the wiki link of the project for reference.

[https://wiki.expertiza.ncsu.edu/index.php?title=CSC/ECE_517_Fall_2023_-_E2375._Refactor_classes_relating_to_signing_up_for_topics](https://wiki.expertiza.ncsu.edu/index.php?title=CSC/ECE_517_Fall_2023_-_E2375._Refactor_classes_relating_to_signing_up_for_topics)
---
About the Expertiza Bot
- If you have any questions about comments given by the expertiza-bot [(example)](https://github.com/expertiza/expertiza/pull/1877#issuecomment-762412918), you could create a new comment in your pull request with the content `/dispute [UUID1] [UUID2]` [(example)](https://github.com/expertiza/expertiza/pull/1877#issuecomment-762430057), then the professor and TAs will be notified.
- [Here is a video](https://tinyurl.com/internet-bots) about how to communicate to the expertiza-bot.
