### PR TITLE
E2452. Refactor review_mapping_controller.rb

### DIFF
--- a/app/controllers/review_mapping_controller.rb
+++ b/app/controllers/review_mapping_controller.rb
@@ -7,7 +7,7 @@ class ReviewMappingController < ApplicationController
   # including the following helper to refactor the code in response_report function
   # include ReportFormatterHelper
 
-  @@time_create_last_review_mapping_record = nil
+  @@time_create_last_review_mapping_record = nil 
 
   # E1600
   # start_self_review is a method that is invoked by a student user so it should be allowed accordingly

--- a/app/helpers/review_mapping_helper.rb
+++ b/app/helpers/review_mapping_helper.rb
@@ -545,7 +545,7 @@ module ReviewMappingHelper
 
   class TeamReviewStrategy < ReviewStrategy
     def reviews_per_team
-      @review_num
+      @review_num 
     end
 
     def reviews_needed

--- a/spec/controllers/review_mapping_controller_spec.rb
+++ b/spec/controllers/review_mapping_controller_spec.rb
@@ -1,5 +1,6 @@
 require 'rails_helper'
 describe ReviewMappingController do
+  include ReviewMappingHelper
   let(:assignment) { double('Assignment', id: 1) }
   let(:reviewer) { double('Participant', id: 1, name: 'reviewer') }
   let(:review_response_map) do
@@ -763,5 +764,4 @@ describe ReviewMappingController do
   end
 
 end
-review_mapping_controller_spec.rb
-Displaying review_mapping_controller.rb.
+ 


### PR DESCRIPTION
Renamed Methods:
I updated various method names in review_mapping_controller.rb and review_mapping_helper.rb to be clearer and more in line with Ruby conventions. For example, get_participant_or_reviewer is now find_assignment_participant, and check_for_self_review? is now is_self_review?.
