### PR TITLE
Issue fix 2855, 2852

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -139,13 +139,6 @@ ActiveRecord::Schema.define(version: 20231203230237) do
     t.index ["sample_assignment_id"], name: "fk_rails_b01b82a1a2"
   end
 
-  create_table "assignments_questionnaires", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
-    t.integer "questionnaire_id", default: 0, null: false
-    t.integer "assignment_id", default: 0, null: false
-    t.index ["assignment_id"], name: "fk_assignments_questionnaires_assignments"
-    t.index ["questionnaire_id"], name: "fk_assignments_questionnaires_questionnaires"
-  end
-
   create_table "automated_metareviews", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
     t.float "relevance", limit: 24
     t.float "content_summative", limit: 24
@@ -251,14 +244,6 @@ ActiveRecord::Schema.define(version: 20231203230237) do
     t.index ["instructor_id"], name: "fk_course_users"
   end
 
-  create_table "courses_users", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
-    t.integer "user_id"
-    t.integer "course_id"
-    t.boolean "active"
-    t.index ["course_id"], name: "fk_users_courses"
-    t.index ["user_id"], name: "fk_courses_users"
-  end
-
   create_table "deadline_rights", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
     t.string "name", limit: 32
   end
@@ -314,117 +299,6 @@ ActiveRecord::Schema.define(version: 20231203230237) do
     t.index ["assignment_id"], name: "index_duties_on_assignment_id"
   end
 
-  create_table "goldberg_content_pages", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
-    t.string "title"
-    t.string "name", default: "", null: false
-    t.integer "markup_style_id"
-    t.text "content"
-    t.integer "permission_id", default: 0, null: false
-    t.datetime "created_at"
-    t.datetime "updated_at"
-    t.text "content_cache"
-    t.string "markup_style"
-    t.index ["markup_style_id"], name: "fk_content_page_markup_style_id"
-    t.index ["permission_id"], name: "fk_content_page_permission_id"
-  end
-
-  create_table "goldberg_controller_actions", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
-    t.integer "site_controller_id", default: 0, null: false
-    t.string "name", default: "", null: false
-    t.integer "permission_id"
-    t.string "url_to_use"
-    t.index ["permission_id"], name: "fk_controller_action_permission_id"
-    t.index ["site_controller_id"], name: "fk_controller_action_site_controller_id"
-  end
-
-  create_table "goldberg_markup_styles", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
-    t.string "name", default: "", null: false
-  end
-
-  create_table "goldberg_menu_items", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
-    t.integer "parent_id"
-    t.string "name", default: "", null: false
-    t.string "label", default: "", null: false
-    t.integer "seq"
-    t.integer "controller_action_id"
-    t.integer "content_page_id"
-    t.index ["content_page_id"], name: "fk_menu_item_content_page_id"
-    t.index ["controller_action_id"], name: "fk_menu_item_controller_action_id"
-    t.index ["parent_id"], name: "fk_menu_item_parent_id"
-  end
-
-  create_table "goldberg_permissions", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
-    t.string "name", default: "", null: false
-  end
-
-  create_table "goldberg_roles", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
-    t.string "name", default: "", null: false
-    t.integer "parent_id"
-    t.string "description", default: "", null: false
-    t.integer "default_page_id"
-    t.text "cache"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-    t.string "start_path"
-    t.index ["default_page_id"], name: "fk_role_default_page_id"
-    t.index ["parent_id"], name: "fk_role_parent_id"
-  end
-
-  create_table "goldberg_roles_permissions", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
-    t.integer "role_id", default: 0, null: false
-    t.integer "permission_id", default: 0, null: false
-    t.index ["permission_id"], name: "fk_roles_permission_permission_id"
-    t.index ["role_id"], name: "fk_roles_permission_role_id"
-  end
-
-  create_table "goldberg_site_controllers", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
-    t.string "name", default: "", null: false
-    t.integer "permission_id", default: 0, null: false
-    t.integer "builtin", default: 0
-    t.index ["permission_id"], name: "fk_site_controller_permission_id"
-  end
-
-  create_table "goldberg_system_settings", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
-    t.string "site_name", default: "", null: false
-    t.string "site_subtitle"
-    t.string "footer_message", default: ""
-    t.integer "public_role_id", default: 0, null: false
-    t.integer "session_timeout", default: 0, null: false
-    t.integer "default_markup_style_id", default: 0
-    t.integer "site_default_page_id", default: 0, null: false
-    t.integer "not_found_page_id", default: 0, null: false
-    t.integer "permission_denied_page_id", default: 0, null: false
-    t.integer "session_expired_page_id", default: 0, null: false
-    t.integer "menu_depth", default: 0, null: false
-    t.string "start_path"
-    t.string "site_url_prefix"
-    t.boolean "self_reg_enabled"
-    t.integer "self_reg_role_id"
-    t.boolean "self_reg_confirmation_required"
-    t.integer "self_reg_confirmation_error_page_id"
-    t.boolean "self_reg_send_confirmation_email"
-    t.index ["not_found_page_id"], name: "fk_system_settings_not_found_page_id"
-    t.index ["permission_denied_page_id"], name: "fk_system_settings_permission_denied_page_id"
-    t.index ["public_role_id"], name: "fk_system_settings_public_role_id"
-    t.index ["session_expired_page_id"], name: "fk_system_settings_session_expired_page_id"
-    t.index ["site_default_page_id"], name: "fk_system_settings_site_default_page_id"
-  end
-
-  create_table "goldberg_users", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
-    t.string "name", default: "", null: false
-    t.string "password", limit: 40, default: "", null: false
-    t.integer "role_id", default: 0, null: false
-    t.string "password_salt"
-    t.string "fullname"
-    t.string "email"
-    t.string "start_path"
-    t.boolean "self_reg_confirmation_required"
-    t.string "confirmation_key"
-    t.datetime "password_changed_at"
-    t.boolean "password_expired"
-    t.index ["role_id"], name: "fk_user_role_id"
-  end
-
   create_table "institutions", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
     t.string "name", default: "", null: false
   end
