### PR TITLE
Issue fix 2920

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ on:
   
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix: # we will be running rspec tests in controllers, models, helpers, and lib folders
          folder: [controllers, models, helpers, lib]
@@ -77,7 +77,7 @@ jobs:
   publish-code-coverage:
     needs: test
     if: github.event_name == 'push'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v3
       - uses: actions/download-artifact@v4
@@ -97,7 +97,7 @@ jobs:
   deploy-on-dev:
     needs: test
     if: github.event_name == 'push' && github.ref == 'refs/heads/development'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v3
     - uses: ruby/setup-ruby@v1
@@ -115,7 +115,7 @@ jobs:
   deploy-on-test:
     needs: test
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v3
     - uses: ruby/setup-ruby@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ on:
   
 jobs:
   test:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix: # we will be running rspec tests in controllers, models, helpers, and lib folders
          folder: [controllers, models, helpers, lib]
@@ -77,7 +77,7 @@ jobs:
   publish-code-coverage:
     needs: test
     if: github.event_name == 'push'
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - uses: actions/download-artifact@v4
@@ -97,7 +97,7 @@ jobs:
   deploy-on-dev:
     needs: test
     if: github.event_name == 'push' && github.ref == 'refs/heads/development'
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
     - uses: ruby/setup-ruby@v1
@@ -115,7 +115,7 @@ jobs:
   deploy-on-test:
     needs: test
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
     - uses: ruby/setup-ruby@v1


### PR DESCRIPTION
This PR updates the GitHub Actions workflows to replace ubuntu-20.04 with a supported version ubuntu-22.04.

Why this is needed: GitHub will fully deprecate ubuntu-20.04 by April 1, 2025, with scheduled brownout periods in March. This update prevents workflow failures due to deprecation.

Newer Ubuntu versions (> 22.04) will not support Ruby versions < 3.

Closes #2920 