@@ -473,10 +347,6 @@ ActiveRecord::Schema.define(version: 20231203230237) do
     t.index ["user_id"], name: "fk_rails_426f571216"
   end
 
-  create_table "mapping_strategies", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
-    t.string "name"
-  end
-
   create_table "markup_styles", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
     t.string "name", default: "", null: false
   end
@@ -499,7 +369,7 @@ ActiveRecord::Schema.define(version: 20231203230237) do
     t.string "type"
   end
 
-  create_table "notifications", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "notifications", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
     t.string "subject"
     t.text "description"
     t.date "expiration_date"
@@ -567,11 +437,6 @@ ActiveRecord::Schema.define(version: 20231203230237) do
     t.index ["plagiarism_checker_assignment_submission_id"], name: "assignment_submission_index"
   end
 
-  create_table "plugin_schema_info", id: false, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
-    t.string "plugin_name"
-    t.integer "version"
-  end
-
   create_table "question_advices", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
     t.integer "question_id"
     t.integer "score"
@@ -581,10 +446,6 @@ ActiveRecord::Schema.define(version: 20231203230237) do
 
   create_table "question_types", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
     t.string "type"
-  end
-
-  create_table "questionnaire_types", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
-    t.string "name", default: "", null: false
   end
 
   create_table "questionnaires", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
@@ -667,20 +528,10 @@ ActiveRecord::Schema.define(version: 20231203230237) do
   create_table "review_comment_paste_bins", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer "review_grade_id"
     t.string "title"
-    t.text "review_comment"
+    t.text "review_comment", limit: 16777215
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["review_grade_id"], name: "fk_rails_0a539bcc81"
-  end
-
-  create_table "review_feedbacks", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
-    t.integer "assignment_id"
-    t.integer "review_id"
-    t.integer "author_id"
-    t.datetime "feedback_at"
-    t.text "additional_comment"
-    t.index ["assignment_id"], name: "fk_review_feedback_assignments"
-    t.index ["review_id"], name: "fk_review_feedback_reviews"
   end
 
   create_table "review_grades", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
@@ -690,67 +541,6 @@ ActiveRecord::Schema.define(version: 20231203230237) do
     t.datetime "review_graded_at"
     t.integer "reviewer_id"
     t.index ["participant_id"], name: "fk_rails_29587cf6a9"
-  end
-
-  create_table "review_mappings", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
-    t.integer "author_id"
-    t.integer "team_id"
-    t.integer "reviewer_id"
-    t.integer "assignment_id"
-    t.integer "round"
-    t.index ["assignment_id"], name: "fk_review_mapping_assignments"
-    t.index ["author_id"], name: "fk_review_users_author"
-    t.index ["reviewer_id"], name: "fk_review_users_reviewer"
-    t.index ["team_id"], name: "fk_review_teams"
-  end
-
-  create_table "review_of_review_mappings", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
-    t.integer "review_mapping_id"
-    t.integer "review_reviewer_id"
-    t.index ["review_mapping_id"], name: "fk_review_of_review_mapping_review_mappings"
-  end
-
-  create_table "review_of_review_scores", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
-    t.integer "review_of_review_id"
-    t.integer "question_id"
-    t.integer "score"
-    t.text "comments"
-    t.index ["question_id"], name: "fk_review_of_review_score_questions"
-    t.index ["review_of_review_id"], name: "fk_review_of_review_score_reviews"
-  end
-
-  create_table "review_of_reviews", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
-    t.datetime "reviewed_at"
-    t.integer "review_of_review_mapping_id"
-    t.integer "review_num_for_author"
-    t.integer "review_num_for_reviewer"
-    t.index ["review_of_review_mapping_id"], name: "fk_review_of_review_review_of_review_mappings"
-  end
-
-  create_table "review_scores", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
-    t.integer "review_id"
-    t.integer "question_id"
-    t.integer "score"
-    t.text "comments"
-    t.integer "questionnaire_type_id"
-    t.index ["question_id"], name: "fk_review_score_questions"
-    t.index ["questionnaire_type_id"], name: "fk_review_scores_questionnaire_type_id"
-    t.index ["review_id"], name: "fk_review_score_reviews"
-  end
-
-  create_table "review_strategies", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
-    t.string "name"
-  end
-
-  create_table "reviews", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
-    t.integer "review_mapping_id"
-    t.integer "review_num_for_author"
-    t.integer "review_num_for_reviewer"
-    t.boolean "ignore", default: false
-    t.text "additional_comment"
-    t.datetime "updated_at"
-    t.datetime "created_at"
-    t.index ["review_mapping_id"], name: "fk_review_mappings"
   end
 
   create_table "roles", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
@@ -861,19 +651,6 @@ ActiveRecord::Schema.define(version: 20231203230237) do
     t.integer "global_survey_id"
     t.string "type"
     t.index ["questionnaire_id"], name: "fk_rails_7c62b6ef2b"
-  end
-
-  create_table "survey_responses", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
-    t.bigint "score"
-    t.text "comments"
-    t.bigint "assignment_id", default: 0, null: false
-    t.bigint "question_id", default: 0, null: false
-    t.bigint "survey_id", default: 0, null: false
-    t.string "email"
-    t.integer "survey_deployment_id"
-    t.index ["assignment_id"], name: "fk_survey_assignments"
-    t.index ["question_id"], name: "fk_survey_questions"
-    t.index ["survey_id"], name: "fk_survey_questionnaires"
   end
 
   create_table "system_settings", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
@@ -1009,10 +786,6 @@ ActiveRecord::Schema.define(version: 20231203230237) do
     t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
   end
 
-  create_table "wiki_types", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
-    t.string "name", default: "", null: false
-  end
-
   add_foreign_key "answer_tags", "answers"
   add_foreign_key "answer_tags", "tag_prompt_deployments"
   add_foreign_key "answer_tags", "users"
@@ -1026,14 +799,10 @@ ActiveRecord::Schema.define(version: 20231203230237) do
   add_foreign_key "assignments", "assignments", column: "sample_assignment_id"
   add_foreign_key "assignments", "late_policies", name: "fk_late_policy_id"
   add_foreign_key "assignments", "users", column: "instructor_id", name: "fk_assignments_instructors"
-  add_foreign_key "assignments_questionnaires", "assignments", name: "fk_assignments_questionnaires_assignments"
-  add_foreign_key "assignments_questionnaires", "questionnaires", name: "fk_assignments_questionnaires_questionnaires"
   add_foreign_key "automated_metareviews", "responses", name: "fk_automated_metareviews_responses_id"
   add_foreign_key "awarded_badges", "badges"
   add_foreign_key "awarded_badges", "participants"
   add_foreign_key "courses", "users", column: "instructor_id", name: "fk_course_users"
-  add_foreign_key "courses_users", "courses", name: "fk_users_courses"
-  add_foreign_key "courses_users", "users", name: "fk_courses_users"
   add_foreign_key "due_dates", "deadline_rights", column: "review_allowed_id", name: "fk_due_date_review_allowed"
   add_foreign_key "due_dates", "deadline_rights", column: "review_of_review_allowed_id", name: "fk_due_date_review_of_review_allowed"
   add_foreign_key "due_dates", "deadline_rights", column: "submission_allowed_id", name: "fk_due_date_submission_allowed"
@@ -1056,20 +825,7 @@ ActiveRecord::Schema.define(version: 20231203230237) do
   add_foreign_key "review_bids", "sign_up_topics", column: "signuptopic_id"
   add_foreign_key "review_bids", "users"
   add_foreign_key "review_comment_paste_bins", "review_grades"
-  add_foreign_key "review_feedbacks", "assignments", name: "fk_review_feedback_assignments"
-  add_foreign_key "review_feedbacks", "reviews", name: "fk_review_feedback_reviews"
   add_foreign_key "review_grades", "participants"
-  add_foreign_key "review_mappings", "assignments", name: "fk_review_mapping_assignments"
-  add_foreign_key "review_mappings", "teams", name: "fk_review_teams"
-  add_foreign_key "review_mappings", "users", column: "author_id", name: "fk_review_users_author"
-  add_foreign_key "review_mappings", "users", column: "reviewer_id", name: "fk_review_users_reviewer"
-  add_foreign_key "review_of_review_scores", "questions", name: "fk_review_of_review_score_questions"
-  add_foreign_key "review_of_review_scores", "review_of_reviews", name: "fk_review_of_review_score_reviews"
-  add_foreign_key "review_of_reviews", "review_of_review_mappings", name: "fk_review_of_review_review_of_review_mappings"
-  add_foreign_key "review_scores", "questionnaire_types", name: "fk_review_scores_questionnaire_type_id"
-  add_foreign_key "review_scores", "questions", name: "fk_review_score_questions"
-  add_foreign_key "review_scores", "reviews", name: "fk_review_score_reviews"
-  add_foreign_key "reviews", "review_mappings", name: "fk_review_mappings"
   add_foreign_key "sign_up_topics", "assignments", name: "fk_sign_up_topics_assignments"
   add_foreign_key "signed_up_teams", "sign_up_topics", column: "topic_id", name: "fk_signed_up_users_sign_up_topics"
   add_foreign_key "survey_deployments", "questionnaires"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: "3.9" # optional since v1.27.0
 services:
   web:
     build:
@@ -17,7 +16,7 @@ services:
       redis:
         condition: service_healthy
     environment:
-      JAVA_HOME: "/usr/lib/jvm/java-1.8.0-openjdk-amd64"
+      JAVA_HOME: "/usr/lib/jvm/java-8-oracle"
       RAILS_ENV: development
       REDIS_HOST: redis
     entrypoint: ["/app/docker_entrypoint.sh"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -21,13 +21,13 @@ services:
       REDIS_HOST: redis
     entrypoint: ["/app/docker_entrypoint.sh"]
     restart: on-failure:3
-    command: /bin/sh "while sleep 1000; do :; done"
   redis:
-    image: redis
+    image: redis:alpine
     ports:
       - "6379:6379"
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
+    restart: on-failure:3  # Add restart policy
   mysql:
     image: mysql:5.7
     ports:
@@ -42,7 +42,7 @@ services:
       timeout: 20s
       retries: 25
     restart: on-failure:3
-    user: mysql
+    user: root
     command: [--ignore-db-dir=lost+found]
 volumes:
   logvolume01: {}

--- a/docker_setup.sh
+++ b/docker_setup.sh
@@ -1,11 +1,28 @@
+#!/bin/bash
+
+# Update package list
 apt-get update
-curl -sL https://deb.nodesource.com/setup_14.x | sh -
-apt-get install -y nodejs
-apt-get install -y npm
-apt-get install -y default-mysql-client
+
+# Install required system packages
+apt-get install -y \
+    curl \
+    default-mysql-client \
+    default-libmysqlclient-dev
+
+# Install nvm (Node Version Manager)
+curl -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash
+
+# Load nvm for the current shell
+export NVM_DIR="$HOME/.nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+
+# Install Node.js using nvm
+nvm install 14  # Install Node.js 14
+nvm use 14      # Use Node.js 14
+nvm alias default 14  # Set Node.js 14 as the default version
+
+# Install global npm packages
 npm install -g bower
-apt-get install -y openjdk-8-jdk
-export JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64
-# gem install rjb -v '1.6.4' --source 'https://rubygems.org/'
-apt-get install default-libmysqlclient-dev
+
+# Install Ruby dependencies
 gem install rspec

--- a/docker_setup.sh
+++ b/docker_setup.sh
@@ -23,6 +23,9 @@ mv node-v${NODE_VERSION}-linux-x64 /usr/local/lib/nodejs
 ln -s /usr/local/lib/nodejs/bin/node /usr/local/bin/node
 ln -s /usr/local/lib/nodejs/bin/npm /usr/local/bin/npm
 
+sudo chown -R $USER:$GROUP ~/.npm
+sudo chown -R $USER:$GROUP ~/.config
+
 # Install bower
 npm install -g bower
 

--- a/docker_setup.sh
+++ b/docker_setup.sh
@@ -1,27 +1,29 @@
 #!/bin/bash
 
 # Update package list
-apt-get update
+apt-get update -qq
 
 # Install required system packages
 apt-get install -y \
+    openjdk-11-jdk \
     curl \
     default-mysql-client \
-    default-libmysqlclient-dev
+    default-libmysqlclient-dev \
+    build-essential \
+    libssl-dev \
+    xz-utils
 
-# Install nvm (Node Version Manager)
-curl -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash
+# Install Node.js 14 manually
+NODE_VERSION="14.21.0"  # Last supported version for older glibc
+cd /tmp
+curl -O https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.xz
+tar -xJf node-v${NODE_VERSION}-linux-x64.tar.xz
+rm node-v${NODE_VERSION}-linux-x64.tar.xz
+mv node-v${NODE_VERSION}-linux-x64 /usr/local/lib/nodejs
+ln -s /usr/local/lib/nodejs/bin/node /usr/local/bin/node
+ln -s /usr/local/lib/nodejs/bin/npm /usr/local/bin/npm
 
-# Load nvm for the current shell
-export NVM_DIR="$HOME/.nvm"
-[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
-
-# Install Node.js using nvm
-nvm install 14  # Install Node.js 14
-nvm use 14      # Use Node.js 14
-nvm alias default 14  # Set Node.js 14 as the default version
-
-# Install global npm packages
+# Install bower
 npm install -g bower
 
 # Install Ruby dependencies

--- a/local.dockerfile
+++ b/local.dockerfile
@@ -11,6 +11,8 @@ RUN npm install -g bower
 ENV JAVA_HOME="/usr/lib/jvm/java-11-openjdk-amd64"
 ENV PATH="/usr/local/lib/nodejs/bin:${PATH}"
 
+RUN bower install --allow-root
+
 RUN bundle install
 RUN bundle config set --local path 'vendor/cache'
 

--- a/local.dockerfile
+++ b/local.dockerfile
@@ -3,17 +3,14 @@ FROM ruby:2.4.10
 COPY . /app
 WORKDIR /app
 
-# Run the setup script
-RUN /bin/sh docker_setup.sh
+RUN bash docker_setup.sh
 
-# Set JAVA_HOME to match the actual Java installation path
-ENV JAVA_HOME="/usr/lib/jvm/java-8-oracle"
-ENV NVM_DIR="/root/.nvm"
+# Install bower
+RUN npm install -g bower
 
-# Load nvm and install bower
-RUN . "$NVM_DIR/nvm.sh" && npm install -g bower
+ENV JAVA_HOME="/usr/lib/jvm/java-11-openjdk-amd64"
+ENV PATH="/usr/local/lib/nodejs/bin:${PATH}"
 
-# Install bundler and project dependencies
 RUN bundle install
 RUN bundle config set --local path 'vendor/cache'
 

--- a/local.dockerfile
+++ b/local.dockerfile
@@ -1,12 +1,20 @@
-FROM ruby:2.3
+FROM ruby:2.4.10
 
 COPY . /app
 WORKDIR /app
 
+# Run the setup script
 RUN /bin/sh docker_setup.sh
-RUN npm install -g bower
-ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64
-RUN bower install --allow-root
+
+# Set JAVA_HOME to match the actual Java installation path
+ENV JAVA_HOME="/usr/lib/jvm/java-8-oracle"
+ENV NVM_DIR="/root/.nvm"
+
+# Load nvm and install bower
+RUN . "$NVM_DIR/nvm.sh" && npm install -g bower
+
+# Install bundler and project dependencies
 RUN bundle install
 RUN bundle config set --local path 'vendor/cache'
+
 ENTRYPOINT ["/app/docker_entrypoint.sh"]


### PR DESCRIPTION
This PR addresses several issues related to our container build process and dependency management:

1. Node Installation Fix (Issue #2855):
    - The original node install script failed because the expertiza VCL image was based on Ubuntu 16, and Nodesource no longer provides free support for NodeJS on Ubuntu versions below 20.
    - Switched to using nvm to install NodeJS 14 for compatibility with Ubuntu 16.

2. JAVA_HOME & JRB Installation Issue:
    - Encountered a runtime error during gem install rjb -v '1.6.5' due to an invalid JAVA_HOME directory.
    - Resolved the issue by switching to OpenJDK 11.

3. Final NodeJS Adjustment for execJS Support:
    - Later, nvm was replaced with a binary installation of NodeJS 14.21.0 to ensure proper execJS support.

4. Successful Build with Docker-Compose:
    - With the above changes, all scripts and docker-compose configurations were running and building successfully.
    - However the application wasn't running on localhost.
    
5. Frontend Asset Import Error:
    - A frontend error was encountered in app/assets/stylesheets/application.scss where @import "react-simpletabs/dist/react-simpletabs"; could not be found.
    - The error was traced back to Bower not installing properly in Docker due to permission issues. This was resolved by adjusting the permissions before running Bower.

Closes #2855 , #2852 